### PR TITLE
docs: update public repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@
 **1. Clone the repository**
 
 ```bash
-git clone https://github.com/lexmount/browseruse-bench.git
-cd browseruse-bench
+git clone https://github.com/lexmount/browseruse-agent-bench.git
+cd browseruse-agent-bench
 ```
 
 **2. Install dependencies (Python>=3.11)**
@@ -259,17 +259,17 @@ Some code in this project is cited and modified from [Online-Mind2Web](https://g
 
 ## Roadmap/ Development Plan
 
-Refer to our [Milestones](https://github.com/lexmount/browseruse-bench/milestones) for upcoming versions and deadlines.
+Refer to our [Milestones](https://github.com/lexmount/browseruse-agent-bench/milestones) for upcoming versions and deadlines.
 
 
 ## Star History
 
 
 
-<a href="https://star-history.com/#lexmount/browseruse-bench&Date">
+<a href="https://star-history.com/#lexmount/browseruse-agent-bench&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-bench&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-bench&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lexmount/browseruse-bench&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-agent-bench&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-agent-bench&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lexmount/browseruse-agent-bench&type=Date" />
  </picture>
 </a>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -52,8 +52,8 @@
 **1. 克隆仓库**
 
 ```bash
-git clone https://github.com/lexmount/browseruse-bench.git
-cd browseruse-bench
+git clone https://github.com/lexmount/browseruse-agent-bench.git
+cd browseruse-agent-bench
 ```
 
 **2. 安装依赖 (Python>=3.11)**
@@ -268,16 +268,16 @@ bubench viz --watch-interval 5       # 轮询间隔秒数（默认 3）
 
 ## Roadmap/ Development Plan
 
-有关后续版本计划和截止时间，请参考我们的 [Milestones](https://github.com/lexmount/browseruse-bench/milestones)。
+有关后续版本计划和截止时间，请参考我们的 [Milestones](https://github.com/lexmount/browseruse-agent-bench/milestones)。
 
 ## Star 历史
 
 
 
-<a href="https://star-history.com/#lexmount/browseruse-bench&Date">
+<a href="https://star-history.com/#lexmount/browseruse-agent-bench&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-bench&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-bench&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lexmount/browseruse-bench&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-agent-bench&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lexmount/browseruse-agent-bench&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lexmount/browseruse-agent-bench&type=Date" />
  </picture>
 </a>

--- a/browseruse_bench/leaderboard/templates/leaderboard_template.html
+++ b/browseruse_bench/leaderboard/templates/leaderboard_template.html
@@ -966,7 +966,7 @@
 
         <div class="footer">
             <p>Generated on {{TIMESTAMP}}</p>
-            <p>Powered by <a href="https://github.com/lexmount/browseruse-bench">BrowserUse Bench</a></p>
+            <p>Powered by <a href="https://github.com/lexmount/browseruse-agent-bench">BrowserUse Bench</a></p>
         </div>
     </div>
 

--- a/browseruse_bench/skills/pr-review-checklist/SKILL.md
+++ b/browseruse_bench/skills/pr-review-checklist/SKILL.md
@@ -34,7 +34,7 @@ Specified PR:
 
 ```bash
 export PYTHONPATH=/path/to/browseruse_bench
-python3 scripts/generate_pr_review_checklists.py --pr-number 122 --repo lexmount/browseruse-bench
+python3 scripts/generate_pr_review_checklists.py --pr-number 122 --repo lexmount/browseruse-agent-bench
 ```
 
 ## Behavior

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -219,7 +219,7 @@
         "links": [
             {
                 "label": "GitHub",
-                "href": "https://github.com/lexmount/browseruse-bench"
+                "href": "https://github.com/lexmount/browseruse-agent-bench"
             }
         ]
     },
@@ -231,7 +231,7 @@
     },
     "footer": {
         "socials": {
-            "github": "https://github.com/lexmount/browseruse-bench"
+            "github": "https://github.com/lexmount/browseruse-agent-bench"
         }
     }
 }

--- a/docs/en/development/get-help.mdx
+++ b/docs/en/development/get-help.mdx
@@ -83,7 +83,7 @@ tail -f output/logs/<latest_log>.log
 
 If none of the above methods solve your problem, please submit an Issue on GitHub:
 
-1. Visit [GitHub Issues](https://github.com/lexmount/browseruse-bench/issues)
+1. Visit [GitHub Issues](https://github.com/lexmount/browseruse-agent-bench/issues)
 2. Click "New Issue"
 3. Provide the following information:
    - Problem description

--- a/docs/en/quickstart.mdx
+++ b/docs/en/quickstart.mdx
@@ -15,8 +15,8 @@ icon: "rocket"
 <Steps>
   <Step title="Clone the repository">
     ```bash
-    git clone https://github.com/lexmount/browseruse-bench.git
-    cd browseruse-bench
+    git clone https://github.com/lexmount/browseruse-agent-bench.git
+    cd browseruse-agent-bench
     ```
   </Step>
   <Step title="Install Python dependencies">

--- a/docs/zh/development/get-help.mdx
+++ b/docs/zh/development/get-help.mdx
@@ -83,7 +83,7 @@ tail -f output/logs/<latest_log>.log
 
 如果以上方法都无法解决问题，请在 GitHub 上提交 Issue：
 
-1. 访问 [GitHub Issues](https://github.com/lexmount/browseruse-bench/issues)
+1. 访问 [GitHub Issues](https://github.com/lexmount/browseruse-agent-bench/issues)
 2. 点击 "New Issue"
 3. 提供以下信息：
    - 问题描述

--- a/docs/zh/quickstart.mdx
+++ b/docs/zh/quickstart.mdx
@@ -15,8 +15,8 @@ icon: "rocket"
 <Steps>
   <Step title="克隆仓库">
     ```bash
-    git clone https://github.com/lexmount/browseruse-bench.git
-    cd browseruse-bench
+    git clone https://github.com/lexmount/browseruse-agent-bench.git
+    cd browseruse-agent-bench
     ```
   </Step>
   <Step title="安装 Python 依赖">

--- a/landing/index.html
+++ b/landing/index.html
@@ -27,7 +27,7 @@
       <a href="#agents">Agents</a>
       <a href="#leaderboard">Leaderboard</a>
       <a href="#citation">Cite</a>
-      <a class="topnav-cta" href="https://github.com/lexmount/browseruse-bench" target="_blank" rel="noopener">GitHub →</a>
+      <a class="topnav-cta" href="https://github.com/lexmount/browseruse-agent-bench" target="_blank" rel="noopener">GitHub →</a>
     </div>
   </div>
 </nav>
@@ -55,7 +55,7 @@
           <a class="btn btn-secondary" href="#" aria-disabled="true" data-placeholder="arxiv">
             <span class="btn-icon">🗂</span> arXiv <span class="btn-tag">soon</span>
           </a>
-          <a class="btn btn-secondary" href="https://github.com/lexmount/browseruse-bench/" target="_blank" rel="noopener">
+          <a class="btn btn-secondary" href="https://github.com/lexmount/browseruse-agent-bench/" target="_blank" rel="noopener">
             <span class="btn-icon">⌨</span> Code
           </a>
         </div>
@@ -440,7 +440,7 @@
   title        = {LexBench-Browser: A Real-World Browser Agent Benchmark with Long-Tail and Multilingual Tasks},
   author       = {Lexmount Research and Collaborators},
   year         = {2026},
-  howpublished = {\url{https://lexmount.github.io/browseruse-bench/}},
+  howpublished = {\url{https://lexmount.github.io/browseruse-agent-bench/}},
   note         = {Open benchmark; v1.0 reference release}
 }</code></pre>
     </div>
@@ -460,7 +460,7 @@
       </div>
       <p class="muted small">
         An open benchmark by <a href="https://lexmount.cn" target="_blank" rel="noopener">Lexmount</a>.
-        Released under <a href="https://github.com/lexmount/browseruse-bench/blob/main/LICENSE" target="_blank" rel="noopener">MIT</a>;
+        Released under <a href="https://github.com/lexmount/browseruse-agent-bench/blob/main/LICENSE" target="_blank" rel="noopener">MIT</a>;
         site content under
         <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC-BY 4.0</a>.
       </p>
@@ -468,9 +468,9 @@
     <div class="footer-col">
       <h4>Project</h4>
       <ul class="tight">
-        <li><a href="https://github.com/lexmount/browseruse-bench" target="_blank" rel="noopener">GitHub</a></li>
-        <li><a href="https://github.com/lexmount/browseruse-bench/issues" target="_blank" rel="noopener">Issue tracker</a></li>
-        <li><a href="https://github.com/lexmount/browseruse-bench/blob/main/README_ZH.md" target="_blank" rel="noopener">中文 README</a></li>
+        <li><a href="https://github.com/lexmount/browseruse-agent-bench" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://github.com/lexmount/browseruse-agent-bench/issues" target="_blank" rel="noopener">Issue tracker</a></li>
+        <li><a href="https://github.com/lexmount/browseruse-agent-bench/blob/main/README_ZH.md" target="_blank" rel="noopener">中文 README</a></li>
       </ul>
     </div>
     <div class="footer-col">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,9 @@ openai-cua = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/lexmount/browseruse-bench"
-Repository = "https://github.com/lexmount/browseruse-bench"
-Issues = "https://github.com/lexmount/browseruse-bench/issues"
+Homepage = "https://github.com/lexmount/browseruse-agent-bench"
+Repository = "https://github.com/lexmount/browseruse-agent-bench"
+Issues = "https://github.com/lexmount/browseruse-agent-bench/issues"
 
 [project.scripts]
 bubench = "browseruse_bench.cli:main"


### PR DESCRIPTION
## Summary
- Update landing page GitHub/Code/footer links to point to lexmount/browseruse-agent-bench
- Update package metadata, docs navigation, quickstart clone commands, issue links, and generated leaderboard footer
- Remove remaining references to the old lexmount/browseruse-bench repository URL

## Verification
- rg -n "github\.com/lexmount/browseruse-bench|lexmount/browseruse-bench|lexmount\.github\.io/browseruse-bench" -S .
- git diff --check