### PR TITLE
fix(prompt): 区域子域算同站 + 多站任务 prompt 路由修复

### DIFF
--- a/browseruse_bench/agents/base.py
+++ b/browseruse_bench/agents/base.py
@@ -49,9 +49,14 @@ class BaseAgent(ABC):
 
         Eliminates the duplicated prompt construction pattern across agents.
 
-        Multi-site tasks (``len(task_info["urls"]) > 1``) skip the
-        "Don't go to any other site" constraint, since the constraint would
-        contradict the requirement to use multiple sites.
+        Single-site tasks keep a "use only this site" constraint, but explicitly
+        treat regional/country variants of the same site (a different subdomain
+        or domain ending, e.g. ``zalando.com`` → ``zalando.co.uk``) as the same
+        site, so a region redirect is not mistaken for an off-site jump.
+
+        Multi-site tasks (``len(task_info["urls"]) > 1``) skip the single-site
+        constraint entirely, since it would contradict the requirement to use
+        multiple sites.
 
         Args:
             task_info: Dict with "task_text" (or "prompt"), "url", and
@@ -83,8 +88,10 @@ class BaseAgent(ABC):
         if url:
             return (
                 f"{task_text}\n"
-                f"Only use {url} to achieve the task. "
-                f"Don't go to any other site. Starting URL: {url}"
+                f"Use only {url} to achieve the task. Regional or country versions of "
+                f"the same site (a different subdomain or domain ending) count as the "
+                f"same site and are allowed; do not navigate to unrelated third-party "
+                f"sites. Starting URL: {url}"
             )
         return task_text
 

--- a/browseruse_bench/agents/claude_code.py
+++ b/browseruse_bench/agents/claude_code.py
@@ -416,8 +416,12 @@ class ClaudeCodeAgent(CLIAgent):
         """Execute a browser automation task using Claude Code CLI."""
         warn_if_local_proxy_unsupported(agent_config, self.name)
         task_id = task_info["task_id"]
-        task_text = task_info.get("prompt") or task_info.get("task_text", "")
-        url = task_info.get("url", "")
+        # Reuse the prompt already formatted by cli/run.py (it carries the
+        # single-site constraint, the same-site region allowance, and the
+        # avoid-loops reminder). Fall back to BaseAgent.build_task_prompt for
+        # direct (non-CLI) callers so the constraint is still applied once and
+        # we never wrap it twice.
+        prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
 
         model = agent_config.get("model_id") or agent_config.get("model", "claude-sonnet-4-6")
         max_turns = int(agent_config.get("max_turns", 50))
@@ -430,15 +434,6 @@ class ClaudeCodeAgent(CLIAgent):
 
         allowed_tools = agent_config.get("allowed_tools", "mcp__playwright*")
         system_prompt = agent_config.get("system_prompt") or _DEFAULT_SYSTEM_PROMPT
-
-        if url:
-            prompt = (
-                f"{task_text}\n"
-                f"Only use {url} to achieve the task. "
-                f"Do not go to any other site. Starting URL: {url}"
-            )
-        else:
-            prompt = task_text
 
         api_key = agent_config.get("api_key")
         base_url = agent_config.get("base_url")

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -142,24 +142,48 @@ def resolve_data_file(benchmark_path: Path, split: str | None) -> str:
     raise SystemExit("[FAILED] data_info.json format is incorrect, must include split")
 
 
-def _prompt_format_for_benchmark(benchmark_name: str) -> str:
-    """Return benchmark-specific task prompt formatting."""
+_AVOID_LOOPS_TAIL = (
+    "Avoid action loops: do not repeatedly switch between the same tabs or click the same filter "
+    "more than twice. If a filter has no data after 1 retry, fallback to available results, "
+    "return the best-effort answer with clear uncertainty, and finish."
+)
+
+
+def _prompt_format_for_benchmark(benchmark_name: str) -> tuple[str, str | None]:
+    """Return ``(prompt_fmt, prompt_fmt_multi)`` for the benchmark.
+
+    ``prompt_fmt`` is the single-site template (placeholders ``{task}`` and
+    ``{url}``). ``prompt_fmt_multi`` is the template for tasks whose
+    ``target_website`` lists several sites (e.g. ``a.com + b.com``); it adds a
+    ``{urls}`` placeholder for the full site list. ``load_tasks`` picks one of
+    the two per task based on how many URLs the task declares, so a multi-site
+    task is never pinned to a single-site "use only" constraint.
+
+    The second element is ``None`` for benchmarks that need only one template
+    (Odysseys is already permissive across sites).
+    """
     if benchmark_name == "Odysseys":
-        return (
+        prompt_fmt = (
             "{task}\n"
             "Start from {url}. You may visit any websites needed to complete the task, "
             "and keep requested proof pages open when the task asks for visual evidence.\n"
-            "Avoid action loops: do not repeatedly switch between the same tabs or click the same filter "
-            "more than twice. If a filter has no data after 1 retry, fallback to available results, "
-            "return the best-effort answer with clear uncertainty, and finish."
+            + _AVOID_LOOPS_TAIL
         )
-    return (
+        return prompt_fmt, None
+    prompt_fmt = (
         "{task}\n"
-        "Only use {url} to achieve the task. Don't go to any other site. Starting URL: {url}\n"
-        "Avoid action loops: do not repeatedly switch between the same tabs or click the same filter "
-        "more than twice. If a filter has no data after 1 retry, fallback to available results, "
-        "return the best-effort answer with clear uncertainty, and finish."
+        "Use only {url} to achieve the task. Regional or country versions of the same "
+        "site (a different subdomain or domain ending) count as the same site and are "
+        "allowed; do not navigate to unrelated third-party sites. Starting URL: {url}\n"
+        + _AVOID_LOOPS_TAIL
     )
+    prompt_fmt_multi = (
+        "{task}\n"
+        "You may use the following websites to complete the task: {urls}. "
+        "Start with {url}.\n"
+        + _AVOID_LOOPS_TAIL
+    )
+    return prompt_fmt, prompt_fmt_multi
 
 
 # Running subprocesses (keyed by pid) — accessed by signal handler.
@@ -560,11 +584,12 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
 
     # Load tasks
     default_task_url = config.get("default", {}).get("task_start_url")
-    prompt_fmt = _prompt_format_for_benchmark(benchmark_name)
+    prompt_fmt, prompt_fmt_multi = _prompt_format_for_benchmark(benchmark_name)
     tasks = load_tasks_with_benchmark_support(
         benchmark_data,
         prompt_fmt=prompt_fmt,
         default_url=default_task_url,
+        prompt_fmt_multi=prompt_fmt_multi,
     )
     if not tasks:
         raise SystemExit(f"No tasks found in {benchmark_data}")

--- a/browseruse_bench/utils/task.py
+++ b/browseruse_bench/utils/task.py
@@ -111,6 +111,7 @@ def load_tasks_with_benchmark_support(
     tasks_json_path: Path,
     prompt_fmt: Optional[str] = None,
     default_url: Optional[str] = None,
+    prompt_fmt_multi: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Load tasks with support for different benchmarks (including BrowseComp)
@@ -119,6 +120,9 @@ def load_tasks_with_benchmark_support(
         tasks_json_path: Path to tasks JSON file
         prompt_fmt: Optional prompt template (ignored for BrowseComp which has its own template)
         default_url: Optional default starting URL used when task URL is missing
+        prompt_fmt_multi: Optional template for multi-site tasks (``target_website``
+            listing several sites). Accepts ``{task}``, ``{url}`` and ``{urls}``.
+            Falls back to ``prompt_fmt`` when omitted.
 
     Returns:
         List of task dictionaries
@@ -127,13 +131,19 @@ def load_tasks_with_benchmark_support(
         logger.info("[INFO] BrowseComp benchmark detected")
         return _load_browsecomp_tasks(tasks_json_path, default_url=default_url)
     else:
-        return load_tasks(tasks_json_path, prompt_fmt=prompt_fmt, default_url=default_url)
+        return load_tasks(
+            tasks_json_path,
+            prompt_fmt=prompt_fmt,
+            default_url=default_url,
+            prompt_fmt_multi=prompt_fmt_multi,
+        )
 
 
 def load_tasks(
     tasks_json_path: str,
     prompt_fmt: Optional[str] = None,
     default_url: Optional[str] = None,
+    prompt_fmt_multi: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Load task data from JSON or JSONL file.
 
@@ -142,6 +152,10 @@ def load_tasks(
         prompt_fmt: Optional prompt template, format "{task}\n...{url}...".
                     If provided, a 'prompt' field will be added to the task dictionary.
         default_url: Optional default starting URL used when task URL is missing.
+        prompt_fmt_multi: Optional template applied to multi-site tasks
+                    (``len(urls) > 1``). Accepts ``{task}``, ``{url}`` (the first
+                    URL) and ``{urls}`` (comma-separated list). Falls back to
+                    ``prompt_fmt`` when omitted, preserving prior behaviour.
 
     Returns:
         List[Dict[str, Any]]: List of tasks, each containing task_id, task_text, url.
@@ -198,7 +212,15 @@ def load_tasks(
                     'url': url,
                     'urls': urls,
                 })
-                if prompt_fmt:
+                # Multi-site tasks (target_website listing several sites) use the
+                # multi-site template so they are not pinned to a single-site
+                # "use only" constraint. Falls back to prompt_fmt when no
+                # multi-site template was supplied.
+                if len(urls) > 1 and prompt_fmt_multi:
+                    task_dict['prompt'] = prompt_fmt_multi.format(
+                        task=task_text, url=url, urls=", ".join(urls)
+                    )
+                elif prompt_fmt:
                     task_dict['prompt'] = prompt_fmt.format(task=task_text, url=url)
                 tasks.append(task_dict)
     except (OSError, ValueError, TypeError) as exc:

--- a/tests/browseruse_bench/test_base_agent.py
+++ b/tests/browseruse_bench/test_base_agent.py
@@ -27,7 +27,7 @@ class TestBuildTaskPrompt:
         prompt = AGENT.build_task_prompt(task_info)
         assert "Find the price" in prompt
         assert "https://example.com" in prompt
-        assert "Only use" in prompt
+        assert "Use only" in prompt
         assert "Starting URL" in prompt
 
     def test_no_url_returns_task_text_only(self):
@@ -69,15 +69,29 @@ class TestBuildTaskPrompt:
             "urls": ["https://example.com"],
         }
         prompt = AGENT.build_task_prompt(task_info)
-        assert "Only use https://example.com" in prompt
-        assert "Don't go to any other site" in prompt
+        assert "Use only https://example.com" in prompt
+        assert "do not navigate to unrelated third-party sites" in prompt
 
     def test_missing_urls_falls_back_to_single_site(self):
-        """If urls is absent, behaviour matches the pre-multi-site format."""
+        """If urls is absent, behaviour matches the single-site format."""
         task_info = {"task_text": "Find X", "url": "https://example.com"}
         prompt = AGENT.build_task_prompt(task_info)
-        assert "Only use https://example.com" in prompt
-        assert "Don't go to any other site" in prompt
+        assert "Use only https://example.com" in prompt
+        assert "do not navigate to unrelated third-party sites" in prompt
+
+    def test_single_site_allows_regional_subdomain_variants(self):
+        """A single-site task must treat regional/country variants of the same
+        site as on-site, so a region redirect (e.g. zalando.com ->
+        zalando.co.uk) is not mistaken for an off-site jump and refused."""
+        task_info = {"task_text": "Search on Zalando", "url": "https://www.zalando.com"}
+        prompt = AGENT.build_task_prompt(task_info)
+        assert "Use only https://www.zalando.com" in prompt
+        assert "same site" in prompt
+        assert "are allowed" in prompt
+        # The allowance must be generic, not a hardcoded list of country TLDs.
+        assert ".de" not in prompt
+        assert ".uk" not in prompt
+        assert ".cn" not in prompt
 
     def test_odysseys_allows_cross_site_navigation(self):
         """Odysseys tasks start from Google but intentionally span sites."""

--- a/tests/browseruse_bench/test_odysseys.py
+++ b/tests/browseruse_bench/test_odysseys.py
@@ -32,23 +32,45 @@ class TestLoadTasksOdysseysFields:
     def test_odysseys_prompt_allows_cross_site_navigation(self):
         from browseruse_bench.cli.run import _prompt_format_for_benchmark
 
-        prompt = _prompt_format_for_benchmark("Odysseys").format(
+        prompt_fmt, prompt_fmt_multi = _prompt_format_for_benchmark("Odysseys")
+        prompt = prompt_fmt.format(
             task="Find evidence across Hulu and Wikipedia.",
             url="https://www.google.com",
         )
 
         assert "You may visit any websites needed" in prompt
         assert "Only use https://www.google.com" not in prompt
+        # Odysseys needs only one template; there is no multi-site variant.
+        assert prompt_fmt_multi is None
 
     def test_single_site_prompt_keeps_existing_constraint(self):
         from browseruse_bench.cli.run import _prompt_format_for_benchmark
 
-        prompt = _prompt_format_for_benchmark("LexBench-Browser").format(
+        prompt_fmt, _ = _prompt_format_for_benchmark("LexBench-Browser")
+        prompt = prompt_fmt.format(
             task="Find one page.",
             url="https://example.com",
         )
 
-        assert "Only use https://example.com" in prompt
+        assert "Use only https://example.com" in prompt
+        # Region redirects to the same site are allowed, off-site is not.
+        assert "do not navigate to unrelated third-party sites" in prompt
+
+    def test_multi_site_benchmark_prompt_lists_all_sites(self):
+        """LexBench multi-site tasks must NOT be pinned to a single-site
+        'use only' constraint via the CLI prompt path."""
+        from browseruse_bench.cli.run import _prompt_format_for_benchmark
+
+        _, prompt_fmt_multi = _prompt_format_for_benchmark("LexBench-Browser")
+        assert prompt_fmt_multi is not None
+        prompt = prompt_fmt_multi.format(
+            task="Compare ratings.",
+            url="https://movie.douban.com",
+            urls="https://movie.douban.com, https://imdb.com",
+        )
+        assert "https://movie.douban.com" in prompt
+        assert "https://imdb.com" in prompt
+        assert "Use only" not in prompt
 
 
 class TestOdysseysRegistry:

--- a/tests/browseruse_bench/test_run_dependency_sync.py
+++ b/tests/browseruse_bench/test_run_dependency_sync.py
@@ -35,7 +35,7 @@ def test_run_agent_installs_dependencies_for_existing_venv(
     monkeypatch.setattr(
         run_module,
         "load_tasks_with_benchmark_support",
-        lambda benchmark_data, prompt_fmt, default_url: [
+        lambda benchmark_data, prompt_fmt, default_url, prompt_fmt_multi=None: [
             {"task_id": "task-1", "task_text": "Open page", "url": "https://example.com"}
         ],
     )
@@ -111,7 +111,7 @@ def _patch_minimal_run_dependencies(
     monkeypatch.setattr(
         run_module,
         "load_tasks_with_benchmark_support",
-        lambda benchmark_data, prompt_fmt, default_url: [
+        lambda benchmark_data, prompt_fmt, default_url, prompt_fmt_multi=None: [
             {"task_id": "task-1", "task_text": "Open page", "url": "https://example.com"}
         ],
     )


### PR DESCRIPTION
## 背景

`only_use` 那版 PR(#26)想解决"agent 因严格站点约束被误判 0 分"的问题,但用的是"全量手标 flag + judge 全局例外"的重型方案,且把两个正交问题缝在一起。

扫描全部 210 个去重任务后的认知:

- 真正"该放开跨站"的任务只有 ~12%(搜索引擎入口 + 模糊建议),且**可由 `target_website` 结构自动推导**,不需要手标 240 条。
- A/B 数据显示:对**点名站点**的任务(如 zalando),"完全放开"反而是负优化(63 < 71);真正把 5 分救到 71 的是**子域名例外**,而它属于另一条正交轴(区域子域),应做成**全局规则**而非塞进 flag 分支。

本 PR 只做**确定、零争议、高价值**的那部分;judge 站点现状例外、派生式 permissive、`rpa.jsonl` 等留作后续独立 PR。

## 改动

**1. 区域子域归一(核心)**
单站约束从 `Don't go to any other site` 改为:同站点的区域/国家变体(不同子域或域名后缀)算同站、允许跳转;但不许去无关第三方站。**通用表述,不枚举 `.de/.uk/.cn`**。`base.py` 与 `cli/run.py` 措辞保持一致。

**2. 多站任务 prompt 路由修复(预存 bug)**
`target_website` 形如 `a.com + b.com` 的多站任务,以前经 CLI(`load_tasks` 的 `prompt_fmt` 路径)被错误地按单站 "use only" 约束——因为该路径只用第一个 url、忽略已解析的 `urls`。现在 `_prompt_format_for_benchmark` 返回 `(单站, 多站)` 两个模板,`load_tasks` 按 `len(urls) > 1` 自动选多站模板(结构派生,非手标)。

**3. 消除 claude_code 双重约束**
删掉 `claude_code.py` 自带的 "Only use" 重复包装,统一复用 CLI 已 format 的 prompt(或直接调用方回退 `build_task_prompt`),避免双重约束。

### 文件
- `browseruse_bench/agents/base.py` — 单站分支措辞 + docstring
- `browseruse_bench/cli/run.py` — 返回 `(prompt_fmt, prompt_fmt_multi)`;抽出共享 avoid-loops 尾串
- `browseruse_bench/utils/task.py` — `load_tasks` / `load_tasks_with_benchmark_support` 新增 `prompt_fmt_multi`,`len(urls) > 1` 时选用
- `browseruse_bench/agents/claude_code.py` — 去重复包装
- 测试:更新旧断言 + 新增"区域子域归一"和"多站 CLI 路径"用例

**未触碰**:judge prompt、数据 jsonl 的手标 flag、`rpa.jsonl`。

## 验证

- 单测:**358 passed, 2 skipped**(跳过的 2 个是 `browser_use`/`agentbay` extra 未装的环境性 collection error,与改动无关)。
- 真实数据生成 prompt:zalando(id 187)单站 + 区域归一 ✓;douban+imdb(id 217)正确列出双站、无 "use only" ✓。
- **活体冒烟**(`bubench run --agent browser-use --data LexBench-Browser --mode by_id --id 187`,lexmount 远程浏览器):**exit 0,Success 1**。agent 完成 `zalando.com → 选 Germany → en.zalando.de → 接受 cookie → 搜索 → 进入筛选`,**不再像旧 prompt 那样在国家选择页死锁**(旧版 step 1 即放弃 → 5/100)。
  - 注:该任务最终 600s 超时,根因是 Zalando SPA DOM 渲染抽风(browser-use 已知 flakiness),与本改动无关。

## Test plan
- [ ] `uv run pytest tests/`
- [ ] reviewer 抽查区域子域措辞是否清晰、对非点名站点是否会被误解为可随意跨站
- [ ] (可选)在更稳的站点重跑一条单站 + 一条多站任务,确认无回归

Made with [Cursor](https://cursor.com)