### PR TITLE
[codex] Extend browser-use CDP timeout

### DIFF
--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -12,19 +12,21 @@ import logging
 import os
 import tempfile
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from browser_use import Agent as BrowserUseSDKAgent
 from browser_use import Browser as BrowserUseSDKBrowser
-from browser_use.browser.profile import ProxySettings as BrowserUseProxySettings
 from browser_use import ChatAnthropic as BrowserUseSDKChatAnthropic
 from browser_use import ChatAzureOpenAI as BrowserUseSDKChatAzureOpenAI
 from browser_use import ChatBrowserUse as BrowserUseSDKChatBrowserUse
 from browser_use import ChatGoogle as BrowserUseSDKChatGoogle
 from browser_use import ChatOpenAI as BrowserUseSDKChatOpenAI
+from browser_use.browser import session as browser_use_session_module
+from browser_use.browser.profile import ProxySettings as BrowserUseProxySettings
 
 from browseruse_bench.agents.base import BaseAgent
 from browseruse_bench.agents.registry import register_agent
@@ -33,7 +35,6 @@ from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
 from browseruse_bench.utils.api_logger import APICallLogger
 
 Agent: type[Any] = BrowserUseSDKAgent
-Browser: type[Any] = BrowserUseSDKBrowser
 ChatBrowserUse: type[Any] = BrowserUseSDKChatBrowserUse
 ChatAnthropic: type[Any] = BrowserUseSDKChatAnthropic
 ChatGoogle: type[Any] = BrowserUseSDKChatGoogle
@@ -42,12 +43,69 @@ ChatOpenAI: type[Any] = BrowserUseSDKChatOpenAI
 
 logger = logging.getLogger(__name__)
 
+BROWSER_USE_CDP_CONNECT_TIMEOUT_SECONDS = 30.0
+_BROWSER_USE_SDK_CDP_CONNECT_TIMEOUT_SECONDS = 15.0
+_BROWSER_USE_CDP_CONNECT_TIMEOUT_LABEL = f"{BROWSER_USE_CDP_CONNECT_TIMEOUT_SECONDS:g}s"
+
 
 def _get_config_value(agent_config: dict[str, Any], *keys: str, default: Any = None) -> Any:
     for key in keys:
         if key in agent_config and agent_config[key] is not None:
             return agent_config[key]
     return default
+
+
+@contextmanager
+def _browser_use_cdp_connect_timeout(timeout_seconds: float) -> Iterator[None]:
+    """Override browser-use SDK's hard-coded 15s CDP connect guard."""
+    original_wait_for = browser_use_session_module.asyncio.wait_for
+
+    async def wait_for_with_cdp_timeout(
+        fut: Any,
+        timeout: float | None = None,
+    ) -> Any:
+        if timeout == _BROWSER_USE_SDK_CDP_CONNECT_TIMEOUT_SECONDS:
+            timeout = timeout_seconds
+        return await original_wait_for(fut, timeout=timeout)
+
+    browser_use_session_module.asyncio.wait_for = wait_for_with_cdp_timeout
+    try:
+        yield
+    finally:
+        browser_use_session_module.asyncio.wait_for = original_wait_for
+
+
+def _browser_use_cdp_timeout_message(message: str) -> str:
+    if "timed out after 15s" in message and "CDP connection" in message:
+        return message.replace("15s", _BROWSER_USE_CDP_CONNECT_TIMEOUT_LABEL)
+    return message
+
+
+class BrowserUseBenchBrowser(BrowserUseSDKBrowser):
+    """browser-use BrowserSession with benchmark-specific CDP connect timeout."""
+
+    async def start(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            with _browser_use_cdp_connect_timeout(BROWSER_USE_CDP_CONNECT_TIMEOUT_SECONDS):
+                return await super().start(*args, **kwargs)
+        except RuntimeError as exc:
+            message = _browser_use_cdp_timeout_message(str(exc))
+            if message != str(exc):
+                raise RuntimeError(message) from exc
+            raise
+
+    async def _auto_reconnect(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            with _browser_use_cdp_connect_timeout(BROWSER_USE_CDP_CONNECT_TIMEOUT_SECONDS):
+                return await super()._auto_reconnect(*args, **kwargs)
+        except RuntimeError as exc:
+            message = _browser_use_cdp_timeout_message(str(exc))
+            if message != str(exc):
+                raise RuntimeError(message) from exc
+            raise
+
+
+Browser: type[Any] = BrowserUseBenchBrowser
 
 
 @register_agent

--- a/tests/browseruse_bench/test_browser_use_agent.py
+++ b/tests/browseruse_bench/test_browser_use_agent.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator
+from typing import Any
 
 import pytest
 
@@ -18,13 +19,13 @@ def test_run_task_uses_backend_manager_session_context(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     @contextmanager
     def fake_open_browser_session(
         browser_id: str,
         agent_name: str,
-        agent_config: Dict[str, Any],
+        agent_config: dict[str, Any],
     ) -> Iterator[BrowserSessionContext]:
         captured["browser_id"] = browser_id
         captured["agent_name"] = agent_name
@@ -37,13 +38,13 @@ def test_run_task_uses_backend_manager_session_context(
 
     async def fake_run_task_async(
         self: BrowserUseAgent,
-        task_info: Dict[str, Any],
+        task_info: dict[str, Any],
         task_workspace: Path,
         timeout: int,
         flash_mode: bool,
-        agent_config: Dict[str, Any],
+        agent_config: dict[str, Any],
         session_context: BrowserSessionContext,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         captured["session_context"] = session_context
         captured["timeout"] = timeout
         captured["flash_mode"] = flash_mode
@@ -81,6 +82,78 @@ def test_run_task_rejects_unknown_backend(tmp_path: Path) -> None:
             agent_config={"BROWSER_ID": "not-exists"},
             task_workspace=tmp_path,
         )
+
+
+def test_browser_use_browser_extends_sdk_cdp_connect_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_timeouts: list[float | None] = []
+
+    async def fake_wait_for(fut: Any, timeout: float | None = None) -> Any:
+        observed_timeouts.append(timeout)
+        return await fut
+
+    async def fake_start(self: Any) -> str:
+        del self
+
+        async def ready() -> str:
+            return "started"
+
+        return await browser_use_module.browser_use_session_module.asyncio.wait_for(
+            ready(),
+            timeout=15.0,
+        )
+
+    async def fake_auto_reconnect(self: Any) -> str:
+        del self
+
+        async def ready() -> str:
+            return "reconnected"
+
+        return await browser_use_module.browser_use_session_module.asyncio.wait_for(
+            ready(),
+            timeout=15.0,
+        )
+
+    monkeypatch.setattr(
+        browser_use_module.browser_use_session_module.asyncio,
+        "wait_for",
+        fake_wait_for,
+    )
+    monkeypatch.setattr(browser_use_module.BrowserUseSDKBrowser, "start", fake_start)
+    monkeypatch.setattr(
+        browser_use_module.BrowserUseSDKBrowser,
+        "_auto_reconnect",
+        fake_auto_reconnect,
+    )
+
+    browser = browser_use_module.Browser(cdp_url="wss://agentbay.example/cdp")
+
+    assert asyncio.run(browser.start()) == "started"
+    assert asyncio.run(browser._auto_reconnect()) == "reconnected"
+    assert observed_timeouts == [
+        browser_use_module.BROWSER_USE_CDP_CONNECT_TIMEOUT_SECONDS,
+        browser_use_module.BROWSER_USE_CDP_CONNECT_TIMEOUT_SECONDS,
+    ]
+    assert browser_use_module.browser_use_session_module.asyncio.wait_for is fake_wait_for
+
+
+def test_browser_use_browser_rewrites_sdk_cdp_timeout_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_start(self: Any) -> None:
+        del self
+        raise RuntimeError(
+            "connect() timed out after 15s - CDP connection to wss://lexmount.example/cdp "
+            "is too slow or unresponsive"
+        )
+
+    monkeypatch.setattr(browser_use_module.BrowserUseSDKBrowser, "start", fake_start)
+
+    browser = browser_use_module.Browser(cdp_url="wss://lexmount.example/cdp")
+
+    with pytest.raises(RuntimeError, match="timed out after 30s"):
+        asyncio.run(browser.start())
 
 
 def test_create_browser_instance_rejects_cloud_transport_for_unknown_backend() -> None:
@@ -171,7 +244,7 @@ def test_run_task_async_tolerates_temp_dir_cleanup_error(
 def test_create_browser_instance_passes_local_proxy_to_browser(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     class FakeBrowser:
         def __init__(self, **kwargs: Any) -> None:
@@ -208,7 +281,7 @@ def test_create_browser_instance_passes_local_proxy_to_browser(
 def test_create_browser_instance_no_proxy_omits_kwarg(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     class FakeBrowser:
         def __init__(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary

- Extend the browser-use CDP connect/reconnect guard from the SDK's hard-coded 15 seconds to 30 seconds for benchmark runs.
- Rewrite the corresponding browser-use CDP timeout message so failures report 30s instead of the SDK's 15s text.
- Add tests covering the timeout override and message rewrite.

## Root Cause

Lexmount browser sessions are returned to the browser-use agent as CDP sessions. The browser-use SDK wraps CDP setup in an internal `asyncio.wait_for(..., timeout=15.0)`, so slower Lexmount CDP handshakes could fail before the benchmark task timeout had a chance to apply.

## Validation

- `uv run --extra dev --extra browser-use ruff check browseruse_bench/agents/browser_use.py tests/browseruse_bench/test_browser_use_agent.py`
- `uv run --extra dev --extra browser-use python -m pytest tests/browseruse_bench/test_browser_use_agent.py`