### PR TITLE
[codex] Fix browser-use unfinished status mapping

### DIFF
--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -19,12 +19,12 @@ from typing import Any
 
 from browser_use import Agent as BrowserUseSDKAgent
 from browser_use import Browser as BrowserUseSDKBrowser
-from browser_use.browser.profile import ProxySettings as BrowserUseProxySettings
 from browser_use import ChatAnthropic as BrowserUseSDKChatAnthropic
 from browser_use import ChatAzureOpenAI as BrowserUseSDKChatAzureOpenAI
 from browser_use import ChatBrowserUse as BrowserUseSDKChatBrowserUse
 from browser_use import ChatGoogle as BrowserUseSDKChatGoogle
 from browser_use import ChatOpenAI as BrowserUseSDKChatOpenAI
+from browser_use.browser.profile import ProxySettings as BrowserUseProxySettings
 
 from browseruse_bench.agents.base import BaseAgent
 from browseruse_bench.agents.registry import register_agent
@@ -43,11 +43,46 @@ ChatOpenAI: type[Any] = BrowserUseSDKChatOpenAI
 logger = logging.getLogger(__name__)
 
 
+_MAX_STEPS_ERROR = "Failed to complete task in maximum steps"
+
+
 def _get_config_value(agent_config: dict[str, Any], *keys: str, default: Any = None) -> Any:
     for key in keys:
         if key in agent_config and agent_config[key] is not None:
             return agent_config[key]
     return default
+
+
+def _history_errors(history: Any) -> list[str]:
+    errors = getattr(history, "errors", None)
+    if not callable(errors):
+        return []
+    try:
+        raw_errors = errors() or []
+    except (AttributeError, TypeError, ValueError):
+        return []
+    return [error for error in raw_errors if isinstance(error, str) and error]
+
+
+def _history_reached_max_steps(
+    *,
+    history_errors: list[str],
+    steps_count: int,
+    max_steps: int,
+) -> bool:
+    if steps_count >= max_steps:
+        return True
+    return any("maximum steps" in error.lower() or "max steps" in error.lower() for error in history_errors)
+
+
+def _unfinished_history_error(
+    *,
+    history_errors: list[str],
+    steps_count: int,
+) -> str:
+    if history_errors:
+        return history_errors[-1]
+    return f"Agent stopped before completion after {steps_count} steps without reporting done"
 
 
 @register_agent
@@ -286,14 +321,39 @@ class BrowserUseAgent(BaseAgent):
                     except Exception as exc:
                         logger.warning(f"Failed to generate API logs for task {task_id}: {exc}")
 
-        final_answer = ""
-        if not error_msg and history:
-            final_answer = history.final_result() or ""
-        elif error_msg:
-            final_answer = f"[Task Failed: {error_msg}]"
-
         # Determine env_status, agent_done, and agent_success
         agent_success: bool | None = None
+        history_errors = _history_errors(history) if history else []
+        max_steps_reached = (
+            _history_reached_max_steps(
+                history_errors=history_errors,
+                steps_count=steps_count,
+                max_steps=max_steps,
+            )
+            if history
+            else False
+        )
+        unfinished_error = None
+        if not error_msg and history and not history.is_done():
+            unfinished_error = (
+                _MAX_STEPS_ERROR
+                if max_steps_reached
+                else _unfinished_history_error(
+                    history_errors=history_errors,
+                    steps_count=steps_count,
+                )
+            )
+        elif not error_msg and not history:
+            unfinished_error = "Agent returned no history before completion"
+
+        final_answer = ""
+        if error_msg:
+            final_answer = f"[Task Failed: {error_msg}]"
+        elif history and history.is_done():
+            final_answer = history.final_result() or ""
+        elif unfinished_error:
+            final_answer = f"[Task Failed: {unfinished_error}]"
+
         if error_msg and "Timeout" in error_msg:
             # Timeout: environment is fine, agent was killed by timeout
             env_status = "success"
@@ -307,10 +367,12 @@ class BrowserUseAgent(BaseAgent):
             env_status = "success"
             agent_done = "done"
             agent_success = history.is_successful()
-        else:
-            # No error but agent didn't self-report done → max_steps
+        elif max_steps_reached:
             env_status = "success"
             agent_done = "max_steps"
+        else:
+            env_status = "failed"
+            agent_done = "error"
 
         return AgentResult(
             task_id=task_id,
@@ -330,7 +392,7 @@ class BrowserUseAgent(BaseAgent):
                 usage=AgentUsage(**usage_data) if usage_data else None,
             ),
             config=config_info,
-            error=error_msg if error_msg else None,
+            error=error_msg or unfinished_error,
         )
 
     def _create_llm(

--- a/tests/browseruse_bench/test_browser_use_agent.py
+++ b/tests/browseruse_bench/test_browser_use_agent.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator
+from typing import Any
 
 import pytest
 
@@ -18,13 +19,13 @@ def test_run_task_uses_backend_manager_session_context(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     @contextmanager
     def fake_open_browser_session(
         browser_id: str,
         agent_name: str,
-        agent_config: Dict[str, Any],
+        agent_config: dict[str, Any],
     ) -> Iterator[BrowserSessionContext]:
         captured["browser_id"] = browser_id
         captured["agent_name"] = agent_name
@@ -37,13 +38,13 @@ def test_run_task_uses_backend_manager_session_context(
 
     async def fake_run_task_async(
         self: BrowserUseAgent,
-        task_info: Dict[str, Any],
+        task_info: dict[str, Any],
         task_workspace: Path,
         timeout: int,
         flash_mode: bool,
-        agent_config: Dict[str, Any],
+        agent_config: dict[str, Any],
         session_context: BrowserSessionContext,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         captured["session_context"] = session_context
         captured["timeout"] = timeout
         captured["flash_mode"] = flash_mode
@@ -159,8 +160,146 @@ def test_run_task_async_tolerates_temp_dir_cleanup_error(
         )
     )
 
-    assert result.env_status.value == "success"
+    assert result.env_status.value == "failed"
+    assert result.agent_done.value == "error"
+    assert result.error == "Agent returned no history before completion"
     assert any("Failed to cleanup temporary directory" in record.message for record in caplog.records)
+
+
+def test_run_task_async_maps_early_unfinished_history_to_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeHistory:
+        history: list[Any] = []
+
+        def extracted_content(self) -> list[str]:
+            return ["Waited for 3 seconds"]
+
+        def number_of_steps(self) -> int:
+            return 4
+
+        def screenshots(self) -> list[str]:
+            return []
+
+        def errors(self) -> list[str | None]:
+            return [None, None, None, None]
+
+        def is_done(self) -> bool:
+            return False
+
+        def final_result(self) -> str:
+            return "Waited for 3 seconds"
+
+    class FakeAgent:
+        def __init__(self, **_: Any) -> None:
+            self.history = FakeHistory()
+
+        async def run(self, max_steps: int) -> FakeHistory:
+            assert max_steps == 40
+            return self.history
+
+    class FakeBrowser:
+        async def stop(self) -> None:
+            return None
+
+    monkeypatch.setattr(browser_use_module, "Agent", FakeAgent)
+    monkeypatch.setattr(
+        BrowserUseAgent,
+        "_create_browser_instance",
+        staticmethod(lambda session_context: (FakeBrowser(), None)),
+    )
+    monkeypatch.setattr(
+        BrowserUseAgent,
+        "_create_llm",
+        lambda self, model_type, model_id, agent_config, config_info: object(),
+    )
+
+    result = asyncio.run(
+        BrowserUseAgent()._run_task_async(
+            task_info={"task_id": "t-incomplete", "task_text": "search", "url": "https://example.com"},
+            task_workspace=tmp_path,
+            timeout=600,
+            flash_mode=False,
+            agent_config={"MODEL_TYPE": "OPENAI", "MODEL_ID": "gpt-test", "SAVE_API_LOGS": False},
+            session_context=BrowserSessionContext(backend_id="Chrome-Local", transport="local"),
+        )
+    )
+
+    assert result.env_status.value == "failed"
+    assert result.agent_done.value == "error"
+    assert result.agent_success is None
+    assert result.metrics.steps == 4
+    assert result.error == "Agent stopped before completion after 4 steps without reporting done"
+    assert result.answer == "[Task Failed: Agent stopped before completion after 4 steps without reporting done]"
+
+
+def test_run_task_async_keeps_real_max_steps_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeHistory:
+        history: list[Any] = []
+
+        def extracted_content(self) -> list[str]:
+            return []
+
+        def number_of_steps(self) -> int:
+            return 40
+
+        def screenshots(self) -> list[str]:
+            return []
+
+        def errors(self) -> list[str | None]:
+            return [None, "Failed to complete task in maximum steps"]
+
+        def is_done(self) -> bool:
+            return False
+
+        def final_result(self) -> str:
+            return "last non-final content"
+
+    class FakeAgent:
+        def __init__(self, **_: Any) -> None:
+            self.history = FakeHistory()
+
+        async def run(self, max_steps: int) -> FakeHistory:
+            assert max_steps == 40
+            return self.history
+
+    class FakeBrowser:
+        async def stop(self) -> None:
+            return None
+
+    monkeypatch.setattr(browser_use_module, "Agent", FakeAgent)
+    monkeypatch.setattr(
+        BrowserUseAgent,
+        "_create_browser_instance",
+        staticmethod(lambda session_context: (FakeBrowser(), None)),
+    )
+    monkeypatch.setattr(
+        BrowserUseAgent,
+        "_create_llm",
+        lambda self, model_type, model_id, agent_config, config_info: object(),
+    )
+
+    result = asyncio.run(
+        BrowserUseAgent()._run_task_async(
+            task_info={"task_id": "t-max", "task_text": "search", "url": "https://example.com"},
+            task_workspace=tmp_path,
+            timeout=600,
+            flash_mode=False,
+            agent_config={"MODEL_TYPE": "OPENAI", "MODEL_ID": "gpt-test", "SAVE_API_LOGS": False},
+            session_context=BrowserSessionContext(backend_id="Chrome-Local", transport="local"),
+        )
+    )
+
+    assert result.env_status.value == "success"
+    assert result.agent_done.value == "max_steps"
+    assert result.agent_success is None
+    assert result.metrics.steps == 40
+    assert result.error == "Failed to complete task in maximum steps"
+    assert result.answer == "[Task Failed: Failed to complete task in maximum steps]"
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +310,7 @@ def test_run_task_async_tolerates_temp_dir_cleanup_error(
 def test_create_browser_instance_passes_local_proxy_to_browser(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     class FakeBrowser:
         def __init__(self, **kwargs: Any) -> None:
@@ -208,7 +347,7 @@ def test_create_browser_instance_passes_local_proxy_to_browser(
 def test_create_browser_instance_no_proxy_omits_kwarg(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     class FakeBrowser:
         def __init__(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary

- Stop mapping every unfinished browser-use history to `agent_done=max_steps`.
- Only report `max_steps` when the history actually reaches the configured step limit or carries the SDK's maximum-steps error.
- Prevent non-final action output such as `Waited for 3 seconds` from being used as the final answer when the agent did not call `done`.
- Add regression tests for early unfinished histories, real max-step histories, and no-history returns.

## Root Cause

The result mapper treated any browser-use run that returned without `history.is_done()` as `max_steps`, regardless of the actual number of recorded steps. In the provided run, task `127` had only 4 recorded steps out of `max_steps=40`; after the page became empty/stalled, browser-use returned an unfinished history. The mapper incorrectly labeled that as `max_steps` and also used the last action's extracted content (`Waited for 3 seconds`) as the answer.

## Validation

- `uv run --extra dev --extra browser-use ruff check browseruse_bench/agents/browser_use.py tests/browseruse_bench/test_browser_use_agent.py`
- `uv run --extra dev --extra browser-use python -m pytest tests/browseruse_bench/test_browser_use_agent.py`
- `git diff --check`