### PR TITLE
Add cloud browser provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Together they make external results easy to run, compare, cite, and submit back.
 
 | Agent | Supported Browsers |
 |-------|-------------------|
-| [browser-use](https://github.com/browser-use/browser-use) | `Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay` |
-| [skyvern](https://github.com/Skyvern-AI/Skyvern/) | `local`, `lexmount`, `skyvern-cloud` |
+| [browser-use](https://github.com/browser-use/browser-use) | `Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `browserbase`, `browserless`, `steel` |
+| [skyvern](https://github.com/Skyvern-AI/Skyvern/) | `local`, `lexmount`, `skyvern-cloud`, `agentbay`, `browserbase`, `browserless`, `steel` |
 | [Agent-TARS](https://github.com/bytedance/UI-TARS-desktop) | Built-in browser |
 | More agents | — |
 
@@ -123,6 +123,9 @@ vim .env
 | `LEXMOUNT_API_KEY` + `LEXMOUNT_PROJECT_ID` | Lexmount cloud browser | [browser.lexmount.cn](https://browser.lexmount.cn/) | When using lexmount |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser | [browser-use.com](https://www.browser-use.com/) | When using browser-use-cloud |
 | `AGENTBAY_API_KEY` | AgentBay cloud browser | [agentbay.ai](https://agentbay.ai/) | When using agentbay |
+| `BROWSERBASE_API_KEY` + optional `BROWSERBASE_PROJECT_ID` | Browserbase cloud browser | [browserbase.com](https://www.browserbase.com/) | When using browserbase |
+| `BROWSERLESS_API_KEY` | Browserless BaaS cloud browser | [browserless.io](https://www.browserless.io/) | When using browserless |
+| `STEEL_API_KEY` | Steel.dev cloud browser | [steel.dev](https://steel.dev/) | When using steel |
 | `HF_ENDPOINT=https://hf-mirror.com` | HuggingFace mirror (China) | — | Optional |
 
 **3.2 Runtime config (`config.yaml`)**
@@ -132,20 +135,22 @@ cp config.example.yaml config.yaml
 vim config.yaml
 ```
 
-All agents are configured in one file. Key fields under `agents.<agent>`:
+All agents are configured in one file. Runtime config is resolved as:
+`agents.<agent> + models.<model> + browsers.<browser>`.
 
 | Field | Description |
 |-------|-------------|
-| `active_model` | Which model entry to use (must match a key under `models`) |
+| `default.model` | Default model key (overridden by `--model`) |
+| `default.browser` | Default browser key (overridden by `--browser-id`) |
+| `agents.<agent>.*` | Agent params: `max_steps`, `timeout`, `use_vision`, etc. |
 | `models.<name>.model_type` | Provider: `BROWSER_USE`, `OPENAI`, `AZURE`, `GEMINI`, `ANTHROPIC` |
 | `models.<name>.model_id` | Model ID (e.g. `gpt-4.1`, `qwen3.5-plus`, `kimi-k2.5`) |
 | `models.<name>.api_key` | API key for this model (supports `$ENV_VAR` expansion) |
 | `models.<name>.base_url` | API base URL (optional, supports `$ENV_VAR` expansion) |
-| `browser.browser_id` | Browser backend: `Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `cdp` |
-| `defaults.*` | Shared agent params: `max_steps`, `timeout`, `use_vision`, etc. |
+| `browsers.<name>.browser_id` | Browser backend: `Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `browserbase`, `browserless`, `steel`, `cdp` |
 | `eval.model` + `eval.api_key` + `eval.base_url` | Evaluation model settings |
 
-To switch models, change `active_model` and ensure the matching entry exists under `models`.
+To switch per run, use `--model <name>` and `--browser-id <name>`.
 
 **4. Install Skills (Optional)**
 

--- a/browseruse_bench/agents/skyvern.py
+++ b/browseruse_bench/agents/skyvern.py
@@ -8,12 +8,15 @@ wraps the existing implementation rather than reimplementing from scratch.
 Prerequisites
 =============
 
-1. PostgreSQL (required by Skyvern internally)
+1. Local database
    ------------------------------------------------
-   Skyvern is a SaaS product that uses PostgreSQL as its backend database
-   for org/auth/artifact metadata. The skyvern package has a built-in
-   default connection string (``postgresql+psycopg://skyvern@localhost/skyvern``),
-   so you only need to create the database and user — no .env config needed.
+   In benchmark local mode, this adapter defaults Skyvern to an isolated
+   temporary PostgreSQL database so smoke tests do not depend on a shared
+   PostgreSQL schema.
+
+   Set ``database_string`` in config.yaml only when you intentionally want a
+   managed/persistent Skyvern database, for example:
+   ``postgresql+psycopg://skyvern@localhost/skyvern``.
 
    # Install (Ubuntu/Debian)
    sudo apt install postgresql postgresql-contrib
@@ -24,9 +27,6 @@ Prerequisites
 
    On first ``Skyvern.local()`` call, ``start_forge_app()`` runs Alembic
    migrations automatically to initialize the schema.
-
-   If you need a custom connection string, set ``DATABASE_STRING`` in the
-   skyvern package's own .env or environment.
 
 2. Skyvern API Key
    ------------------------------------------------
@@ -62,6 +62,7 @@ Prerequisites
 from __future__ import annotations
 
 import asyncio
+import atexit
 import base64
 import binascii
 import importlib
@@ -69,10 +70,12 @@ import json
 import logging
 import os
 import shutil
+import tempfile
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -89,9 +92,6 @@ except ImportError:
     except ImportError:
         TargetClosedError = None
 
-import tempfile
-import uuid
-
 from browseruse_bench.agents.base import BaseAgent
 from browseruse_bench.agents.registry import register_agent
 from browseruse_bench.browsers import BrowserSessionContext
@@ -106,6 +106,91 @@ RunEngine: type[Any] | None = None
 RunStatus: type[Any] | None = None
 skyvern_settings: Any | None = None
 _SKYVERN_IMPORT_ERROR: str | None = None
+
+
+def _make_temp_database_string() -> str:
+    db_name = f"bubench_skyvern_{uuid.uuid4().hex}"
+    return f"postgresql+psycopg:///{db_name}?host=/tmp"
+
+
+def _parse_temp_postgres_database(database_string: str) -> tuple[str, urllib.parse.SplitResult] | None:
+    parsed = urllib.parse.urlsplit(database_string)
+    if parsed.scheme not in {"postgresql", "postgresql+psycopg"}:
+        return None
+
+    db_name = parsed.path.lstrip("/")
+    if not db_name.startswith("bubench_skyvern_"):
+        return None
+
+    return db_name, parsed
+
+
+def _psycopg_conninfo(parsed: urllib.parse.SplitResult, database: str) -> str:
+    query = f"?{parsed.query}" if parsed.query else ""
+    if parsed.netloc:
+        return f"postgresql://{parsed.netloc}/{database}{query}"
+    return f"postgresql:///{database}{query}"
+
+
+def _drop_temp_postgres_database(parsed: urllib.parse.SplitResult, db_name: str) -> None:
+    try:
+        import psycopg
+        from psycopg import sql
+    except ImportError:
+        return
+
+    admin_conninfo = _psycopg_conninfo(parsed, "postgres")
+    try:
+        with (
+            psycopg.connect(admin_conninfo, autocommit=True) as connection,
+            connection.cursor() as cursor,
+        ):
+            cursor.execute(
+                "SELECT pg_terminate_backend(pid) "
+                "FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (db_name,),
+            )
+            cursor.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name)))
+    except psycopg.Error as exc:
+        logger.warning("Failed to drop temporary Skyvern database %s: %s", db_name, exc)
+
+
+def _ensure_temp_postgres_database(database_string: str) -> bool:
+    parsed_db = _parse_temp_postgres_database(database_string)
+    if parsed_db is None:
+        return False
+
+    db_name, parsed = parsed_db
+    try:
+        import psycopg
+        from psycopg import sql
+        from psycopg.errors import DuplicateDatabase
+    except ImportError as exc:
+        raise ImportError(
+            "Skyvern temporary Postgres mode requires psycopg. "
+            "Install/run with the skyvern extra."
+        ) from exc
+
+    admin_conninfo = _psycopg_conninfo(parsed, "postgres")
+    with (
+        psycopg.connect(admin_conninfo, autocommit=True) as connection,
+        connection.cursor() as cursor,
+    ):
+        try:
+            cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name)))
+        except DuplicateDatabase:
+            logger.info("Temporary Skyvern database already exists: %s", db_name)
+        else:
+            logger.info("Created temporary Skyvern database: %s", db_name)
+    target_conninfo = _psycopg_conninfo(parsed, db_name)
+    with (
+        psycopg.connect(target_conninfo, autocommit=True) as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    atexit.register(_drop_temp_postgres_database, parsed, db_name)
+    return True
 
 
 def _build_local_chromium_args(
@@ -667,7 +752,9 @@ class SkyvernAgent(BaseAgent):
             # Config value takes priority, then existing env var
             config_val = agent_config.get(config_key)
             if config_val is not None:
-                if isinstance(config_val, bool):
+                if config_key == "database_string" and config_val == "":
+                    os.environ.pop(env_key, None)
+                elif isinstance(config_val, bool):
                     os.environ[env_key] = "true" if config_val else "false"
                 else:
                     os.environ[env_key] = str(config_val)
@@ -680,6 +767,13 @@ class SkyvernAgent(BaseAgent):
                 or os.getenv("OPENAI_COMPATIBLE_MODEL_KEY")
                 or "OPENAI_COMPATIBLE"
             )
+
+        # For benchmark smoke runs, default Skyvern local mode to an isolated
+        # temporary Postgres DB. A repo/root .env may contain a DATABASE_STRING
+        # for an older Skyvern schema; only use it when explicitly selected in
+        # config.
+        if agent_config.get("enable_openai_compatible") and "database_string" not in agent_config:
+            os.environ["DATABASE_STRING"] = _make_temp_database_string()
 
         # NOTE: local_proxy_* is NOT wired through Skyvern's own setup_proxy()
         # (which reads ENABLE_PROXY / HOSTED_PROXY_POOL env vars). The bench's
@@ -1264,12 +1358,19 @@ class SkyvernAgent(BaseAgent):
         in PostgreSQL. The key is also written to .env and os.environ
         so the embedded server transport can use it.
         """
+        from skyvern.forge import app
         from skyvern.forge.forge_app_initializer import start_forge_app
+        from skyvern.forge.sdk.db.models import Base
         from skyvern.forge.sdk.services.local_org_auth_token_service import (
             regenerate_local_api_key,
         )
 
+        database_string = os.getenv("DATABASE_STRING", "")
+        uses_temp_postgres = _ensure_temp_postgres_database(database_string)
         start_forge_app()
+        if database_string.startswith("sqlite") or uses_temp_postgres:
+            async with app.DATABASE.engine.begin() as connection:
+                await connection.run_sync(Base.metadata.create_all)
         api_key, org_id, _, _ = await regenerate_local_api_key()
         logger.info(
             "Local Skyvern auth ready: org_id=%s, key=%s...%s",

--- a/browseruse_bench/browsers/orphan_cleanup.py
+++ b/browseruse_bench/browsers/orphan_cleanup.py
@@ -105,6 +105,56 @@ def _cleanup_agentbay_session(session_id: str) -> bool:
         return False
 
 
+def _cleanup_browserbase_session(session_id: str) -> bool:
+    api_key = os.getenv("BROWSERBASE_API_KEY")
+    if not api_key:
+        logger.error("BROWSERBASE_API_KEY is required for Browserbase cleanup")
+        return False
+
+    base_url = os.getenv("BROWSERBASE_BASE_URL", "https://api.browserbase.com").rstrip("/")
+    project_id = os.getenv("BROWSERBASE_PROJECT_ID", "")
+    body: dict[str, str] = {"status": "REQUEST_RELEASE"}
+    if project_id:
+        body["projectId"] = project_id
+    try:
+        from browseruse_bench.browsers.providers.cloud_utils import post_json
+
+        post_json(
+            url=f"{base_url}/v1/sessions/{session_id}",
+            headers={"X-BB-API-Key": api_key},
+            body=body,
+            timeout_seconds=30,
+        )
+        logger.info("Requested Browserbase session release: %s", session_id)
+        return True
+    except (ConnectionError, OSError, RuntimeError, TimeoutError) as exc:
+        logger.error("Browserbase session cleanup failed (session_id=%s): %s", session_id, exc)
+        return False
+
+
+def _cleanup_steel_session(session_id: str) -> bool:
+    api_key = os.getenv("STEEL_API_KEY")
+    if not api_key:
+        logger.error("STEEL_API_KEY is required for Steel cleanup")
+        return False
+
+    base_url = os.getenv("STEEL_BASE_URL", "https://api.steel.dev").rstrip("/")
+    try:
+        from browseruse_bench.browsers.providers.cloud_utils import post_json
+
+        post_json(
+            url=f"{base_url}/v1/sessions/{session_id}/release",
+            headers={"steel-api-key": api_key},
+            body=None,
+            timeout_seconds=30,
+        )
+        logger.info("Requested Steel session release: %s", session_id)
+        return True
+    except (ConnectionError, OSError, RuntimeError, TimeoutError) as exc:
+        logger.error("Steel session cleanup failed (session_id=%s): %s", session_id, exc)
+        return False
+
+
 def _remove_state_file(path: Path) -> bool:
     try:
         path.unlink(missing_ok=True)
@@ -140,6 +190,10 @@ def cleanup_orphaned_session_state(state_file: Path) -> int:
         )
     elif backend_id == "agentbay":
         success = _cleanup_agentbay_session(session_id=session_id)
+    elif backend_id == "browserbase":
+        success = _cleanup_browserbase_session(session_id=session_id)
+    elif backend_id == "steel":
+        success = _cleanup_steel_session(session_id=session_id)
     else:
         logger.info("Unsupported backend_id in session state (%s), skipping cleanup", backend_id)
         success = True

--- a/browseruse_bench/browsers/providers/browserbase.py
+++ b/browseruse_bench/browsers/providers/browserbase.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from browseruse_bench.browsers.base import BrowserBackend
+from browseruse_bench.browsers.providers import cloud_utils
+from browseruse_bench.browsers.session_state import clear_session_state, write_session_state
+from browseruse_bench.browsers.types import BrowserSessionContext
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserbaseBackend(BrowserBackend):
+    """Browserbase cloud browser backend using the public Sessions REST API."""
+
+    def open(self, agent_name: str, agent_config: dict[str, Any]) -> BrowserSessionContext:
+        api_key = cloud_utils.read_config(agent_config, "browserbase_api_key", "BROWSERBASE_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Browserbase requires an API key: set `browserbase_api_key` in config.yaml "
+                "or BROWSERBASE_API_KEY in the environment"
+            )
+
+        base_url = str(
+            cloud_utils.read_config(agent_config, "browserbase_base_url", "BROWSERBASE_BASE_URL")
+            or "https://api.browserbase.com"
+        ).rstrip("/")
+        timeout_seconds = cloud_utils.read_int(
+            cloud_utils.read_config(agent_config, "browserbase_request_timeout"),
+            "browserbase_request_timeout",
+        ) or 30
+
+        body: dict[str, Any] = {}
+        project_id = cloud_utils.read_config(agent_config, "browserbase_project_id", "BROWSERBASE_PROJECT_ID")
+        if project_id:
+            body["projectId"] = project_id
+        context_id = cloud_utils.read_config(agent_config, "browserbase_context_id")
+        if context_id:
+            body["contextId"] = context_id
+        extension_id = cloud_utils.read_config(agent_config, "browserbase_extension_id")
+        if extension_id:
+            body["extensionId"] = extension_id
+
+        browser_settings: dict[str, Any] = {}
+        session_timeout = cloud_utils.read_int(
+            cloud_utils.read_config(agent_config, "browserbase_timeout"),
+            "browserbase_timeout",
+        )
+        if session_timeout is not None:
+            browser_settings["timeout"] = session_timeout
+        if "browserbase_keep_alive" in agent_config:
+            browser_settings["keepAlive"] = cloud_utils.read_bool(
+                agent_config.get("browserbase_keep_alive"),
+                default=False,
+                config_key="browserbase_keep_alive",
+            )
+        region = cloud_utils.read_config(agent_config, "browserbase_region")
+        if region:
+            browser_settings["region"] = region
+        if browser_settings:
+            body["browserSettings"] = browser_settings
+
+        logger.info("[INFO] Creating Browserbase browser session...")
+        session = cloud_utils.post_json(
+            url=f"{base_url}/v1/sessions",
+            headers={"X-BB-API-Key": str(api_key)},
+            body=body,
+            timeout_seconds=timeout_seconds,
+        )
+        cdp_url = str(session.get("connectUrl") or "")
+        session_id = str(session.get("id") or "")
+        if not session_id:
+            raise RuntimeError("Browserbase session creation failed: id is empty")
+        if not cdp_url:
+            self._release_session(
+                base_url=base_url,
+                api_key=str(api_key),
+                project_id=str(project_id or ""),
+                session_id=session_id,
+                timeout_seconds=timeout_seconds,
+            )
+            raise RuntimeError("Browserbase session creation failed: connectUrl is empty")
+
+        write_session_state(backend_id=self.backend_id, session_id=session_id)
+        logger.info("[SUCCESS] Browserbase session created: %s", session_id)
+        return BrowserSessionContext(
+            backend_id=self.backend_id,
+            transport="cdp",
+            cdp_url=cdp_url,
+            metadata={
+                "base_url": base_url,
+                "api_key": str(api_key),
+                "project_id": str(project_id or ""),
+                "session_id": session_id,
+                "request_timeout": timeout_seconds,
+                "session": session,
+            },
+        )
+
+    def close(self, session_context: BrowserSessionContext) -> None:
+        session_id = str(session_context.metadata.get("session_id") or "")
+        if session_id:
+            try:
+                self._release_session(
+                    base_url=str(session_context.metadata.get("base_url") or "https://api.browserbase.com"),
+                    api_key=str(session_context.metadata.get("api_key") or ""),
+                    project_id=str(session_context.metadata.get("project_id") or ""),
+                    session_id=session_id,
+                    timeout_seconds=int(session_context.metadata.get("request_timeout") or 30),
+                )
+            except cloud_utils.CLEANUP_EXCEPTIONS as exc:
+                logger.error("Browserbase session release failed (session_id=%s): %s", session_id, exc)
+        try:
+            clear_session_state()
+        except (OSError, RuntimeError) as exc:
+            logger.error("Failed to clear browser session state: %s", exc)
+
+    def _release_session(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        project_id: str,
+        session_id: str,
+        timeout_seconds: int,
+    ) -> None:
+        if not api_key:
+            raise RuntimeError("Browserbase session release failed: api key is empty")
+        body: dict[str, Any] = {"status": "REQUEST_RELEASE"}
+        if project_id:
+            body["projectId"] = project_id
+        cloud_utils.post_json(
+            url=f"{base_url.rstrip('/')}/v1/sessions/{session_id}",
+            headers={"X-BB-API-Key": api_key},
+            body=body,
+            timeout_seconds=timeout_seconds,
+        )

--- a/browseruse_bench/browsers/providers/browserless.py
+++ b/browseruse_bench/browsers/providers/browserless.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from browseruse_bench.browsers.base import BrowserBackend
+from browseruse_bench.browsers.providers import cloud_utils
+from browseruse_bench.browsers.types import BrowserSessionContext
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_browserless_query(config_key: str, value: Any) -> Any:
+    if config_key != "browserless_timeout":
+        return value
+    timeout = cloud_utils.read_int(value, config_key)
+    if timeout is None:
+        return value
+    if timeout > 60_000:
+        normalized = max(1, timeout // 1000)
+        logger.warning(
+            "browserless_timeout=%s looks like milliseconds; sending %s seconds to Browserless",
+            timeout,
+            normalized,
+        )
+        return normalized
+    return timeout
+
+
+class BrowserlessBackend(BrowserBackend):
+    """Browserless BaaS backend that exposes a connection URL directly."""
+
+    def open(self, agent_name: str, agent_config: dict[str, Any]) -> BrowserSessionContext:
+        token = (
+            cloud_utils.read_config(agent_config, "browserless_token", "BROWSERLESS_TOKEN")
+            or cloud_utils.read_config(agent_config, "browserless_api_key", "BROWSERLESS_API_KEY")
+        )
+        if not token:
+            raise ValueError(
+                "Browserless requires an API token: set `browserless_token` in config.yaml "
+                "(e.g. `browserless_token: $BROWSERLESS_TOKEN`) or BROWSERLESS_TOKEN in the environment"
+            )
+
+        endpoint = str(
+            cloud_utils.read_config(agent_config, "browserless_ws_url", "BROWSERLESS_WS_URL")
+            or cloud_utils.read_config(agent_config, "browserless_endpoint", "BROWSERLESS_ENDPOINT")
+            or "wss://production-sfo.browserless.io"
+        ).rstrip("/")
+        if "://" not in endpoint:
+            endpoint = "wss://" + endpoint
+        browser_path = str(agent_config.get("browserless_browser_path") or "")
+        if browser_path and not browser_path.startswith("/"):
+            browser_path = "/" + browser_path
+        base_url = endpoint + browser_path
+
+        query: dict[str, Any] = {"token": token}
+        for key in (
+            "timeout",
+            "proxy",
+            "proxyCountry",
+            "proxyCity",
+            "proxyState",
+            "blockAds",
+            "headless",
+            "solveCaptchas",
+            "integrations",
+        ):
+            cfg_key = f"browserless_{key}"
+            value = cloud_utils.read_config(agent_config, cfg_key)
+            if value not in (None, ""):
+                query[key] = _normalize_browserless_query(cfg_key, value)
+
+        cdp_url = cloud_utils.append_query(base_url, query)
+        resolve_debugger_url = cloud_utils.read_bool(
+            cloud_utils.read_config(agent_config, "browserless_resolve_debugger_url"),
+            default=False,
+            config_key="browserless_resolve_debugger_url",
+        )
+        if resolve_debugger_url:
+            http_endpoint = endpoint.replace("wss://", "https://", 1).replace("ws://", "http://", 1)
+            version_url = cloud_utils.append_query(http_endpoint + "/json/version", query)
+            version_payload = cloud_utils.get_json(url=version_url, timeout_seconds=30)
+            debugger_url = version_payload.get("webSocketDebuggerUrl")
+            if not isinstance(debugger_url, str) or not debugger_url:
+                raise RuntimeError("Browserless /json/version response did not include webSocketDebuggerUrl")
+            cdp_url = debugger_url
+        logger.info("[SUCCESS] Browserless connection URL prepared for %s", endpoint)
+        return BrowserSessionContext(
+            backend_id=self.backend_id,
+            transport="cdp",
+            cdp_url=cdp_url,
+            metadata={"endpoint": endpoint, "browser_path": browser_path},
+        )
+
+    def close(self, session_context: BrowserSessionContext) -> None:
+        return None

--- a/browseruse_bench/browsers/providers/cloud_utils.py
+++ b/browseruse_bench/browsers/providers/cloud_utils.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+CLEANUP_EXCEPTIONS = (
+    HTTPError,
+    URLError,
+    OSError,
+    RuntimeError,
+    TimeoutError,
+    socket.timeout,
+)
+_URL_SECRET_QUERY_KEYS = {"token", "apikey", "apiKey", "key"}
+_DEFAULT_USER_AGENT = "browseruse-bench/1.0"
+
+
+def read_config(agent_config: dict[str, Any], key: str, env_key: str | None = None) -> Any:
+    value = agent_config.get(key)
+    if value not in (None, ""):
+        return value
+    if env_key:
+        return os.getenv(env_key)
+    return None
+
+
+def read_bool(value: Any, default: bool, config_key: str) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    logger.warning("Invalid boolean value for %s: %r; using default=%s", config_key, value, default)
+    return default
+
+
+def read_int(value: Any, config_key: str) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid integer value for %s: %r; ignoring", config_key, value)
+        return None
+
+
+def redact_url_query(url: str) -> str:
+    parsed = urlparse(url)
+    if not parsed.query:
+        return url
+    redacted_query = urlencode(
+        (key, "<redacted>" if key in _URL_SECRET_QUERY_KEYS else value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+    )
+    return urlunparse(parsed._replace(query=redacted_query))
+
+
+def post_json(
+    *,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any] | None,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    encoded_body = None
+    request_headers = dict(headers)
+    request_headers.setdefault("User-Agent", _DEFAULT_USER_AGENT)
+    if body is not None:
+        encoded_body = json.dumps(body).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+    request = Request(url=url, data=encoded_body, headers=request_headers, method="POST")
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            payload = response.read().decode("utf-8")
+    except HTTPError as exc:
+        error_payload = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"POST {redact_url_query(url)} failed with HTTP {exc.code}: {error_payload}") from exc
+    except (URLError, OSError, TimeoutError) as exc:
+        raise RuntimeError(f"POST {redact_url_query(url)} failed: {exc}") from exc
+
+    if not payload:
+        return {}
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"POST {redact_url_query(url)} returned invalid JSON") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError(f"POST {redact_url_query(url)} returned non-object JSON")
+    return decoded
+
+
+def get_json(*, url: str, timeout_seconds: int) -> dict[str, Any]:
+    request = Request(url=url, headers={"User-Agent": _DEFAULT_USER_AGENT}, method="GET")
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            payload = response.read().decode("utf-8")
+    except HTTPError as exc:
+        error_payload = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GET {redact_url_query(url)} failed with HTTP {exc.code}: {error_payload}") from exc
+    except (URLError, OSError, TimeoutError) as exc:
+        raise RuntimeError(f"GET {redact_url_query(url)} failed: {exc}") from exc
+
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"GET {redact_url_query(url)} returned invalid JSON") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError(f"GET {redact_url_query(url)} returned non-object JSON")
+    return decoded
+
+
+def append_query(url: str, params: dict[str, Any]) -> str:
+    parsed = urlparse(url)
+    existing_query = parsed.query
+    extra_query = urlencode({k: v for k, v in params.items() if v not in (None, "")})
+    query = "&".join(part for part in (existing_query, extra_query) if part)
+    return urlunparse(parsed._replace(query=query))

--- a/browseruse_bench/browsers/providers/steel.py
+++ b/browseruse_bench/browsers/providers/steel.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from browseruse_bench.browsers.base import BrowserBackend
+from browseruse_bench.browsers.providers import cloud_utils
+from browseruse_bench.browsers.session_state import clear_session_state, write_session_state
+from browseruse_bench.browsers.types import BrowserSessionContext
+
+logger = logging.getLogger(__name__)
+
+
+class SteelBackend(BrowserBackend):
+    """Steel.dev cloud browser backend using the public Sessions REST API."""
+
+    def open(self, agent_name: str, agent_config: dict[str, Any]) -> BrowserSessionContext:
+        api_key = cloud_utils.read_config(agent_config, "steel_api_key", "STEEL_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Steel requires an API key: set `steel_api_key` in config.yaml "
+                "or STEEL_API_KEY in the environment"
+            )
+
+        base_url = str(
+            cloud_utils.read_config(agent_config, "steel_base_url", "STEEL_BASE_URL")
+            or "https://api.steel.dev"
+        ).rstrip("/")
+        connect_url = str(
+            cloud_utils.read_config(agent_config, "steel_connect_url", "STEEL_CONNECT_URL")
+            or "wss://connect.steel.dev"
+        ).rstrip("/")
+        timeout_seconds = (
+            cloud_utils.read_int(cloud_utils.read_config(agent_config, "steel_request_timeout"), "steel_request_timeout")
+            or 30
+        )
+
+        body = self._build_create_body(agent_config)
+        logger.info("[INFO] Creating Steel browser session...")
+        session = cloud_utils.post_json(
+            url=f"{base_url}/v1/sessions",
+            headers={"steel-api-key": str(api_key)},
+            body=body,
+            timeout_seconds=timeout_seconds,
+        )
+        session_id = str(session.get("id") or "")
+        if not session_id:
+            raise RuntimeError("Steel session creation failed: id is empty")
+
+        cdp_url = str(session.get("websocketUrl") or session.get("websocket_url") or "")
+        if not cdp_url:
+            cdp_url = cloud_utils.append_query(connect_url, {"apiKey": api_key, "sessionId": session_id})
+        elif "apiKey=" not in cdp_url:
+            cdp_url = cloud_utils.append_query(cdp_url, {"apiKey": api_key})
+
+        write_session_state(backend_id=self.backend_id, session_id=session_id)
+        logger.info("[SUCCESS] Steel session created: %s", session_id)
+        return BrowserSessionContext(
+            backend_id=self.backend_id,
+            transport="cdp",
+            cdp_url=cdp_url,
+            metadata={
+                "base_url": base_url,
+                "api_key": str(api_key),
+                "session_id": session_id,
+                "request_timeout": timeout_seconds,
+                "session": session,
+            },
+        )
+
+    def close(self, session_context: BrowserSessionContext) -> None:
+        session_id = str(session_context.metadata.get("session_id") or "")
+        if session_id:
+            try:
+                base_url = str(session_context.metadata.get("base_url") or "https://api.steel.dev").rstrip("/")
+                cloud_utils.post_json(
+                    url=f"{base_url}/v1/sessions/{session_id}/release",
+                    headers={"steel-api-key": str(session_context.metadata.get("api_key") or "")},
+                    body=None,
+                    timeout_seconds=int(session_context.metadata.get("request_timeout") or 30),
+                )
+            except cloud_utils.CLEANUP_EXCEPTIONS as exc:
+                logger.error("Steel session release failed (session_id=%s): %s", session_id, exc)
+        try:
+            clear_session_state()
+        except (OSError, RuntimeError) as exc:
+            logger.error("Failed to clear browser session state: %s", exc)
+
+    def _build_create_body(self, agent_config: dict[str, Any]) -> dict[str, Any]:
+        field_map = {
+            "steel_block_ads": "blockAds",
+            "steel_headless": "headless",
+            "steel_persist_profile": "persistProfile",
+            "steel_profile_id": "profileId",
+            "steel_proxy_url": "proxyUrl",
+            "steel_region": "region",
+            "steel_session_id": "sessionId",
+            "steel_solve_captcha": "solveCaptcha",
+            "steel_timeout": "timeout",
+            "steel_use_proxy": "useProxy",
+            "steel_user_agent": "userAgent",
+        }
+        bool_keys = {
+            "steel_block_ads",
+            "steel_headless",
+            "steel_persist_profile",
+            "steel_solve_captcha",
+            "steel_use_proxy",
+        }
+        int_keys = {"steel_timeout"}
+        body: dict[str, Any] = {}
+        for config_key, api_key in field_map.items():
+            if config_key not in agent_config:
+                continue
+            value = agent_config.get(config_key)
+            if value in (None, ""):
+                continue
+            if config_key in bool_keys:
+                body[api_key] = cloud_utils.read_bool(value, default=False, config_key=config_key)
+            elif config_key in int_keys:
+                int_value = cloud_utils.read_int(value, config_key)
+                if int_value is not None:
+                    body[api_key] = int_value
+            else:
+                body[api_key] = value
+        return body

--- a/browseruse_bench/browsers/registry.py
+++ b/browseruse_bench/browsers/registry.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Callable, Dict
+from collections.abc import Callable
 
 from browseruse_bench.browsers.base import BrowserBackend
 
-_BACKEND_FACTORIES: Dict[str, Callable[[], BrowserBackend]] = {}
+_BACKEND_FACTORIES: dict[str, Callable[[], BrowserBackend]] = {}
 _DEFAULTS_REGISTERED = False
 
 
@@ -38,6 +38,24 @@ def _create_agentbay_backend() -> BrowserBackend:
     return AgentBayBackend("agentbay")
 
 
+def _create_browserbase_backend() -> BrowserBackend:
+    from browseruse_bench.browsers.providers.browserbase import BrowserbaseBackend
+
+    return BrowserbaseBackend("browserbase")
+
+
+def _create_browserless_backend() -> BrowserBackend:
+    from browseruse_bench.browsers.providers.browserless import BrowserlessBackend
+
+    return BrowserlessBackend("browserless")
+
+
+def _create_steel_backend() -> BrowserBackend:
+    from browseruse_bench.browsers.providers.steel import SteelBackend
+
+    return SteelBackend("steel")
+
+
 def register_backend(browser_id: str, factory: Callable[[], BrowserBackend]) -> None:
     if browser_id in _BACKEND_FACTORIES:
         raise ValueError(f"Browser backend already registered: {browser_id}")
@@ -56,6 +74,9 @@ def _register_default_backends() -> None:
     register_backend("cdp", _create_cdp_backend)
     register_backend("lexmount", _create_lexmount_backend)
     register_backend("agentbay", _create_agentbay_backend)
+    register_backend("browserbase", _create_browserbase_backend)
+    register_backend("browserless", _create_browserless_backend)
+    register_backend("steel", _create_steel_backend)
     _DEFAULTS_REGISTERED = True
 
 

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -479,8 +479,8 @@ def configure_run_parser(parser: argparse.ArgumentParser, config: dict[str, Any]
         default=None,
         help=(
             "Optional path to an alternate root-config YAML (same shape as the repo "
-            "config.yaml). The runtime config for --agent is resolved from that file "
-            "via agents.<agent>.models. By default the repo root config.yaml is used."
+            "config.yaml). The runtime config for --agent is resolved from that file. "
+            "By default the repo root config.yaml is used."
         ),
     )
     parser.add_argument(
@@ -488,7 +488,14 @@ def configure_run_parser(parser: argparse.ArgumentParser, config: dict[str, Any]
         "--model",
         dest="model_name",
         default=None,
-        help="Optional model config name under config.yaml agents.<agent>.models to override active_model for this run.",
+        help="Optional model config name under config.yaml models to override default.model for this run.",
+    )
+    parser.add_argument(
+        "--browser-id",
+        "--browser",
+        dest="browser_id",
+        default=None,
+        help="Optional browser backend id under config.yaml browsers to override the selected browser for this run.",
     )
     parser.add_argument(
         "--force-download",
@@ -905,15 +912,15 @@ def run_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
         source_cfg = load_config_file(cfg_path)
         source_label = str(cfg_path)
 
-    # --agent-config only overrides the inline model config (agents.<agent>.models.*).
+    # --agent-config only overrides the inline runtime config (models/browsers/agents defaults).
     # Benchmark definitions and the agent registry keep coming from the root config,
     # which is why run_agent still receives `config`, not `source_cfg`.
-    inline = resolve_agent_inline_config(args.agent, source_cfg, args.model_name)
+    inline = resolve_agent_inline_config(args.agent, source_cfg, args.model_name, args.browser_id)
     if inline is None:
         model_hint = (
-            f"agents.{args.agent}.models.{args.model_name}"
+            f"models.{args.model_name}"
             if args.model_name
-            else f"agents.{args.agent}.active_model"
+            else "default.model plus models.<name>"
         )
         raise SystemExit(
             f"[FAILED] Inline agent runtime config not found in {source_label}.\n"

--- a/browseruse_bench/utils/config_loader.py
+++ b/browseruse_bench/utils/config_loader.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import uuid
 import warnings
 from copy import deepcopy
 from pathlib import Path
@@ -18,6 +19,11 @@ from browseruse_bench.utils.repo_root import REPO_ROOT
 
 logger = logging.getLogger(__name__)
 _EVAL_STRUCTURAL_KEYS = {"api_key", "base_url"}
+
+
+def _skyvern_temp_database_string() -> str:
+    db_name = f"bubench_skyvern_{uuid.uuid4().hex}"
+    return f"postgresql+psycopg:///{db_name}?host=/tmp"
 
 
 def load_eval_config(benchmark_name: str) -> dict[str, Any]:
@@ -223,15 +229,21 @@ def resolve_agent_inline_config(
     agent: str,
     root_config: dict[str, Any],
     model_name: str | None = None,
+    browser_id: str | None = None,
 ) -> dict[str, Any] | None:
-    """Resolve runtime config from root config's agents.<agent>.models[selected_model].
+    """Resolve runtime config for an agent/model/browser selection.
 
-    Merges agent-level defaults with model-specific params (model params win).
+    New-style root config resolves as:
+    ``agents.<agent> runtime fields + models.<selected_model> + browsers.<selected_browser>``.
+
+    Legacy root config remains supported and resolves as:
+    ``agents.<agent>.browser + agents.<agent>.defaults + agents.<agent>.models.<selected_model>``.
 
     Args:
         agent: Agent name.
         root_config: Root configuration dictionary.
         model_name: Optional explicit model key override.
+        browser_id: Optional explicit browser backend key override.
 
     Returns:
         Dict with runtime params, or None if not using inline model config.
@@ -239,12 +251,45 @@ def resolve_agent_inline_config(
     agents = root_config.get("agents", {})
     agent = _resolve_agent_key(agent, agents)
     agent_entry = agents.get(agent, {})
+
+    structural_agent_keys = {
+        "active_model",
+        "active_browser",
+        "models",
+        "browser",
+        "defaults",
+    }
+    agent_defaults = {
+        key: value
+        for key, value in agent_entry.items()
+        if key not in structural_agent_keys
+    }
+    defaults = {**agent_defaults, **(agent_entry.get("defaults", {}) or {})}
+    shared_models = root_config.get("models", {})
+    shared_browsers = root_config.get("browsers", {})
+    if isinstance(shared_models, dict) and isinstance(shared_browsers, dict) and shared_models:
+        active_model = model_name or agent_entry.get("active_model") or root_config.get("default", {}).get("model")
+        active_browser = (
+            browser_id
+            or agent_entry.get("active_browser")
+            or root_config.get("default", {}).get("browser")
+            or root_config.get("default", {}).get("browser_id")
+        )
+        if not (active_model and active_model in shared_models):
+            return None
+        model_cfg = shared_models[active_model] or {}
+        browser_cfg = shared_browsers.get(active_browser, {}) if active_browser else {}
+        if active_browser and active_browser not in shared_browsers:
+            browser_cfg = {"browser_id": active_browser}
+        return {**defaults, **model_cfg, **browser_cfg}
+
     active_model = model_name or agent_entry.get("active_model")
     models = agent_entry.get("models", {})
     if not (active_model and models and active_model in models):
         return None
     browser = agent_entry.get("browser", {})
-    defaults = agent_entry.get("defaults", {})
+    if browser_id:
+        browser = {**browser, "browser_id": browser_id}
     return {**browser, **defaults, **models[active_model]}
 
 
@@ -356,14 +401,20 @@ def apply_skyvern_env(agent_config: dict[str, Any], env: dict[str, str]) -> None
         "supports_vision": "OPENAI_COMPATIBLE_SUPPORTS_VISION",
         "llm_key": "LLM_KEY",
         "skyvern_api_key": "SKYVERN_API_KEY",
+        "database_string": "DATABASE_STRING",
     }
     for config_key, env_key in key_map.items():
         if config_key in agent_config and agent_config[config_key] is not None:
             value = agent_config[config_key]
-            if isinstance(value, bool):
+            if config_key == "database_string" and value == "":
+                env.pop(env_key, None)
+            elif isinstance(value, bool):
                 env[env_key] = "true" if value else "false"
             else:
                 env[env_key] = str(value)
 
     if agent_config.get("enable_openai_compatible") and not env.get("LLM_KEY"):
         env["LLM_KEY"] = "OPENAI_COMPATIBLE"
+
+    if agent_config.get("enable_openai_compatible") and "database_string" not in agent_config:
+        env["DATABASE_STRING"] = _skyvern_temp_database_string()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,419 +1,260 @@
 # browseruse-bench configuration file
-# =====================================
-# This file is git-ignored. Copy config.example.yaml to config.yaml to get started.
-# API keys and runtime parameters are stored here.
+#
+# Shared runtime config is intentionally flat:
+#   runtime config = agents.<agent> + models.<model> + browsers.<browser>
+# Select defaults globally with default.model/default.browser. Override per run
+# with `--model` and `--browser-id`.
 
 default:
   agent: browser-use
   data: LexBench-Browser
-
-# Agent Runtime Configuration
-# Each agent has an active_model and a models section with per-model parameters.
-# Registration info (venv, path, supported_benchmarks) is in configs/agent_registry.yaml
+  model: gpt-5.4
+  browser: lexmount
+models:
+  # Browser Use official hosted model. Only supported by the browser-use agent.
+  browser-use:
+    model_type: BROWSER_USE
+    model_id: bu-2-0
+    api_key: $BROWSER_USE_API_KEY
+  gpt-5.4:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: gpt-5.4
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+  qwen-plus:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: qwen3.5-plus
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    dont_force_structured_output: true
+    add_schema_to_system_prompt: true
+    max_tokens: 16000
+    temperature: 0.0
+    request_timeout: 600
+  kimi-k2.5:
+    model_type: OPENAI
+    model_id: kimi-k2.5
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    temperature: 1.0
+    frequency_penalty: 0
+    remove_min_items_from_schema: true
+    remove_defaults_from_schema: true
+    add_schema_to_system_prompt: true
+  minimax-m2.5:
+    model_type: OPENAI
+    model_id: MiniMax-M2.5
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    dont_force_structured_output: true
+    add_schema_to_system_prompt: true
+  doubao-seed:
+    model_type: AZURE
+    model_id: doubao-seed-2-0-pro
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+  claude-sonnet:
+    model_type: OPENAI
+    model_id: claude-sonnet-4-6
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    dont_force_structured_output: true
+    add_schema_to_system_prompt: true
+  gemini-2.5-pro:
+    model_type: OPENAI
+    model_id: gemini-2.5-pro
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    frequency_penalty: null
+  gpt-5-mini:
+    model_type: OPENAI
+    model_id: gpt-5-mini
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+  gemini-3-pro-preview:
+    model_type: OPENAI
+    model_id: gemini-3.1-pro-preview
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    frequency_penalty: null
+  gemini:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: gemini-3.1-pro-preview
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    supports_vision: true
+    max_tokens: 16000
+    temperature: 0.0
+    request_timeout: 600
+  gpt:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: gpt-5.4
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    supports_vision: true
+    temperature: 1.0
+    max_tokens: 16000
+    request_timeout: 600
+  claude:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: dmx-claude-sonnet-4-6
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    supports_vision: true
+    max_tokens: 16000
+    temperature: 0.0
+    request_timeout: 600
+  minimax:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: MiniMax-M2.5
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    supports_vision: true
+    max_tokens: 16000
+    temperature: 0.0
+    request_timeout: 600
+  kimi:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: kimi-k2.5
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    supports_vision: false
+    temperature: 1.0
+    frequency_penalty: 0
+    remove_min_items_from_schema: true
+    remove_defaults_from_schema: true
+    add_schema_to_system_prompt: true
+    max_tokens: 16000
+    request_timeout: 600
+  glm-5:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: glm-5
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    supports_vision: true
+    max_tokens: 16000
+    temperature: 0.0
+    request_timeout: 600
+  sonnet:
+    model_id: claude-sonnet-4-6
+    api_key: $ANTHROPIC_API_KEY
+  opus:
+    model_id: claude-opus-4-6
+    api_key: $ANTHROPIC_API_KEY
+  openrouter:
+    model_type: OPENROUTER
+    model_id: openai/gpt-5.4
+    api_key: $OPENROUTER_API_KEY
+    base_url: https://openrouter.ai/api/v1/chat/completions
+browsers:
+  lexmount:
+    browser_id: lexmount
+    lexmount_browser_mode: normal
+    lexmount_api_key: $LEXMOUNT_API_KEY
+    lexmount_project_id: $LEXMOUNT_PROJECT_ID
+  local:
+    browser_id: local
+    headless: false
+    local_proxy_server: ''
+  browser-use-cloud:
+    browser_id: browser-use-cloud
+    browser_use_cloud_profile_id: your_profile_id
+    browser_use_cloud_proxy_country_code: US
+    browser_use_cloud_timeout: 5
+  skyvern-cloud:
+    browser_id: skyvern-cloud
+    proxy_location: RESIDENTIAL
+  agentbay:
+    browser_id: agentbay
+    agentbay_api_key: $AGENTBAY_API_KEY
+    agentbay_image_id: browser_latest
+    agentbay_enable_browser_replay: true
+    agentbay_browser_use_stealth: false
+  browserbase:
+    browser_id: browserbase
+    browserbase_api_key: $BROWSERBASE_API_KEY
+    browserbase_project_id: $BROWSERBASE_PROJECT_ID
+    browserbase_region: us-west-2
+    browserbase_timeout: 600
+    browserbase_keep_alive: false
+  browserless:
+    browser_id: browserless
+    browserless_token: $BROWSERLESS_TOKEN
+    browserless_ws_url: wss://production-sfo.browserless.io
+    browserless_browser_path: ''
+  steel:
+    browser_id: steel
+    steel_api_key: $STEEL_API_KEY
+    steel_region: iad
+    steel_timeout: 600000
+    steel_use_proxy: false
+    steel_solve_captcha: false
+    steel_block_ads: false
+  cdp:
+    browser_id: cdp
+    CDP_ADDRESS: http://localhost:9222
 agents:
   browser-use:
-    active_model: browser-use
-    models:
-      browser-use:
-        model_type: BROWSER_USE
-        model_id: bu-2-0
-        api_key: $BROWSER_USE_API_KEY
-      gpt-5.4:
-        model_type: OPENAI
-        model_id: gpt-5.4
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      qwen-plus:
-        model_type: OPENAI
-        model_id: qwen3.5-plus
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        dont_force_structured_output: true
-        add_schema_to_system_prompt: true
-      kimi-k2.5:
-        model_type: OPENAI
-        model_id: kimi-k2.5
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        temperature: 1.0          # Kimi enforces temperature >= 1.0
-        frequency_penalty: 0      # Kimi only allows frequency_penalty = 0
-        remove_min_items_from_schema: true
-        remove_defaults_from_schema: true
-        add_schema_to_system_prompt: true
-      minimax-m2.5:
-        model_type: OPENAI
-        model_id: MiniMax-M2.5
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        dont_force_structured_output: true
-        add_schema_to_system_prompt: true
-      doubao-seed:
-        model_type: AZURE
-        model_id: doubao-seed-2-0-pro
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      claude-sonnet:
-        model_type: OPENAI
-        model_id: claude-sonnet-4-6
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        dont_force_structured_output: true
-        add_schema_to_system_prompt: true
-      gemini-2.5-pro:
-        model_type: OPENAI
-        model_id: gemini-2.5-pro
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        # browser-use 0.12 ChatOpenAI defaults frequency_penalty=0.3, but LiteLLM's
-        # vertex_ai backend rejects this param — set null to drop it from the request.
-        frequency_penalty: null
-      gpt-5-mini:
-        model_type: OPENAI
-        model_id: gpt-5-mini
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      gemini-3-pro-preview:
-        model_type: OPENAI
-        model_id: gemini-3.1-pro-preview
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        # See gemini-2.5-pro entry above for the rationale.
-        frequency_penalty: null
-    browser:
-      # ── Active browser backend ──────────────────────────────────────────────
-      browser_id: lexmount
-      lexmount_browser_mode: normal   # normal | light
-      lexmount_api_key: $LEXMOUNT_API_KEY
-      lexmount_project_id: $LEXMOUNT_PROJECT_ID
-      # lexmount_base_url: $LEXMOUNT_BASE_URL       # override default; pick the endpoint for your region:
-                                                  #   https://api.lexmount.cn            — production (mainland China / 国内, default)
-                                                  #   https://api.lexmount.com           — production (international / 国外)
-                                                  #   https://apitest.local.lexmount.net — staging / test
-      # lexmount_verify_ssl: false                  # set false for self-signed certs
-
-      # Per-region profiles. Keys mirror the dataset's `website_region` field
-      # (zh / en today). The runner picks one per case automatically; users
-      # register against each profile via `bubench login add <site>` (the
-      # command iterates configured profiles). Top-level lexmount_* keys
-      # above act as a fallback when a profile lacks a particular field.
-      # lexmount_profiles:
-      #   zh:
-      #     api_key: $LEXMOUNT_API_KEY_ZH
-      #     project_id: $LEXMOUNT_PROJECT_ID_ZH
-      #     base_url: $LEXMOUNT_BASE_URL_ZH
-      #   en:
-      #     api_key: $LEXMOUNT_API_KEY_EN
-      #     project_id: $LEXMOUNT_PROJECT_ID_EN
-      #     base_url: $LEXMOUNT_BASE_URL_EN
-
-      # Optional proxy for lexmount sessions:
-      # lexmount_proxy_server: http://1.2.3.4:8080
-      # lexmount_proxy_type: external
-      # lexmount_proxy_username: your_username
-      # lexmount_proxy_password: your_password
-
-      # ── Other browser backends (uncomment to switch) ─────────────────────────
-      # Chrome-Local — launch a local Chrome/Chromium instance
-      # browser_id: Chrome-Local
-      # The local browser does NOT inherit your OS / clash / v2ray proxy.
-      # If you need to reach sites your direct connection can't (GFW etc.),
-      # set the fields below. Empty server == no proxy (direct connection).
-      # local_proxy_server: ""           # e.g. http://127.0.0.1:7890 (clash) or socks5://127.0.0.1:1080
-      # local_proxy_username: ""         # optional auth
-      # local_proxy_password: ""
-      # local_proxy_bypass: ""           # comma-separated, e.g. 127.0.0.1,localhost,*.local
-      # NOTE: only `skyvern` and `browser-use` agents currently honour these
-      # fields. For Agent-TARS / Claude Code / OpenAI CUA / DeepBrowse, the
-      # underlying CLI/SDK launches Chrome itself and ignores them — switch
-      # to `browser_id: lexmount` (cloud, ex-CN egress) instead.
-
-      # browser-use-cloud — browser session managed by the browser-use SDK
-      # browser_id: browser-use-cloud
-      # browser_use_cloud_profile_id: your_profile_id
-      # browser_use_cloud_proxy_country_code: US
-      # browser_use_cloud_timeout: 5              # minutes
-
-      # AgentBay — Alibaba Cloud remote browser (set AGENTBAY_API_KEY in .env)
-      # browser_id: agentbay
-      # agentbay_api_key: $AGENTBAY_API_KEY
-      # agentbay_image_id: browser_latest
-      # agentbay_enable_browser_replay: true
-      # agentbay_browser_use_stealth: false
-
-      # CDP — connect to any browser that exposes a remote-debugging port
-      # browser_id: cdp
-      # CDP_ADDRESS: http://localhost:9222
-    defaults:
-      use_judge: false
-      use_vision: false
-      max_steps: 40
-      flash_mode: true
-      timeout: 600
-
+    use_judge: false
+    use_vision: false
+    max_steps: 40
+    flash_mode: true
+    timeout: 600
   skyvern:
-    active_model: gemini
-    models:
-      gemini:
-        model_id: gemini-3.1-pro-preview
-        supports_vision: true
-      gpt:
-        model_id: gpt-5.4
-        supports_vision: true
-        temperature: 1.0  # gpt-5 only supports temperature=1
-      claude:
-        model_id: claude-sonnet-4-6
-        supports_vision: true
-      doubao-seed:
-        model_id: doubao-seed-2-0-pro
-        supports_vision: true
-      minimax:
-        model_id: MiniMax-M2.5
-        supports_vision: true
-      qwen-plus:
-        model_id: qwen3.5-plus
-        supports_vision: false
-      kimi:
-        model_id: kimi-k2.5
-        supports_vision: false
-        temperature: 1.0
-      glm-5:
-        model_id: glm-5
-        supports_vision: true
-    browser:
-      # ── Active browser backend ──────────────────────────────────────────────
-      browser_id: local
-      headless: false
-      # Local browser does NOT inherit your OS / clash / v2ray proxy. Set the
-      # fields below to point Chromium at one. Empty server == no proxy.
-      local_proxy_server: ""             # e.g. http://127.0.0.1:7890 (clash) or socks5://127.0.0.1:1080
-      # local_proxy_username: ""         # optional auth
-      # local_proxy_password: ""
-      # local_proxy_bypass: ""           # comma-separated, e.g. 127.0.0.1,localhost,*.local
-
-      # ── Other browser backends (uncomment to switch) ─────────────────────────
-      # lexmount — Lexmount cloud browser
-      # browser_id: lexmount
-      # lexmount_browser_mode: normal   # normal | light
-      # lexmount_api_key: $LEXMOUNT_API_KEY
-      # lexmount_project_id: $LEXMOUNT_PROJECT_ID
-      # lexmount_proxy_server: http://1.2.3.4:8080
-      # lexmount_proxy_type: external
-      # lexmount_proxy_username: your_username
-      # lexmount_proxy_password: your_password
-
-      # AgentBay — Alibaba Cloud remote browser (set AGENTBAY_API_KEY in .env)
-      # browser_id: agentbay
-      # agentbay_api_key: $AGENTBAY_API_KEY
-      # agentbay_image_id: browser_latest
-      # agentbay_enable_browser_replay: true
-      # agentbay_browser_use_stealth: false
-
-      # skyvern-cloud — browser session managed by Skyvern cloud (requires skyvern_api_key)
-      # browser_id: skyvern-cloud
-      # proxy_location: RESIDENTIAL
-    defaults:
-      engine: skyvern_v2
-      max_steps: 50
-      timeout: 600
-      max_screenshot_scrolls: 5
-      include_action_history_in_verification: true
-      max_consecutive_repeats: 3
-      max_action_occurrences: 5
-      enable_openai_compatible: true
-      # Renamed from $OPENAI_COMPATIBLE_API_KEY / $OPENAI_COMPATIBLE_BASE_URL —
-      # update your .env if you were using the old variable names.
-      api_key: $OPENAI_API_KEY
-      base_url: $OPENAI_BASE_URL
-      max_tokens: 16000
-      temperature: 0.0
-      request_timeout: 600  # LiteLLM per-request timeout in seconds (default)
-
+    engine: skyvern_v2
+    max_steps: 50
+    timeout: 600
+    max_screenshot_scrolls: 5
+    include_action_history_in_verification: true
+    max_consecutive_repeats: 3
+    max_action_occurrences: 5
+    enable_openai_compatible: true
+    # Default: ignore inherited DATABASE_STRING and use a temporary PostgreSQL DB.
+    # Set database_string only when you want a managed/persistent Skyvern database.
+    # database_string: postgresql+psycopg://skyvern@localhost/skyvern
   claude-code:
-    # NOTE: model_id is passed as `--model` to the `claude` CLI, which only supports
-    # Anthropic Claude models (claude-*). GPT or other third-party models are not supported.
-    active_model: sonnet
-    models:
-      sonnet:
-        model_id: claude-sonnet-4-6
-        api_key: $ANTHROPIC_API_KEY
-        # base_url: $ANTHROPIC_BASE_URL
-      opus:
-        model_id: claude-opus-4-6
-        api_key: $ANTHROPIC_API_KEY
-        # base_url: $ANTHROPIC_BASE_URL
-    defaults:
-      max_turns: 50
-      timeout: 300
-      allowed_tools: "mcp__playwright*"
-
+    max_turns: 50
+    timeout: 300
+    allowed_tools: mcp__playwright*
   deepbrowse:
-    active_model: gpt
-    models:
-      gpt:
-        model_type: OPENAI
-        model_id: gpt-5.4
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        # model_api_style: chat_completions  # set for gateways that do not support /responses
-      gemini:
-        model_type: GEMINI
-        model_id: gemini-2.5-pro
-        api_key: $GOOGLE_API_KEY
-        # base_url: $GOOGLE_BASE_URL
-    browser:
-      browser_id: lexmount
-      lexmount_api_key: $LEXMOUNT_API_KEY
-      lexmount_project_id: $LEXMOUNT_PROJECT_ID
-      # lexmount_base_url: $LEXMOUNT_BASE_URL
-      # Per-region profiles — see the browser-use agent block above for the
-      # full explanation. Top-level lexmount_* keys remain the fallback.
-      # lexmount_profiles:
-      #   zh:
-      #     api_key: $LEXMOUNT_API_KEY_ZH
-      #     project_id: $LEXMOUNT_PROJECT_ID_ZH
-      #     base_url: $LEXMOUNT_BASE_URL_ZH
-      #   en:
-      #     api_key: $LEXMOUNT_API_KEY_EN
-      #     project_id: $LEXMOUNT_PROJECT_ID_EN
-      #     base_url: $LEXMOUNT_BASE_URL_EN
-    defaults:
-      use_vision: auto
-      max_steps: 50
-      max_action_history_steps: 10
-      keep_last_n_rounds: 0
-      enable_dom_retry: false
-      disable_security: true
-      enable_api_tool: false
-      enable_network_recording: true
-      debug_artifacts: true
-      timeout: 600
-
+    use_vision: auto
+    max_steps: 50
+    max_action_history_steps: 10
+    keep_last_n_rounds: 0
+    enable_dom_retry: false
+    disable_security: true
+    enable_api_tool: false
+    enable_network_recording: true
+    debug_artifacts: true
+    timeout: 600
   webwright:
-    active_model: gpt
-    models:
-      gpt:
-        model_type: OPENAI
-        model_id: gpt-5.4
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      claude:
-        model_type: ANTHROPIC
-        model_id: claude-opus-4-6
-        api_key: $ANTHROPIC_API_KEY
-        # base_url: $ANTHROPIC_BASE_URL
-      openrouter:
-        model_type: OPENROUTER
-        model_id: openai/gpt-5.4
-        api_key: $OPENROUTER_API_KEY
-        base_url: https://openrouter.ai/api/v1/chat/completions
-    browser:
-      browser_id: lexmount
-      lexmount_browser_mode: normal
-      lexmount_api_key: $LEXMOUNT_API_KEY
-      lexmount_project_id: $LEXMOUNT_PROJECT_ID
-      # lexmount_base_url: $LEXMOUNT_BASE_URL
-    defaults:
-      max_steps: 100
-      timeout: 600
-      request_timeout_seconds: 120
-
+    max_steps: 100
+    timeout: 600
+    request_timeout_seconds: 120
   Agent-TARS:
-    active_model: claude
-    browser:
-      # ── Active browser backend ──────────────────────────────────────────────
-      # local — launch a local headless browser
-      browser_id: local
-      # local_proxy_*: unsupported on Agent-TARS (CLI 0.3.0 has no browser.proxy
-      # config field). Use browser_id=lexmount if you need a proxy / out-of-CN
-      # egress. See docs/{en,zh}/browser/local.mdx for the full agent matrix.
-
-      # ── Other browser backends (uncomment to switch) ─────────────────────────
-      # lexmount — Lexmount cloud browser (LEXMOUNT_API_KEY must be in .env)
-      # browser_id: lexmount
-      # lexmount_browser_mode: normal   # normal | light
-      # lexmount_api_key: $LEXMOUNT_API_KEY
-      # lexmount_project_id: $LEXMOUNT_PROJECT_ID
-      # lexmount_proxy_server: http://1.2.3.4:8080
-      # lexmount_proxy_type: external
-      # lexmount_proxy_username: your_username
-      # lexmount_proxy_password: your_password
-    defaults:
-      # ── browser_control options ──────────────────────────────────────────────
-      # dom              — DOM-only: fast & stable, but fails on canvas / dynamic UI
-      # visual-grounding — screenshot + VLM coordinate click; handles any visible element
-      # hybrid           — model chooses DOM or vision per step; best fault tolerance
-      browser_control: hybrid
-      timeout: 300
-      max_turns: 50
-    models:
-      gpt-5.4:
-        model_provider: openai
-        model_id: gpt-5.4-mini
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        timeout: 600
-        temperature: 1.0  # gpt-5 only supports temperature=1
-      gemini:
-        model_provider: openai
-        model_id: gemini-3.1-pro-preview
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      claude:
-        model_provider: openai
-        model_id: dmx-claude-sonnet-4-6
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      doubao-seed:
-        model_provider: openai
-        model_id: doubao-seed-2-0-pro
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      minimax:
-        model_provider: openai
-        model_id: MiniMax-M2.5
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-      qwen-plus:
-        model_provider: openai
-        model_id: qwen3.6-plus
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        dont_force_structured_output: true
-        add_schema_to_system_prompt: true
-      kimi:
-        model_provider: openai
-        model_id: kimi-k2.5
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-        temperature: 1.0          # Kimi enforces temperature >= 1.0
-        frequency_penalty: 0      # Kimi only allows frequency_penalty = 0
-        remove_min_items_from_schema: true
-        remove_defaults_from_schema: true
-        add_schema_to_system_prompt: true
-      glm-5:
-        model_provider: openai
-        model_id: glm-5
-        api_key: $OPENAI_API_KEY
-        base_url: $OPENAI_BASE_URL
-
-# Eval Model Configuration
-# All graders share these settings. api_key and base_url are CLI-only (not forwarded to graders).
+    browser_control: hybrid
+    timeout: 300
+    max_turns: 50
 eval:
   model: gpt-5.4
   api_key: $OPENAI_API_KEY
-  base_url: $OPENAI_BASE_URL # optional, remove if using OpenAI directly
-  temperature: 1.0           # gpt-5 only supports temperature=1
-  max_tries: 5               # shared default for all benchmark graders
+  base_url: $OPENAI_BASE_URL
+  temperature: 1.0
+  max_tries: 5
   api_max_images: 50
   detail: high
-  max_tokens: 512            # grader output token limit (max_new_tokens also accepted for compat)
-
-# Leaderboard Configuration
+  max_tokens: 512
 leaderboard:
   default_timeout_seconds: 300
   regenerate_timeout_seconds: 300
-
-# Systemd Service Configuration (Linux only)
 service:
   name: benchmark-server
   description: BrowserUse Bench Leaderboard Server

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -60,6 +60,7 @@
                                         "pages": [
                                             "en/browser/local",
                                             "en/browser/lexmount",
+                                            "en/browser/cloud-browsers",
                                             "en/browser/custom-backend"
                                         ]
                                     },
@@ -165,6 +166,7 @@
                                         "pages": [
                                             "zh/browser/local",
                                             "zh/browser/lexmount",
+                                            "zh/browser/cloud-browsers",
                                             "zh/browser/custom-backend"
                                         ]
                                     },

--- a/docs/en/agents/custom-agent.mdx
+++ b/docs/en/agents/custom-agent.mdx
@@ -139,19 +139,18 @@ from browseruse_bench.agents import my_agent  # noqa: F401
 
 ### 3. Register in config
 
-In the root `config.yaml` under `agents`:
+In the root `config.yaml`, add a shared model and agent runtime fields:
 
 ```yaml
+models:
+  my-agent-default:
+    model_id: your-model-id
+    api_key: $YOUR_API_KEY
+
 agents:
   my-agent:
-    active_model: default
-    models:
-      default:
-        model_id: your-model-id
-        api_key: $YOUR_API_KEY
-    defaults:
-      timeout: 300
-      max_steps: 40
+    timeout: 300
+    max_steps: 40
 ```
 
 Also add metadata to `configs/agent_registry.yaml`:
@@ -347,7 +346,7 @@ Optional but recommended: `answer` (`str`) — the agent's final answer string, 
 
 **`task_info`** is loaded from the benchmark dataset. Standard fields: `task_id`, `task_text`, `url`, `prompt` (optional).
 
-**`agent_config`** comes from `agents.<agent>.models[active_model]` in root `config.yaml`. The framework injects `timeout_seconds` at runtime.
+**`agent_config`** is resolved from root `config.yaml` as `agents.<agent> + models.<model> + browsers.<browser>`. The framework injects `timeout_seconds` at runtime.
 
 **`task_workspace`** is the per-task output directory (`<output_dir>/tasks/<task_id>/`). The framework writes `result.json` there; you can write screenshots, logs, or any artifacts alongside it.
 

--- a/docs/en/agents/skyvern.mdx
+++ b/docs/en/agents/skyvern.mdx
@@ -21,31 +21,34 @@ Activate `.venv` (or use `uv run bubench ...`) before running `bubench` commands
 
 ## Configuration
 
-Configure Skyvern in the root `config.yaml` under `agents.skyvern`:
+Configure shared model/browser profiles and Skyvern runtime fields in the root `config.yaml`:
 
 ```yaml
+models:
+  gemini:
+    enable_openai_compatible: true
+    model_id: gemini-3-flash-preview
+    max_tokens: 16000
+    temperature: 0.0
+    supports_vision: true
+    api_key: $OPENAI_COMPATIBLE_API_KEY
+    base_url: $OPENAI_BASE_URL
+
+browsers:
+  local:
+    browser_id: local
+    headless: false
+
 agents:
   skyvern:
-    active_model: gemini        # active model profile
-    models:
-      gemini:
-        enable_openai_compatible: true
-        model_id: gemini-3-flash-preview
-        max_tokens: 16000
-        temperature: 0.0
-        supports_vision: true
-        api_key: $OPENAI_COMPATIBLE_API_KEY
-    browser:
-      browser_id: local
-      headless: false
-    defaults:
-      engine: skyvern_v2
-      max_steps: 25
-      timeout: 600
-      max_screenshot_scrolls: 5
-      include_action_history_in_verification: true
-      max_consecutive_repeats: 3
-      max_action_occurrences: 5
+    enable_openai_compatible: true
+    engine: skyvern_v2
+    max_steps: 25
+    timeout: 600
+    max_screenshot_scrolls: 5
+    include_action_history_in_verification: true
+    max_consecutive_repeats: 3
+    max_action_occurrences: 5
 ```
 
 Store sensitive keys (e.g. `OPENAI_COMPATIBLE_API_KEY`, `SKYVERN_API_KEY`) in the repo root `.env`.
@@ -69,11 +72,10 @@ Store sensitive keys (e.g. `OPENAI_COMPATIBLE_API_KEY`, `SKYVERN_API_KEY`) in th
 | `lexmount` | Lexmount cloud browser (set `LEXMOUNT_BROWSER_MODE`) |
 | `skyvern-cloud` | Skyvern cloud browser |
 
-### Common Parameters
+### Model Parameters
 
 | Parameter | Description | Example |
 |-----------|-------------|---------|
-| `enable_openai_compatible` | Enable OpenAI-compatible mode | `true` |
 | `model_id` | LLM model name | `gemini-3-flash-preview` |
 | `api_key` | LLM API key (use `$ENV_VAR` form) | `$OPENAI_COMPATIBLE_API_KEY` |
 | `base_url` | LLM API base URL | `$OPENAI_BASE_URL` |
@@ -81,6 +83,12 @@ Store sensitive keys (e.g. `OPENAI_COMPATIBLE_API_KEY`, `SKYVERN_API_KEY`) in th
 | `temperature` | Temperature | `0.0` |
 | `supports_vision` | Model supports vision | `true` |
 | `request_timeout` | LiteLLM per-request timeout (seconds) | `600` |
+
+### Agent Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `enable_openai_compatible` | Enable OpenAI-compatible mode | `true` |
 | `execution_engine` | Skyvern execution engine | `skyvern_v2` (default) |
 | `headless` | Headless mode for local browser | `true` / `false` |
 | `timeout` | Task timeout (seconds) | `600` |

--- a/docs/en/browser/cloud-browsers.mdx
+++ b/docs/en/browser/cloud-browsers.mdx
@@ -1,0 +1,178 @@
+---
+title: "Third-party Cloud Browsers"
+description: "Use Browserbase, Browserless, or Steel.dev as CDP-compatible cloud browser backends"
+---
+
+browseruse-bench can run CDP-compatible agents against third-party cloud browser providers.
+These backends are useful when local Chrome is unavailable, when you need a clean cloud egress
+environment, or when you want provider features such as session viewers, proxies, CAPTCHA support,
+or managed browser capacity.
+
+<Info>
+Lexmount has a dedicated guide because it also integrates with `bubench login` persistent contexts.
+See [Lexmount Cloud Browser](./lexmount).
+</Info>
+
+## Supported Backends
+
+| `browser_id` | Provider | Session model | Required secret |
+| --- | --- | --- | --- |
+| `browserbase` | Browserbase | Creates and releases a Browserbase session through the Sessions API | `BROWSERBASE_API_KEY` |
+| `browserless` | Browserless BaaS v2 | Builds a WebSocket/CDP URL; Browserless creates the session when the agent connects | `BROWSERLESS_TOKEN` |
+| `steel` | Steel.dev | Creates and releases a Steel session through the Sessions API | `STEEL_API_KEY` |
+
+All three return `transport: cdp`, so they are meant for agents that can connect to a remote Chrome
+DevTools Protocol endpoint.
+
+## Get API Keys
+
+<Steps>
+  <Step title="Browserbase">
+    Sign up at [browserbase.com/sign-up](https://www.browserbase.com/sign-up). In the Browserbase
+    dashboard, open **Settings** and copy your API key. If your account uses projects, also copy the
+    project ID and set it as `BROWSERBASE_PROJECT_ID`.
+  </Step>
+  <Step title="Browserless">
+    Sign up at [browserless.io](https://www.browserless.io/). Copy your API token from the
+    Browserless account dashboard. The token is passed as the `?token=` query parameter on the
+    BaaS v2 connection URL.
+  </Step>
+  <Step title="Steel.dev">
+    Sign up at [steel.dev](https://steel.dev/). In the Steel dashboard, go to
+    **Settings > API Keys**, create an API key, and store it securely. Steel shows the key once.
+  </Step>
+</Steps>
+
+Add the secrets to `.env`:
+
+```bash
+BROWSERBASE_API_KEY=bb_live_...
+BROWSERBASE_PROJECT_ID=your_browserbase_project_id
+
+BROWSERLESS_TOKEN=your_browserless_token
+BROWSERLESS_WS_URL=wss://production-sfo.browserless.io
+
+STEEL_API_KEY=your_steel_api_key
+```
+
+## Browserbase
+
+Use `browserbase` when you want Browserbase-managed sessions with explicit create/release
+lifecycle.
+
+```yaml
+browsers:
+  browserbase:
+    browser_id: browserbase
+    browserbase_api_key: $BROWSERBASE_API_KEY
+    browserbase_project_id: $BROWSERBASE_PROJECT_ID
+    browserbase_region: us-west-2
+    browserbase_timeout: 600
+    browserbase_keep_alive: false
+```
+
+Optional keys:
+
+| Key | Notes |
+| --- | --- |
+| `browserbase_base_url` | Override the API base URL; defaults to `https://api.browserbase.com` |
+| `browserbase_project_id` | Browserbase project ID, if your account requires one |
+| `browserbase_region` | Region passed into `browserSettings.region` |
+| `browserbase_timeout` | Session timeout in seconds |
+| `browserbase_keep_alive` | Whether Browserbase should keep the session alive after disconnect |
+| `browserbase_context_id` | Existing Browserbase context ID |
+| `browserbase_extension_id` | Existing Browserbase extension ID |
+
+On close, browseruse-bench requests `REQUEST_RELEASE` for the Browserbase session.
+
+## Browserless
+
+Use `browserless` when you want a simple BaaS v2 WebSocket endpoint. No explicit session create API
+is called by browseruse-bench; Browserless starts a browser when the agent connects.
+
+```yaml
+browsers:
+  browserless:
+    browser_id: browserless
+    browserless_token: $BROWSERLESS_TOKEN
+    browserless_ws_url: wss://production-sfo.browserless.io
+    browserless_browser_path: ''
+    browserless_timeout: 600
+```
+
+Optional keys:
+
+| Key | Notes |
+| --- | --- |
+| `browserless_ws_url` | Browserless WebSocket host; defaults to `wss://production-sfo.browserless.io` |
+| `browserless_browser_path` | Browser endpoint path; empty matches the standard Browser Use example, advanced routes include `/chromium` and `/chromium/stealth` |
+| `browserless_timeout` | Browserless launch/session timeout in seconds; legacy millisecond values are converted |
+| `browserless_solveCaptchas` | Enable Browserless CAPTCHA solving |
+| `browserless_integrations` | Browserless integration bridge, for example `browseruse` |
+| `browserless_proxy` | Proxy type, for example `residential` |
+| `browserless_proxyCountry` | Proxy country/region, for example `US` |
+| `browserless_resolve_debugger_url` | Whether to call `/json/version` first and use `webSocketDebuggerUrl`; defaults to `false` |
+
+Browserless sessions are normally cleaned up by disconnecting the CDP client.
+
+## Steel.dev
+
+Use `steel` when you want Steel-managed sessions with optional proxies, CAPTCHA solving, or
+profile-related options.
+
+```yaml
+browsers:
+  steel:
+    browser_id: steel
+    steel_api_key: $STEEL_API_KEY
+    steel_region: iad
+    steel_timeout: 600000
+    steel_use_proxy: false
+    steel_solve_captcha: false
+    steel_block_ads: false
+```
+
+Optional keys:
+
+| Key | Notes |
+| --- | --- |
+| `steel_base_url` | Override the API base URL; defaults to `https://api.steel.dev` |
+| `steel_connect_url` | Override the CDP connect host; defaults to `wss://connect.steel.dev` |
+| `steel_region` | Steel region, for example `lax`, `ord`, or `iad` |
+| `steel_timeout` | Session timeout in milliseconds |
+| `steel_use_proxy` | Enable Steel-provided proxy support |
+| `steel_proxy_url` | Custom proxy URL |
+| `steel_solve_captcha` | Enable Steel CAPTCHA solving when available on your plan |
+| `steel_block_ads` | Ask Steel to block ads |
+| `steel_profile_id` | Existing Steel profile ID |
+| `steel_user_agent` | Custom user agent |
+
+On close, browseruse-bench calls Steel's session release endpoint.
+
+## Run a Smoke Test
+
+After editing `config.yaml`, run one real task:
+
+```bash
+uv run bubench run \
+  --agent browser-use \
+  --data LexBench-Browser \
+  --mode first_n --count 1
+```
+
+For agent-touching changes or before committing backend work, run the project-required real smoke:
+
+```bash
+uv run bubench run --agent <agent> --data LexBench-Browser --mode single
+```
+
+## Notes
+
+<Warning>
+Keep cloud browser API keys in `.env` or your secret manager. Do not commit `config.yaml` with
+expanded keys, browser cookies, CDP URLs, or provider session tokens.
+</Warning>
+
+- Provider pricing, regions, and quota limits change over time; check the provider dashboard before large runs.
+- `browserbase` and `steel` write session state so the orphan cleanup path can release leaked sessions after a crash.
+- `browserless` does not write session state because browseruse-bench does not create a named session up front.

--- a/docs/en/quickstart.mdx
+++ b/docs/en/quickstart.mdx
@@ -90,48 +90,59 @@ icon: "rocket"
     The root `config.yaml` is the canonical runtime config. `$VAR` placeholders are
     resolved from `.env` at runtime. Three parts to set up:
 
-    **1. Agent (model)** — pick the active model for each agent under `agents.<agent>`:
+    **1. Models** — define shared model profiles under top-level `models` and pick the default in `default.model`:
 
     ```yaml
+    default:
+      model: gpt-5.4
+
+    models:
+      gpt-5.4:
+        model_type: OPENAI        # OPENAI | GEMINI | ANTHROPIC | AZURE | BROWSER_USE
+        model_id: gpt-5.4
+        api_key: $OPENAI_API_KEY
+        base_url: $OPENAI_BASE_URL
+      browser-use:
+        model_type: BROWSER_USE
+        model_id: bu-2-0
+        api_key: $BROWSER_USE_API_KEY
+        # Only supported by the browser-use agent.
+
     agents:
       browser-use:
-        active_model: gpt-5.4         # pick any key from models below
-        models:
-          gpt-5.4:
-            model_type: OPENAI        # OPENAI | GEMINI | ANTHROPIC | AZURE | BROWSER_USE
-            model_id: gpt-5.4
-            api_key: $OPENAI_API_KEY
-            base_url: $OPENAI_BASE_URL
-          browser-use:
-            model_type: BROWSER_USE
-            model_id: bu-2-0
-            api_key: $BROWSER_USE_API_KEY
+        max_steps: 40
+        timeout: 600
     ```
 
     <Tip>
       Override the active model per run with `--model <name>` — no need to edit the file.
     </Tip>
 
-    **2. Browser backend** — set `browser_id` under `agents.<agent>.browser`. Only one
-    backend is active at a time; fill in its required keys and leave others commented:
+    **2. Browser backend** — define shared browser profiles under top-level `browsers`
+    and pick the default in `default.browser`:
 
     ```yaml
+    default:
+      browser: lexmount
+
+    browsers:
+      lexmount:
+        browser_id: lexmount          # lexmount | Chrome-Local | agentbay | browserbase | browserless | steel | cdp
+        lexmount_browser_mode: normal
+        lexmount_api_key: $LEXMOUNT_API_KEY
+        lexmount_project_id: $LEXMOUNT_PROJECT_ID
+      Chrome-Local:
+        browser_id: Chrome-Local
+      agentbay:
+        browser_id: agentbay
+        agentbay_api_key: $AGENTBAY_API_KEY
+
     agents:
       browser-use:
-        browser:
-          browser_id: lexmount          # lexmount | Chrome-Local | agentbay | browser-use-cloud | cdp
-          # --- lexmount ---
-          lexmount_browser_mode: normal
-          lexmount_api_key: $LEXMOUNT_API_KEY
-          lexmount_project_id: $LEXMOUNT_PROJECT_ID
-          # --- Chrome-Local ---
-          # browser_id: Chrome-Local
-          # local_proxy_server: ""     # http://127.0.0.1:7890 etc. — local Chromium does NOT inherit OS / clash / v2ray proxy
-          # --- agentbay ---
-          # browser_id: agentbay       # set AGENTBAY_API_KEY in .env
+        max_steps: 40
     ```
 
-    See [Local Chromium Browser](/en/browser/local) and [Lexmount Cloud Browser](/en/browser/lexmount), plus each agent's page, for backend-specific options. **Important**: the local Chromium does NOT pick up your OS / clash / v2ray proxy — set `local_proxy_server` if you need to reach sites the bare-connect can't (e.g. `bloomberg.com`, `archive.org`).
+    Override the browser per run with `--browser-id <name>`. See [Local Chromium Browser](/en/browser/local), [Lexmount Cloud Browser](/en/browser/lexmount), and [Third-party Cloud Browsers](/en/browser/cloud-browsers) for backend-specific options. **Important**: local Chromium does NOT pick up your OS / clash / v2ray proxy — set `local_proxy_server` if you need to reach sites the bare-connect can't (e.g. `bloomberg.com`, `archive.org`).
 
     **3. Eval model** — used by `bubench eval` for LLM-as-judge scoring:
 

--- a/docs/zh/agents/custom-agent.mdx
+++ b/docs/zh/agents/custom-agent.mdx
@@ -139,19 +139,18 @@ from browseruse_bench.agents import my_agent  # noqa: F401
 
 ### 3. 注册配置
 
-在根目录 `config.yaml` 的 `agents` 下添加：
+在根目录 `config.yaml` 中添加共享模型和 agent 运行参数：
 
 ```yaml
+models:
+  my-agent-default:
+    model_id: your-model-id
+    api_key: $YOUR_API_KEY
+
 agents:
   my-agent:
-    active_model: default
-    models:
-      default:
-        model_id: your-model-id
-        api_key: $YOUR_API_KEY
-    defaults:
-      timeout: 300
-      max_steps: 40
+    timeout: 300
+    max_steps: 40
 ```
 
 同时在 `configs/agent_registry.yaml` 中添加元数据：
@@ -343,7 +342,7 @@ bubench run --agent my-agent --data LexBench-Browser --mode first_n --count 1
 
 **`task_info`** 从 benchmark 数据集加载。标准字段：`task_id`、`task_text`、`url`、`prompt`（可选）。
 
-**`agent_config`** 来自根目录 `config.yaml` 中 `agents.<agent>.models[active_model]` 的配置。框架在运行时会注入 `timeout_seconds`。
+**`agent_config`** 来自根目录 `config.yaml`，按 `agents.<agent> + models.<model> + browsers.<browser>` 合并得到。框架在运行时会注入 `timeout_seconds`。
 
 **`task_workspace`** 是每个任务的输出目录（`<output_dir>/tasks/<task_id>/`）。框架会在此写入 `result.json`，你可以在同目录保存截图、日志或其他产物。
 

--- a/docs/zh/agents/skyvern.mdx
+++ b/docs/zh/agents/skyvern.mdx
@@ -21,31 +21,34 @@ skyvern 与 browser-use 的 extra 依赖冲突，建议使用独立 venv（`conf
 
 ## 配置
 
-在根目录 `config.yaml` 的 `agents.skyvern` 下配置：
+在根目录 `config.yaml` 中配置共享模型/浏览器 profile，以及 Skyvern 运行参数：
 
 ```yaml
+models:
+  gemini:
+    enable_openai_compatible: true
+    model_id: gemini-3-flash-preview
+    max_tokens: 16000
+    temperature: 0.0
+    supports_vision: true
+    api_key: $OPENAI_COMPATIBLE_API_KEY
+    base_url: $OPENAI_BASE_URL
+
+browsers:
+  local:
+    browser_id: local
+    headless: false
+
 agents:
   skyvern:
-    active_model: gemini        # 当前使用的模型配置名
-    models:
-      gemini:
-        enable_openai_compatible: true
-        model_id: gemini-3-flash-preview
-        max_tokens: 16000
-        temperature: 0.0
-        supports_vision: true
-        api_key: $OPENAI_COMPATIBLE_API_KEY
-    browser:
-      browser_id: local
-      headless: false
-    defaults:
-      engine: skyvern_v2
-      max_steps: 25
-      timeout: 600
-      max_screenshot_scrolls: 5
-      include_action_history_in_verification: true
-      max_consecutive_repeats: 3
-      max_action_occurrences: 5
+    enable_openai_compatible: true
+    engine: skyvern_v2
+    max_steps: 25
+    timeout: 600
+    max_screenshot_scrolls: 5
+    include_action_history_in_verification: true
+    max_consecutive_repeats: 3
+    max_action_occurrences: 5
 ```
 
 敏感密钥（如 `OPENAI_COMPATIBLE_API_KEY`、`SKYVERN_API_KEY`）请放在根目录 `.env` 中。
@@ -69,11 +72,10 @@ agents:
 | `lexmount` | Lexmount 云浏览器（可配 `LEXMOUNT_BROWSER_MODE`） |
 | `skyvern-cloud` | Skyvern 云浏览器 |
 
-### 常用参数
+### 模型参数
 
 | 参数 | 说明 | 示例值 |
 |------|------|--------|
-| `enable_openai_compatible` | 启用 OpenAI-Compatible 运行模式 | `true` |
 | `model_id` | LLM 模型名 | `gemini-3-flash-preview` |
 | `api_key` | LLM API 密钥（推荐 `$ENV_VAR` 形式） | `$OPENAI_COMPATIBLE_API_KEY` |
 | `base_url` | LLM API 地址 | `$OPENAI_BASE_URL` |
@@ -81,6 +83,12 @@ agents:
 | `temperature` | 温度 | `0.0` |
 | `supports_vision` | 模型是否支持视觉 | `true` |
 | `request_timeout` | LiteLLM 单次请求超时（秒） | `600` |
+
+### Agent 参数
+
+| 参数 | 说明 | 示例值 |
+|------|------|--------|
+| `enable_openai_compatible` | 启用 OpenAI-Compatible 运行模式 | `true` |
 | `headless` | 本地浏览器无头模式 | `true` / `false` |
 | `timeout` | 任务超时（秒） | `600` |
 | `max_steps` | 最大任务步数 | `25` |

--- a/docs/zh/browser/cloud-browsers.mdx
+++ b/docs/zh/browser/cloud-browsers.mdx
@@ -1,0 +1,173 @@
+---
+title: "第三方云浏览器"
+description: "使用 Browserbase、Browserless 或 Steel.dev 作为 CDP 兼容云浏览器后端"
+---
+
+browseruse-bench 可以把支持 CDP 的 agent 连接到第三方云浏览器。适用场景包括：本机没有
+Chrome、需要干净的云端出口、需要 provider 的会话回放/代理/CAPTCHA/托管浏览器容量等能力。
+
+<Info>
+Lexmount 有单独手册，因为它还集成了 `bubench login` 持久登录上下文。
+见 [Lexmount 云浏览器](./lexmount)。
+</Info>
+
+## 支持的后端
+
+| `browser_id` | Provider | 会话模式 | 必填密钥 |
+| --- | --- | --- | --- |
+| `browserbase` | Browserbase | 通过 Sessions API 创建和释放 Browserbase session | `BROWSERBASE_API_KEY` |
+| `browserless` | Browserless BaaS v2 | 拼接 WebSocket/CDP URL；agent 连接时由 Browserless 创建 session | `BROWSERLESS_TOKEN` |
+| `steel` | Steel.dev | 通过 Sessions API 创建和释放 Steel session | `STEEL_API_KEY` |
+
+三者都会返回 `transport: cdp`，适合能连接远程 Chrome DevTools Protocol endpoint 的 agent。
+
+## 注册和获取 API Key
+
+<Steps>
+  <Step title="Browserbase">
+    在 [browserbase.com/sign-up](https://www.browserbase.com/sign-up) 注册。进入 Browserbase
+    dashboard 后打开 **Settings**，复制 API key。如果你的账号使用 project，也复制 project ID，
+    并配置为 `BROWSERBASE_PROJECT_ID`。
+  </Step>
+  <Step title="Browserless">
+    在 [browserless.io](https://www.browserless.io/) 注册。进入 Browserless account dashboard
+    复制 API token。该 token 会作为 BaaS v2 连接 URL 的 `?token=` 查询参数传入。
+  </Step>
+  <Step title="Steel.dev">
+    在 [steel.dev](https://steel.dev/) 注册。进入 Steel dashboard 的 **Settings > API Keys**，
+    创建 API key 并妥善保存；Steel 只会展示一次完整密钥。
+  </Step>
+</Steps>
+
+把密钥写入 `.env`：
+
+```bash
+BROWSERBASE_API_KEY=bb_live_...
+BROWSERBASE_PROJECT_ID=your_browserbase_project_id
+
+BROWSERLESS_TOKEN=your_browserless_token
+BROWSERLESS_WS_URL=wss://production-sfo.browserless.io
+
+STEEL_API_KEY=your_steel_api_key
+```
+
+## Browserbase
+
+当你希望使用 Browserbase 托管会话，并由框架显式创建/释放 session 时，选择 `browserbase`。
+
+```yaml
+browsers:
+  browserbase:
+    browser_id: browserbase
+    browserbase_api_key: $BROWSERBASE_API_KEY
+    browserbase_project_id: $BROWSERBASE_PROJECT_ID
+    browserbase_region: us-west-2
+    browserbase_timeout: 600
+    browserbase_keep_alive: false
+```
+
+可选配置：
+
+| Key | 说明 |
+| --- | --- |
+| `browserbase_base_url` | 覆盖 API base URL；默认 `https://api.browserbase.com` |
+| `browserbase_project_id` | Browserbase project ID；账号要求时填写 |
+| `browserbase_region` | 传入 `browserSettings.region` 的区域 |
+| `browserbase_timeout` | session 超时时间，单位秒 |
+| `browserbase_keep_alive` | 断开后是否让 Browserbase 保持 session |
+| `browserbase_context_id` | 已存在的 Browserbase context ID |
+| `browserbase_extension_id` | 已存在的 Browserbase extension ID |
+
+关闭时，browseruse-bench 会对 Browserbase session 请求 `REQUEST_RELEASE`。
+
+## Browserless
+
+当你只需要一个简单的 BaaS v2 WebSocket endpoint 时，选择 `browserless`。browseruse-bench
+不会提前调用创建 session 的 API；agent 连接时 Browserless 会启动浏览器。
+
+```yaml
+browsers:
+  browserless:
+    browser_id: browserless
+    browserless_token: $BROWSERLESS_TOKEN
+    browserless_ws_url: wss://production-sfo.browserless.io
+    browserless_browser_path: ''
+    browserless_timeout: 600
+```
+
+可选配置：
+
+| Key | 说明 |
+| --- | --- |
+| `browserless_ws_url` | Browserless WebSocket host；默认 `wss://production-sfo.browserless.io` |
+| `browserless_browser_path` | 浏览器 endpoint 路径；标准 Browser Use 示例为空，高级场景可用 `/chromium`、`/chromium/stealth` |
+| `browserless_timeout` | Browserless 启动/session 超时时间，单位秒；旧的毫秒值会自动折算 |
+| `browserless_solveCaptchas` | 是否开启 Browserless CAPTCHA solving |
+| `browserless_integrations` | Browserless integration bridge，例如 `browseruse` |
+| `browserless_proxy` | 代理类型，例如 `residential` |
+| `browserless_proxyCountry` | 代理国家/地区，例如 `US` |
+| `browserless_resolve_debugger_url` | 是否先请求 `/json/version` 并使用返回的 `webSocketDebuggerUrl`；默认 `false` |
+
+Browserless session 通常会在 CDP client 断开后由 Browserless 清理。
+
+## Steel.dev
+
+当你希望使用 Steel 托管会话，并按需打开代理、CAPTCHA solving 或 profile 相关能力时，选择
+`steel`。
+
+```yaml
+browsers:
+  steel:
+    browser_id: steel
+    steel_api_key: $STEEL_API_KEY
+    steel_region: iad
+    steel_timeout: 600000
+    steel_use_proxy: false
+    steel_solve_captcha: false
+    steel_block_ads: false
+```
+
+可选配置：
+
+| Key | 说明 |
+| --- | --- |
+| `steel_base_url` | 覆盖 API base URL；默认 `https://api.steel.dev` |
+| `steel_connect_url` | 覆盖 CDP connect host；默认 `wss://connect.steel.dev` |
+| `steel_region` | Steel 区域，例如 `lax`、`ord` 或 `iad` |
+| `steel_timeout` | session 超时时间，单位毫秒 |
+| `steel_use_proxy` | 启用 Steel 提供的代理能力 |
+| `steel_proxy_url` | 自定义代理 URL |
+| `steel_solve_captcha` | 在套餐支持时启用 Steel CAPTCHA solving |
+| `steel_block_ads` | 请求 Steel 屏蔽广告 |
+| `steel_profile_id` | 已存在的 Steel profile ID |
+| `steel_user_agent` | 自定义 user agent |
+
+关闭时，browseruse-bench 会调用 Steel 的 session release endpoint。
+
+## 运行 Smoke Test
+
+编辑 `config.yaml` 后，先跑一个真实任务：
+
+```bash
+uv run bubench run \
+  --agent browser-use \
+  --data LexBench-Browser \
+  --mode first_n --count 1
+```
+
+如果改动触及 agent 运行路径，或准备提交后端相关代码，按项目要求跑真实 smoke：
+
+```bash
+uv run bubench run --agent <agent> --data LexBench-Browser --mode single
+```
+
+## 注意事项
+
+<Warning>
+云浏览器 API key 应放在 `.env` 或密钥管理系统里。不要提交展开后的 `config.yaml`、浏览器
+cookie、CDP URL 或 provider session token。
+</Warning>
+
+- Provider 的价格、区域、额度会变化；大规模运行前请先查看对应 dashboard。
+- `browserbase` 和 `steel` 会写入 session state，崩溃后的 orphan cleanup 可以释放泄漏 session。
+- `browserless` 不会写 session state，因为 browseruse-bench 不会提前创建具名 session。

--- a/docs/zh/quickstart.mdx
+++ b/docs/zh/quickstart.mdx
@@ -90,47 +90,58 @@ icon: "rocket"
     根目录 `config.yaml` 是项目的运行时主配置，`$VAR` 占位符会在运行时从 `.env` 解析。
     需要配置三部分：
 
-    **1. Agent 模型** — 在 `agents.<agent>` 下指定默认使用的模型：
+    **1. 模型** — 在顶层 `models` 定义共享模型配置，并通过 `default.model` 选择默认模型：
 
     ```yaml
+    default:
+      model: gpt-5.4
+
+    models:
+      gpt-5.4:
+        model_type: OPENAI        # OPENAI | GEMINI | ANTHROPIC | AZURE | BROWSER_USE
+        model_id: gpt-5.4
+        api_key: $OPENAI_API_KEY
+        base_url: $OPENAI_BASE_URL
+      browser-use:
+        model_type: BROWSER_USE
+        model_id: bu-2-0
+        api_key: $BROWSER_USE_API_KEY
+        # 仅 browser-use agent 支持。
+
     agents:
       browser-use:
-        active_model: gpt-5.4         # 指向下方 models 里的任一 key
-        models:
-          gpt-5.4:
-            model_type: OPENAI        # OPENAI | GEMINI | ANTHROPIC | AZURE | BROWSER_USE
-            model_id: gpt-5.4
-            api_key: $OPENAI_API_KEY
-            base_url: $OPENAI_BASE_URL
-          browser-use:
-            model_type: BROWSER_USE
-            model_id: bu-2-0
-            api_key: $BROWSER_USE_API_KEY
+        max_steps: 40
+        timeout: 600
     ```
 
     <Tip>
       运行时可通过 `--model <name>` 覆盖 `active_model`，无需改文件。
     </Tip>
 
-    **2. 浏览器后端** — 在 `agents.<agent>.browser` 下选择一个 `browser_id`，
-    只保留对应后端所需的参数，其它注释掉：
+    **2. 浏览器后端** — 在顶层 `browsers` 定义共享浏览器配置，并通过 `default.browser` 选择默认浏览器：
 
     ```yaml
+    default:
+      browser: lexmount
+
+    browsers:
+      lexmount:
+        browser_id: lexmount          # lexmount | Chrome-Local | agentbay | browserbase | browserless | steel | cdp
+        lexmount_browser_mode: normal
+        lexmount_api_key: $LEXMOUNT_API_KEY
+        lexmount_project_id: $LEXMOUNT_PROJECT_ID
+      Chrome-Local:
+        browser_id: Chrome-Local
+      agentbay:
+        browser_id: agentbay
+        agentbay_api_key: $AGENTBAY_API_KEY
+
     agents:
       browser-use:
-        browser:
-          browser_id: lexmount          # lexmount | Chrome-Local | agentbay | browser-use-cloud | cdp
-          # --- lexmount ---
-          lexmount_browser_mode: normal
-          lexmount_api_key: $LEXMOUNT_API_KEY
-          lexmount_project_id: $LEXMOUNT_PROJECT_ID
-          # --- Chrome-Local ---
-          # browser_id: Chrome-Local   # 无需额外参数
-          # --- agentbay ---
-          # browser_id: agentbay       # 需在 .env 中设置 AGENTBAY_API_KEY
+        max_steps: 40
     ```
 
-    详细后端选项参见 [本地 Chromium 浏览器](/zh/browser/local)、[Lexmount 云浏览器](/zh/browser/lexmount) 及各 Agent 的文档页。**重要**：本地 Chromium 不会继承系统 / clash / v2ray 代理——若需访问裸连不可达的站点（如 `bloomberg.com`、`archive.org`），请配 `local_proxy_server`。
+    运行时可用 `--browser-id <name>` 覆盖浏览器。详细后端选项参见 [本地 Chromium 浏览器](/zh/browser/local)、[Lexmount 云浏览器](/zh/browser/lexmount)、[第三方云浏览器](/zh/browser/cloud-browsers)。**重要**：本地 Chromium 不会继承系统 / clash / v2ray 代理——若需访问裸连不可达的站点（如 `bloomberg.com`、`archive.org`），请配 `local_proxy_server`。
 
     **3. Eval 评估模型** — 供 `bubench eval` 作为 LLM-as-judge 评判使用：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,10 @@ browser-use = [
 ]
 
 skyvern = [
-    "skyvern>=1.0.0",
-    # TODO: Re-enable playwright when skyvern execution becomes a regular path
-    # and we verify the explicit dependency is required in this repo.
-    # "playwright>=1.57.0; python_full_version >= '3.12'",
-    "psycopg[binary,pool]>=3.2.13; python_full_version >= '3.14'",
+    # Local Skyvern execution imports forge/server components even when using
+    # an OpenAI-compatible llm_config.
+    "skyvern[local]>=1.0.37",
+    "psycopg[binary,pool]>=3.2.13; python_full_version >= '3.13'",
 ]
 
 openai-cua = [

--- a/tests/browseruse_bench/test_cloud_browsers.py
+++ b/tests/browseruse_bench/test_cloud_browsers.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from browseruse_bench.browsers.providers import browserbase as browserbase_module
+from browseruse_bench.browsers.providers import browserless as browserless_module
+from browseruse_bench.browsers.providers import steel as steel_module
+from browseruse_bench.browsers.providers.browserbase import BrowserbaseBackend
+from browseruse_bench.browsers.providers.browserless import BrowserlessBackend
+from browseruse_bench.browsers.providers.steel import SteelBackend
+from browseruse_bench.browsers.registry import get_backend
+
+
+def test_browserbase_backend_open_and_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_post_json(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        if kwargs["url"].endswith("/v1/sessions"):
+            return {"id": "bb-session-1", "connectUrl": "wss://browserbase.example/cdp"}
+        return {"id": "bb-session-1", "status": "COMPLETED"}
+
+    monkeypatch.setattr(browserbase_module.cloud_utils, "post_json", fake_post_json)
+    monkeypatch.delenv("BROWSERBASE_API_KEY", raising=False)
+    backend = BrowserbaseBackend("browserbase")
+
+    session_context = backend.open(
+        agent_name="browser-use",
+        agent_config={
+            "browserbase_api_key": "bb-key",
+            "browserbase_project_id": "project-1",
+            "browserbase_region": "us-east-1",
+            "browserbase_timeout": "120",
+            "browserbase_keep_alive": "true",
+        },
+    )
+
+    assert session_context.transport == "cdp"
+    assert session_context.cdp_url == "wss://browserbase.example/cdp"
+    assert calls[0]["headers"] == {"X-BB-API-Key": "bb-key"}
+    assert calls[0]["body"] == {
+        "projectId": "project-1",
+        "browserSettings": {
+            "timeout": 120,
+            "keepAlive": True,
+            "region": "us-east-1",
+        },
+    }
+
+    backend.close(session_context)
+    assert calls[1]["url"] == "https://api.browserbase.com/v1/sessions/bb-session-1"
+    assert calls[1]["body"] == {"status": "REQUEST_RELEASE", "projectId": "project-1"}
+
+
+def test_browserbase_backend_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BROWSERBASE_API_KEY", raising=False)
+    backend = BrowserbaseBackend("browserbase")
+
+    with pytest.raises(ValueError, match="Browserbase requires an API key"):
+        backend.open(agent_name="browser-use", agent_config={})
+
+
+def test_browserbase_backend_empty_connect_url_releases_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_post_json(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        if kwargs["url"].endswith("/v1/sessions"):
+            return {"id": "bb-session-1", "connectUrl": ""}
+        return {"id": "bb-session-1", "status": "COMPLETED"}
+
+    monkeypatch.setattr(browserbase_module.cloud_utils, "post_json", fake_post_json)
+    backend = BrowserbaseBackend("browserbase")
+
+    with pytest.raises(RuntimeError, match="connectUrl is empty"):
+        backend.open(agent_name="browser-use", agent_config={"browserbase_api_key": "bb-key"})
+    assert calls[1]["url"] == "https://api.browserbase.com/v1/sessions/bb-session-1"
+
+
+def test_browserless_backend_resolves_debugger_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BROWSERLESS_TOKEN", "browserless-token")
+    calls: list[dict[str, Any]] = []
+
+    def fake_get_json(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"webSocketDebuggerUrl": "wss://production-ams.browserless.io/e/session"}
+
+    monkeypatch.setattr(browserless_module.cloud_utils, "get_json", fake_get_json)
+    backend = BrowserlessBackend("browserless")
+
+    session_context = backend.open(
+        agent_name="browser-use",
+        agent_config={
+            "browserless_ws_url": "production-ams.browserless.io",
+            "browserless_browser_path": "chromium",
+            "browserless_timeout": "600000",
+            "browserless_resolve_debugger_url": True,
+        },
+    )
+
+    assert session_context.transport == "cdp"
+    assert session_context.cdp_url == "wss://production-ams.browserless.io/e/session"
+    assert calls[0]["url"] == (
+        "https://production-ams.browserless.io/json/version"
+        "?token=browserless-token&timeout=600"
+    )
+
+
+def test_browserless_backend_builds_cdp_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BROWSERLESS_TOKEN", "browserless-token")
+    backend = BrowserlessBackend("browserless")
+
+    session_context = backend.open(
+        agent_name="browser-use",
+        agent_config={
+            "browserless_ws_url": "production-ams.browserless.io",
+            "browserless_timeout": "600000",
+        },
+    )
+
+    assert session_context.transport == "cdp"
+    assert session_context.cdp_url == (
+        "wss://production-ams.browserless.io"
+        "?token=browserless-token&timeout=600"
+    )
+
+
+def test_browserless_backend_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BROWSERLESS_TOKEN", raising=False)
+    monkeypatch.delenv("BROWSERLESS_API_KEY", raising=False)
+    backend = BrowserlessBackend("browserless")
+
+    with pytest.raises(ValueError, match="Browserless requires an API token"):
+        backend.open(agent_name="browser-use", agent_config={})
+
+
+def test_steel_backend_open_and_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_post_json(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        if kwargs["url"].endswith("/v1/sessions"):
+            return {"id": "steel-session-1"}
+        return {"id": "steel-session-1", "released": True}
+
+    monkeypatch.setattr(steel_module.cloud_utils, "post_json", fake_post_json)
+    monkeypatch.delenv("STEEL_API_KEY", raising=False)
+    backend = SteelBackend("steel")
+
+    session_context = backend.open(
+        agent_name="browser-use",
+        agent_config={
+            "steel_api_key": "steel-key",
+            "steel_region": "iad",
+            "steel_timeout": "600000",
+            "steel_use_proxy": "true",
+            "steel_solve_captcha": False,
+        },
+    )
+
+    assert session_context.transport == "cdp"
+    assert session_context.cdp_url == (
+        "wss://connect.steel.dev?apiKey=steel-key&sessionId=steel-session-1"
+    )
+    assert calls[0]["headers"] == {"steel-api-key": "steel-key"}
+    assert calls[0]["body"] == {
+        "region": "iad",
+        "timeout": 600000,
+        "useProxy": True,
+        "solveCaptcha": False,
+    }
+
+    backend.close(session_context)
+    assert calls[1]["url"] == "https://api.steel.dev/v1/sessions/steel-session-1/release"
+    assert calls[1]["body"] is None
+
+
+def test_steel_backend_uses_websocket_url_from_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post_json(**kwargs: Any) -> dict[str, Any]:
+        return {"id": "steel-session-1", "websocketUrl": "wss://steel.example/cdp"}
+
+    monkeypatch.setattr(steel_module.cloud_utils, "post_json", fake_post_json)
+    backend = SteelBackend("steel")
+
+    session_context = backend.open(
+        agent_name="browser-use",
+        agent_config={"steel_api_key": "steel-key"},
+    )
+
+    assert session_context.cdp_url == "wss://steel.example/cdp?apiKey=steel-key"
+
+
+def test_steel_backend_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("STEEL_API_KEY", raising=False)
+    backend = SteelBackend("steel")
+
+    with pytest.raises(ValueError, match="Steel requires an API key"):
+        backend.open(agent_name="browser-use", agent_config={})
+
+
+def test_cloud_backends_are_registered() -> None:
+    assert get_backend("browserbase").backend_id == "browserbase"
+    assert get_backend("browserless").backend_id == "browserless"
+    assert get_backend("steel").backend_id == "steel"

--- a/tests/browseruse_bench/test_config_loader.py
+++ b/tests/browseruse_bench/test_config_loader.py
@@ -7,7 +7,6 @@ import pytest
 import yaml
 
 import browseruse_bench.utils.config_loader as config_loader_module
-from browseruse_bench.utils.config_loader import load_eval_config
 from browseruse_bench.utils import (
     REPO_ROOT,
     get_default_split,
@@ -17,6 +16,7 @@ from browseruse_bench.utils import (
     resolve_agent_entry,
     resolve_agent_inline_config,
 )
+from browseruse_bench.utils.config_loader import load_eval_config
 
 
 class TestLoadConfigFile:
@@ -159,6 +159,114 @@ def test_resolve_agent_inline_config_uses_explicit_model_override(tmp_path: Path
     assert inline.get("browser_id") == "lexmount"
 
 
+def test_resolve_agent_inline_config_merges_flat_model_and_browser_config() -> None:
+    config = {
+        "default": {"model": "gpt", "browser": "browserbase"},
+        "models": {
+            "gpt": {
+                "model_id": "gpt-5.4",
+                "api_key": "$OPENAI_API_KEY",
+                "temperature": 1.0,
+            },
+        },
+        "browsers": {
+            "browserbase": {
+                "browser_id": "browserbase",
+                "browserbase_api_key": "$BROWSERBASE_API_KEY",
+                "timeout": 999,
+            },
+        },
+        "agents": {
+            "browser-use": {
+                "max_steps": 40,
+                "timeout": 600,
+            },
+        },
+    }
+
+    inline = resolve_agent_inline_config("browser-use", config)
+
+    assert inline == {
+        "max_steps": 40,
+        "timeout": 999,
+        "model_id": "gpt-5.4",
+        "api_key": "$OPENAI_API_KEY",
+        "temperature": 1.0,
+        "browser_id": "browserbase",
+        "browserbase_api_key": "$BROWSERBASE_API_KEY",
+    }
+
+
+def test_resolve_agent_inline_config_uses_top_level_defaults_without_agent_active_keys() -> None:
+    config = {
+        "default": {"model": "gpt", "browser": "lexmount"},
+        "models": {"gpt": {"model_id": "gpt-5.4"}},
+        "browsers": {"lexmount": {"browser_id": "lexmount"}},
+        "agents": {"browser-use": {"timeout": 600}},
+    }
+
+    inline = resolve_agent_inline_config("browser-use", config)
+
+    assert inline == {
+        "timeout": 600,
+        "model_id": "gpt-5.4",
+        "browser_id": "lexmount",
+    }
+
+
+def test_resolve_agent_inline_config_still_accepts_legacy_defaults_key() -> None:
+    config = {
+        "default": {"model": "gpt", "browser": "lexmount"},
+        "models": {"gpt": {"model_id": "gpt-5.4"}},
+        "browsers": {"lexmount": {"browser_id": "lexmount"}},
+        "agents": {"browser-use": {"timeout": 300, "defaults": {"timeout": 600}}},
+    }
+
+    inline = resolve_agent_inline_config("browser-use", config)
+
+    assert inline is not None
+    assert inline["timeout"] == 600
+
+
+def test_resolve_agent_inline_config_flat_browser_override() -> None:
+    config = {
+        "default": {"model": "gpt", "browser": "lexmount"},
+        "models": {"gpt": {"model_id": "gpt-5.4"}},
+        "browsers": {
+            "lexmount": {"browser_id": "lexmount"},
+            "steel": {"browser_id": "steel", "steel_api_key": "$STEEL_API_KEY"},
+        },
+        "agents": {"browser-use": {"timeout": 600}},
+    }
+
+    inline = resolve_agent_inline_config("browser-use", config, browser_id="steel")
+
+    assert inline is not None
+    assert inline["browser_id"] == "steel"
+    assert inline["steel_api_key"] == "$STEEL_API_KEY"
+    assert inline["model_id"] == "gpt-5.4"
+
+
+def test_resolve_agent_inline_config_legacy_browser_override() -> None:
+    config = {
+        "agents": {
+            "browser-use": {
+                "active_model": "gpt",
+                "browser": {"browser_id": "lexmount", "lexmount_api_key": "$LEXMOUNT_API_KEY"},
+                "defaults": {"timeout": 600},
+                "models": {"gpt": {"model_id": "gpt-5.4"}},
+            },
+        },
+    }
+
+    inline = resolve_agent_inline_config("browser-use", config, browser_id="browserbase")
+
+    assert inline is not None
+    assert inline["browser_id"] == "browserbase"
+    assert inline["lexmount_api_key"] == "$LEXMOUNT_API_KEY"
+    assert inline["model_id"] == "gpt-5.4"
+
+
 def test_resolve_agent_entry_uses_registry_venvs_for_builtin_agents(tmp_path: Path) -> None:
     config = load_config_file(_write_runtime_root_config(tmp_path))
 
@@ -285,3 +393,24 @@ class TestSkyvernConfigCanonicalization:
             and "openai_compatible_model_name" in str(w.message)
             for w in caught
         )
+
+    def test_apply_skyvern_env_uses_temp_postgres_db_by_default(self) -> None:
+        env = {"DATABASE_STRING": "postgresql+psycopg://old/skyvern"}
+
+        config_loader_module.apply_skyvern_env({"enable_openai_compatible": True}, env)
+
+        assert env["DATABASE_STRING"].startswith("postgresql+psycopg:///bubench_skyvern_")
+        assert env["DATABASE_STRING"].endswith("?host=/tmp")
+
+    def test_apply_skyvern_env_preserves_explicit_database_string(self) -> None:
+        env = {"DATABASE_STRING": "postgresql+psycopg://old/skyvern"}
+
+        config_loader_module.apply_skyvern_env(
+            {
+                "enable_openai_compatible": True,
+                "database_string": "postgresql+psycopg://new/skyvern",
+            },
+            env,
+        )
+
+        assert env["DATABASE_STRING"] == "postgresql+psycopg://new/skyvern"

--- a/tests/browseruse_bench/test_orphan_cleanup.py
+++ b/tests/browseruse_bench/test_orphan_cleanup.py
@@ -45,3 +45,74 @@ def test_cleanup_returns_success_when_state_file_removed(tmp_path: Path) -> None
 
     assert result == 0
     assert not state_file.exists()
+
+
+def test_cleanup_browserbase_session_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls = []
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps({"backend_id": "browserbase", "session_id": "bb-session-1"}),
+        encoding="utf-8",
+    )
+
+    def fake_post_json(**kwargs):
+        calls.append(kwargs)
+        return {"id": "bb-session-1"}
+
+    monkeypatch.setenv("BROWSERBASE_API_KEY", "bb-key")
+    monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "project-1")
+    monkeypatch.setattr(
+        "browseruse_bench.browsers.providers.cloud_utils.post_json",
+        fake_post_json,
+    )
+
+    result = orphan_cleanup_module.cleanup_orphaned_session_state(state_file)
+
+    assert result == 0
+    assert not state_file.exists()
+    assert calls == [
+        {
+            "url": "https://api.browserbase.com/v1/sessions/bb-session-1",
+            "headers": {"X-BB-API-Key": "bb-key"},
+            "body": {"status": "REQUEST_RELEASE", "projectId": "project-1"},
+            "timeout_seconds": 30,
+        }
+    ]
+
+
+def test_cleanup_steel_session_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls = []
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps({"backend_id": "steel", "session_id": "steel-session-1"}),
+        encoding="utf-8",
+    )
+
+    def fake_post_json(**kwargs):
+        calls.append(kwargs)
+        return {"id": "steel-session-1"}
+
+    monkeypatch.setenv("STEEL_API_KEY", "steel-key")
+    monkeypatch.setattr(
+        "browseruse_bench.browsers.providers.cloud_utils.post_json",
+        fake_post_json,
+    )
+
+    result = orphan_cleanup_module.cleanup_orphaned_session_state(state_file)
+
+    assert result == 0
+    assert not state_file.exists()
+    assert calls == [
+        {
+            "url": "https://api.steel.dev/v1/sessions/steel-session-1/release",
+            "headers": {"steel-api-key": "steel-key"},
+            "body": None,
+            "timeout_seconds": 30,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add Browserbase, Browserless, and Steel cloud browser providers with shared REST/CDP utilities
- flatten runtime config resolution to agent + selected model + selected browser and document cloud browser setup
- update Skyvern local DB defaults, orphan cleanup, routing, and tests for the new browser config structure

## Verification
- uv run pytest tests/browseruse_bench/test_cloud_browsers.py tests/browseruse_bench/test_config_loader.py tests/browseruse_bench/test_orphan_cleanup.py
- uv run ruff check browseruse_bench/browsers/providers/browserbase.py browseruse_bench/browsers/providers/browserless.py browseruse_bench/browsers/providers/steel.py browseruse_bench/browsers/providers/cloud_utils.py browseruse_bench/browsers/registry.py browseruse_bench/browsers/orphan_cleanup.py browseruse_bench/utils/config_loader.py browseruse_bench/cli/run.py tests/browseruse_bench/test_cloud_browsers.py tests/browseruse_bench/test_config_loader.py tests/browseruse_bench/test_orphan_cleanup.py

## Smoke notes
- Browserbase, Browserless, Lexmount, and Steel were exercised against selected LexBench-Browser tasks during development.
- Browserless can complete task 292 but still shows intermittent WebSocket reconnects.
- Steel session creation was fixed for Cloudflare 1010 by setting a User-Agent, but one later task 292 run hit Steel API read timeouts before browser launch.
- AgentBay config was added locally for runtime selection, but real smoke is blocked until AGENTBAY_API_KEY is configured.
