### PR TITLE
Address cloud browser review feedback

### DIFF
--- a/browseruse_bench/agents/skyvern.py
+++ b/browseruse_bench/agents/skyvern.py
@@ -110,7 +110,10 @@ _SKYVERN_IMPORT_ERROR: str | None = None
 
 def _make_temp_database_string() -> str:
     db_name = f"bubench_skyvern_{uuid.uuid4().hex}"
-    return f"postgresql+psycopg:///{db_name}?host=/tmp"
+    socket_host = os.getenv("BUBENCH_SKYVERN_POSTGRES_HOST")
+    if not socket_host:
+        socket_host = "/var/run/postgresql" if Path("/var/run/postgresql").exists() else "/tmp"
+    return f"postgresql+psycopg:///{db_name}?host={urllib.parse.quote(socket_host, safe='/')}"
 
 
 def _parse_temp_postgres_database(database_string: str) -> tuple[str, urllib.parse.SplitResult] | None:
@@ -386,7 +389,7 @@ def _extract_usage_from_response_blob(blob: Any) -> dict[str, int] | None:
     shaped like ``{"prompt_tokens": int, "completion_tokens": int, ...}``
     regardless of where it lives in the JSON tree.
     """
-    if not isinstance(blob, (dict, list)):
+    if not isinstance(blob, dict | list):
         return None
 
     def _safe_int(v: Any) -> int:
@@ -438,11 +441,11 @@ def _extract_usage_from_response_blob(blob: Any) -> dict[str, int] | None:
             if found:
                 return found
             for v in node.values():
-                if isinstance(v, (dict, list)):
+                if isinstance(v, dict | list):
                     stack.append(v)
         elif isinstance(node, list):
             for item in node:
-                if isinstance(item, (dict, list)):
+                if isinstance(item, dict | list):
                     stack.append(item)
     return None
 
@@ -572,7 +575,7 @@ def _normalize_answer_text(value: Any) -> tuple[str, Any | None]:
         return "", None
     if isinstance(value, str):
         return value, None
-    if isinstance(value, (dict, list)):
+    if isinstance(value, dict | list):
         return json.dumps(value, ensure_ascii=False), value
     return str(value), value
 

--- a/browseruse_bench/browsers/orphan_cleanup.py
+++ b/browseruse_bench/browsers/orphan_cleanup.py
@@ -18,10 +18,21 @@ def _load_session_state(state_file: Path) -> dict[str, str]:
     session_id = str(data.get("session_id") or "").strip()
     if not backend_id or not session_id:
         raise ValueError("Session state file must include backend_id and session_id")
+    cleanup_metadata_raw = str(data.get("cleanup_metadata") or "").strip()
+    cleanup_metadata: dict[str, str] = {}
+    if cleanup_metadata_raw:
+        try:
+            decoded_metadata = json.loads(cleanup_metadata_raw)
+        except json.JSONDecodeError:
+            decoded_metadata = {}
+        if isinstance(decoded_metadata, dict):
+            cleanup_metadata = {str(k): str(v) for k, v in decoded_metadata.items()}
+
     return {
         "backend_id": backend_id,
         "session_id": session_id,
         "forked_context_id": str(data.get("forked_context_id") or "").strip(),
+        "cleanup_metadata": json.dumps(cleanup_metadata, ensure_ascii=True),
     }
 
 
@@ -105,14 +116,32 @@ def _cleanup_agentbay_session(session_id: str) -> bool:
         return False
 
 
-def _cleanup_browserbase_session(session_id: str) -> bool:
-    api_key = os.getenv("BROWSERBASE_API_KEY")
+def _read_cleanup_metadata(state: dict[str, str]) -> dict[str, str]:
+    raw_metadata = state.get("cleanup_metadata", "")
+    if not raw_metadata:
+        return {}
+    try:
+        decoded = json.loads(raw_metadata)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(decoded, dict):
+        return {}
+    return {str(k): str(v) for k, v in decoded.items()}
+
+
+def _cleanup_browserbase_session(session_id: str, metadata: dict[str, str] | None = None) -> bool:
+    metadata = metadata or {}
+    api_key = metadata.get("api_key") or os.getenv("BROWSERBASE_API_KEY")
     if not api_key:
         logger.error("BROWSERBASE_API_KEY is required for Browserbase cleanup")
         return False
 
-    base_url = os.getenv("BROWSERBASE_BASE_URL", "https://api.browserbase.com").rstrip("/")
-    project_id = os.getenv("BROWSERBASE_PROJECT_ID", "")
+    base_url = (metadata.get("base_url") or os.getenv("BROWSERBASE_BASE_URL", "https://api.browserbase.com")).rstrip("/")
+    project_id = metadata.get("project_id") or os.getenv("BROWSERBASE_PROJECT_ID", "")
+    try:
+        timeout_seconds = int(metadata.get("request_timeout") or 30)
+    except ValueError:
+        timeout_seconds = 30
     body: dict[str, str] = {"status": "REQUEST_RELEASE"}
     if project_id:
         body["projectId"] = project_id
@@ -123,7 +152,7 @@ def _cleanup_browserbase_session(session_id: str) -> bool:
             url=f"{base_url}/v1/sessions/{session_id}",
             headers={"X-BB-API-Key": api_key},
             body=body,
-            timeout_seconds=30,
+            timeout_seconds=timeout_seconds,
         )
         logger.info("Requested Browserbase session release: %s", session_id)
         return True
@@ -191,7 +220,10 @@ def cleanup_orphaned_session_state(state_file: Path) -> int:
     elif backend_id == "agentbay":
         success = _cleanup_agentbay_session(session_id=session_id)
     elif backend_id == "browserbase":
-        success = _cleanup_browserbase_session(session_id=session_id)
+        success = _cleanup_browserbase_session(
+            session_id=session_id,
+            metadata=_read_cleanup_metadata(state),
+        )
     elif backend_id == "steel":
         success = _cleanup_steel_session(session_id=session_id)
     else:

--- a/browseruse_bench/browsers/providers/browserbase.py
+++ b/browseruse_bench/browsers/providers/browserbase.py
@@ -82,7 +82,16 @@ class BrowserbaseBackend(BrowserBackend):
             )
             raise RuntimeError("Browserbase session creation failed: connectUrl is empty")
 
-        write_session_state(backend_id=self.backend_id, session_id=session_id)
+        write_session_state(
+            backend_id=self.backend_id,
+            session_id=session_id,
+            cleanup_metadata={
+                "api_key": str(api_key),
+                "base_url": base_url,
+                "project_id": str(project_id or ""),
+                "request_timeout": str(timeout_seconds),
+            },
+        )
         logger.info("[SUCCESS] Browserbase session created: %s", session_id)
         return BrowserSessionContext(
             backend_id=self.backend_id,
@@ -100,6 +109,7 @@ class BrowserbaseBackend(BrowserBackend):
 
     def close(self, session_context: BrowserSessionContext) -> None:
         session_id = str(session_context.metadata.get("session_id") or "")
+        released = False
         if session_id:
             try:
                 self._release_session(
@@ -109,8 +119,13 @@ class BrowserbaseBackend(BrowserBackend):
                     session_id=session_id,
                     timeout_seconds=int(session_context.metadata.get("request_timeout") or 30),
                 )
+                released = True
             except cloud_utils.CLEANUP_EXCEPTIONS as exc:
                 logger.error("Browserbase session release failed (session_id=%s): %s", session_id, exc)
+        else:
+            released = True
+        if not released:
+            return
         try:
             clear_session_state()
         except (OSError, RuntimeError) as exc:

--- a/browseruse_bench/browsers/providers/browserless.py
+++ b/browseruse_bench/browsers/providers/browserless.py
@@ -10,23 +10,6 @@ from browseruse_bench.browsers.types import BrowserSessionContext
 logger = logging.getLogger(__name__)
 
 
-def _normalize_browserless_query(config_key: str, value: Any) -> Any:
-    if config_key != "browserless_timeout":
-        return value
-    timeout = cloud_utils.read_int(value, config_key)
-    if timeout is None:
-        return value
-    if timeout > 60_000:
-        normalized = max(1, timeout // 1000)
-        logger.warning(
-            "browserless_timeout=%s looks like milliseconds; sending %s seconds to Browserless",
-            timeout,
-            normalized,
-        )
-        return normalized
-    return timeout
-
-
 class BrowserlessBackend(BrowserBackend):
     """Browserless BaaS backend that exposes a connection URL directly."""
 
@@ -68,7 +51,7 @@ class BrowserlessBackend(BrowserBackend):
             cfg_key = f"browserless_{key}"
             value = cloud_utils.read_config(agent_config, cfg_key)
             if value not in (None, ""):
-                query[key] = _normalize_browserless_query(cfg_key, value)
+                query[key] = value
 
         cdp_url = cloud_utils.append_query(base_url, query)
         resolve_debugger_url = cloud_utils.read_bool(

--- a/browseruse_bench/browsers/session_state.py
+++ b/browseruse_bench/browsers/session_state.py
@@ -21,6 +21,7 @@ def write_session_state(
     backend_id: str,
     session_id: str,
     forked_context_id: str | None = None,
+    cleanup_metadata: dict[str, str] | None = None,
 ) -> None:
     path = _resolve_session_state_path()
     if path is None or not session_id:
@@ -31,6 +32,8 @@ def write_session_state(
     }
     if forked_context_id:
         payload["forked_context_id"] = forked_context_id
+    if cleanup_metadata:
+        payload["cleanup_metadata"] = json.dumps(cleanup_metadata, ensure_ascii=True)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload, ensure_ascii=True), encoding="utf-8")

--- a/browseruse_bench/utils/config_loader.py
+++ b/browseruse_bench/utils/config_loader.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import urllib.parse
 import uuid
 import warnings
 from copy import deepcopy
@@ -23,7 +24,11 @@ _EVAL_STRUCTURAL_KEYS = {"api_key", "base_url"}
 
 def _skyvern_temp_database_string() -> str:
     db_name = f"bubench_skyvern_{uuid.uuid4().hex}"
-    return f"postgresql+psycopg:///{db_name}?host=/tmp"
+    socket_host = os.getenv("BUBENCH_SKYVERN_POSTGRES_HOST")
+    if not socket_host:
+        socket_host = "/var/run/postgresql" if Path("/var/run/postgresql").exists() else "/tmp"
+    encoded_host = urllib.parse.quote(socket_host, safe="/")
+    return f"postgresql+psycopg:///{db_name}?host={encoded_host}"
 
 
 def load_eval_config(benchmark_name: str) -> dict[str, Any]:

--- a/tests/browseruse_bench/test_cloud_browsers.py
+++ b/tests/browseruse_bench/test_cloud_browsers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -13,8 +15,12 @@ from browseruse_bench.browsers.providers.steel import SteelBackend
 from browseruse_bench.browsers.registry import get_backend
 
 
-def test_browserbase_backend_open_and_close(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_browserbase_backend_open_and_close(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     calls: list[dict[str, Any]] = []
+    state_file = tmp_path / "session-state.json"
 
     def fake_post_json(**kwargs: Any) -> dict[str, Any]:
         calls.append(kwargs)
@@ -24,6 +30,7 @@ def test_browserbase_backend_open_and_close(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(browserbase_module.cloud_utils, "post_json", fake_post_json)
     monkeypatch.delenv("BROWSERBASE_API_KEY", raising=False)
+    monkeypatch.setenv("BROWSERUSE_BENCH_SESSION_STATE_FILE", str(state_file))
     backend = BrowserbaseBackend("browserbase")
 
     session_context = backend.open(
@@ -48,10 +55,43 @@ def test_browserbase_backend_open_and_close(monkeypatch: pytest.MonkeyPatch) -> 
             "region": "us-east-1",
         },
     }
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    cleanup_metadata = json.loads(state["cleanup_metadata"])
+    assert cleanup_metadata == {
+        "api_key": "bb-key",
+        "base_url": "https://api.browserbase.com",
+        "project_id": "project-1",
+        "request_timeout": "30",
+    }
 
     backend.close(session_context)
     assert calls[1]["url"] == "https://api.browserbase.com/v1/sessions/bb-session-1"
     assert calls[1]["body"] == {"status": "REQUEST_RELEASE", "projectId": "project-1"}
+    assert not state_file.exists()
+
+
+def test_browserbase_backend_keeps_state_when_release_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_file = tmp_path / "session-state.json"
+
+    def fake_post_json(**kwargs: Any) -> dict[str, Any]:
+        if kwargs["url"].endswith("/v1/sessions"):
+            return {"id": "bb-session-1", "connectUrl": "wss://browserbase.example/cdp"}
+        raise RuntimeError("release failed")
+
+    monkeypatch.setattr(browserbase_module.cloud_utils, "post_json", fake_post_json)
+    monkeypatch.setenv("BROWSERUSE_BENCH_SESSION_STATE_FILE", str(state_file))
+    backend = BrowserbaseBackend("browserbase")
+
+    session_context = backend.open(
+        agent_name="browser-use",
+        agent_config={"browserbase_api_key": "bb-key"},
+    )
+    backend.close(session_context)
+
+    assert state_file.exists()
 
 
 def test_browserbase_backend_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -106,7 +146,7 @@ def test_browserless_backend_resolves_debugger_url(monkeypatch: pytest.MonkeyPat
     assert session_context.cdp_url == "wss://production-ams.browserless.io/e/session"
     assert calls[0]["url"] == (
         "https://production-ams.browserless.io/json/version"
-        "?token=browserless-token&timeout=600"
+        "?token=browserless-token&timeout=600000"
     )
 
 
@@ -125,7 +165,7 @@ def test_browserless_backend_builds_cdp_url(monkeypatch: pytest.MonkeyPatch) -> 
     assert session_context.transport == "cdp"
     assert session_context.cdp_url == (
         "wss://production-ams.browserless.io"
-        "?token=browserless-token&timeout=600"
+        "?token=browserless-token&timeout=600000"
     )
 
 

--- a/tests/browseruse_bench/test_config_loader.py
+++ b/tests/browseruse_bench/test_config_loader.py
@@ -394,13 +394,17 @@ class TestSkyvernConfigCanonicalization:
             for w in caught
         )
 
-    def test_apply_skyvern_env_uses_temp_postgres_db_by_default(self) -> None:
+    def test_apply_skyvern_env_uses_temp_postgres_db_by_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BUBENCH_SKYVERN_POSTGRES_HOST", "/var/run/postgresql")
         env = {"DATABASE_STRING": "postgresql+psycopg://old/skyvern"}
 
         config_loader_module.apply_skyvern_env({"enable_openai_compatible": True}, env)
 
         assert env["DATABASE_STRING"].startswith("postgresql+psycopg:///bubench_skyvern_")
-        assert env["DATABASE_STRING"].endswith("?host=/tmp")
+        assert env["DATABASE_STRING"].endswith("?host=/var/run/postgresql")
 
     def test_apply_skyvern_env_preserves_explicit_database_string(self) -> None:
         env = {"DATABASE_STRING": "postgresql+psycopg://old/skyvern"}

--- a/tests/browseruse_bench/test_orphan_cleanup.py
+++ b/tests/browseruse_bench/test_orphan_cleanup.py
@@ -83,6 +83,55 @@ def test_cleanup_browserbase_session_state(
     ]
 
 
+def test_cleanup_browserbase_session_uses_state_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls = []
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "backend_id": "browserbase",
+                "session_id": "bb-session-1",
+                "cleanup_metadata": json.dumps(
+                    {
+                        "api_key": "metadata-key",
+                        "base_url": "https://browserbase.example",
+                        "project_id": "metadata-project",
+                        "request_timeout": "12",
+                    }
+                ),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_post_json(**kwargs):
+        calls.append(kwargs)
+        return {"id": "bb-session-1"}
+
+    monkeypatch.delenv("BROWSERBASE_API_KEY", raising=False)
+    monkeypatch.delenv("BROWSERBASE_PROJECT_ID", raising=False)
+    monkeypatch.setattr(
+        "browseruse_bench.browsers.providers.cloud_utils.post_json",
+        fake_post_json,
+    )
+
+    result = orphan_cleanup_module.cleanup_orphaned_session_state(state_file)
+
+    assert result == 0
+    assert not state_file.exists()
+    assert calls == [
+        {
+            "url": "https://browserbase.example/v1/sessions/bb-session-1",
+            "headers": {"X-BB-API-Key": "metadata-key"},
+            "body": {"status": "REQUEST_RELEASE", "projectId": "metadata-project"},
+            "timeout_seconds": 12,
+        }
+    ]
+
+
 def test_cleanup_steel_session_state(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- preserve Browserless timeout values as configured
- keep Browserbase session state when release fails and persist cleanup metadata for orphan cleanup
- align Skyvern temporary Postgres socket selection across runtime and config loader
- add regression coverage for the review feedback

## Tests
- uv run pytest tests/browseruse_bench/test_cloud_browsers.py tests/browseruse_bench/test_config_loader.py tests/browseruse_bench/test_orphan_cleanup.py
- uv run ruff check browseruse_bench/browsers/providers/browserbase.py browseruse_bench/browsers/providers/browserless.py browseruse_bench/browsers/providers/steel.py browseruse_bench/browsers/providers/cloud_utils.py browseruse_bench/browsers/session_state.py browseruse_bench/browsers/orphan_cleanup.py browseruse_bench/agents/skyvern.py browseruse_bench/utils/config_loader.py tests/browseruse_bench/test_cloud_browsers.py tests/browseruse_bench/test_config_loader.py tests/browseruse_bench/test_orphan_cleanup.py