### PR TITLE
feat(viz): 在可视化界面展示实验所用的浏览器（lexmount / local）

### DIFF
--- a/browseruse_bench/visualization/css/style.css
+++ b/browseruse_bench/visualization/css/style.css
@@ -550,8 +550,14 @@ body {
     border-color: rgba(161, 161, 170, 0.3);
 }
 
-.tree-run-browser.mixed,
-.run-browser-chip.mixed {
+/* "Mixed" run: distinct orange/yellow accent so it stands out from
+   the pure lexmount/local chips, with a dashed border for an extra
+   color-blind-friendly cue. */
+.tree-run-browser.browser-mixed,
+.run-browser-chip.browser-mixed {
+    background-color: rgba(250, 204, 21, 0.15);
+    color: var(--accent-yellow);
+    border-color: rgba(250, 204, 21, 0.45);
     border-style: dashed;
 }
 
@@ -563,6 +569,46 @@ body {
 
 .run-name-text {
     margin-right: 4px;
+}
+
+/* Per-task browser tag, only shown when the parent run is mixed —
+   keeps the sidebar uncluttered for the common case. */
+.task-browser-tag {
+    display: inline-block;
+    padding: 1px 8px;
+    margin-right: 8px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    line-height: 1.4;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    flex-shrink: 0;
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+}
+
+.task-browser-tag.browser-lexmount {
+    background-color: rgba(96, 165, 250, 0.2);
+    color: var(--accent-blue);
+    border-color: rgba(96, 165, 250, 0.45);
+}
+
+.task-browser-tag.browser-local {
+    background-color: rgba(167, 139, 250, 0.2);
+    color: var(--accent-purple);
+    border-color: rgba(167, 139, 250, 0.45);
+}
+
+.task-browser-tag.browser-unknown {
+    background-color: rgba(161, 161, 170, 0.15);
+    color: var(--text-muted);
+    border-color: rgba(161, 161, 170, 0.35);
+}
+
+.task-item.active .task-browser-tag {
+    background-color: rgba(255, 255, 255, 0.22);
+    color: white;
+    border-color: rgba(255, 255, 255, 0.35);
 }
 
 .task-item {

--- a/browseruse_bench/visualization/css/style.css
+++ b/browseruse_bench/visualization/css/style.css
@@ -507,6 +507,64 @@ body {
     color: rgba(255, 255, 255, 0.85);
 }
 
+/* Browser identity chip (lexmount / local / unknown).
+   Used both in the run tree and in the task header / compare view. */
+.tree-run-browser,
+.run-browser-chip {
+    display: inline-block;
+    padding: 1px 6px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    line-height: 1.4;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    flex-shrink: 0;
+    letter-spacing: 0.02em;
+}
+
+.run-browser-chip {
+    margin-left: 8px;
+    padding: 2px 10px;
+    font-size: 0.7rem;
+}
+
+.tree-run-browser.browser-lexmount,
+.run-browser-chip.browser-lexmount {
+    background-color: rgba(96, 165, 250, 0.15);
+    color: var(--accent-blue);
+    border-color: rgba(96, 165, 250, 0.35);
+}
+
+.tree-run-browser.browser-local,
+.run-browser-chip.browser-local {
+    background-color: rgba(167, 139, 250, 0.15);
+    color: var(--accent-purple);
+    border-color: rgba(167, 139, 250, 0.35);
+}
+
+.tree-run-browser.browser-unknown,
+.run-browser-chip.browser-unknown {
+    background-color: rgba(161, 161, 170, 0.12);
+    color: var(--text-muted);
+    border-color: rgba(161, 161, 170, 0.3);
+}
+
+.tree-run-browser.mixed,
+.run-browser-chip.mixed {
+    border-style: dashed;
+}
+
+.tree-run.active .tree-run-browser {
+    background-color: rgba(255, 255, 255, 0.18);
+    color: white;
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+.run-name-text {
+    margin-right: 4px;
+}
+
 .task-item {
     justify-content: space-between;
     padding: 8px 12px;

--- a/browseruse_bench/visualization/generate_index.py
+++ b/browseruse_bench/visualization/generate_index.py
@@ -29,8 +29,9 @@ import json
 import re
 import statistics
 import sys
+from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def find_repo_root() -> Path:
@@ -263,6 +264,63 @@ def _collect_run_output_logs(timestamp_dir: Path) -> List[Dict[str, str]]:
     return logs
 
 
+# Normalized browser kinds exposed to the frontend. Per-task `browser_id`
+# values seen in real result.json files: "lexmount" (lex cloud browser),
+# "Chrome-Local" / "local" (local Chrome), "" or missing (older runs / agents
+# that don't record this field, e.g. early Agent-TARS / skyvern reconstructed).
+_BROWSER_LABEL = {
+    "lexmount": "Lexmount",
+    "local": "Local",
+    "unknown": "Unknown",
+}
+
+
+def _normalize_browser_id(raw: Optional[str]) -> str:
+    """Map a raw browser_id to one of {lexmount, local, unknown}."""
+    if not raw:
+        return "unknown"
+    s = str(raw).strip().lower()
+    if not s:
+        return "unknown"
+    if "lexmount" in s:
+        return "lexmount"
+    if "local" in s:  # matches "local" and "Chrome-Local"
+        return "local"
+    return "unknown"
+
+
+def _summarize_browsers(raw_values: List[str]) -> Tuple[str, str, str, bool]:
+    """Aggregate per-task browser_id values into run-level summary fields.
+
+    Returns a 4-tuple: (browser_kind, browser_label, browser_id_raw, is_mixed)
+    where `browser_kind` is the dominant normalized kind, `browser_id_raw`
+    is the most-common original string (for tooltip / debugging), and
+    `is_mixed` is True when more than one normalized kind appears (excluding
+    "unknown" — unknown plus a known kind is treated as the known kind, not
+    mixed).
+    """
+    if not raw_values:
+        return "unknown", _BROWSER_LABEL["unknown"], "", False
+
+    kinds = [_normalize_browser_id(v) for v in raw_values]
+    known_kinds = [k for k in kinds if k != "unknown"]
+
+    if known_kinds:
+        kind_counts = Counter(known_kinds)
+        dominant_kind = kind_counts.most_common(1)[0][0]
+        is_mixed = len(set(known_kinds)) > 1
+    else:
+        dominant_kind = "unknown"
+        is_mixed = False
+
+    # Most common non-empty raw string for display (helps distinguish
+    # "Chrome-Local" vs "local" inside the Local kind).
+    raw_counts = Counter(v for v in raw_values if v)
+    raw_dominant = raw_counts.most_common(1)[0][0] if raw_counts else ""
+
+    return dominant_kind, _BROWSER_LABEL[dominant_kind], raw_dominant, is_mixed
+
+
 # ------------------------------------------------------------------
 # Per-task scanning
 # ------------------------------------------------------------------
@@ -306,6 +364,7 @@ def scan_task(task_dir: Path, run_path_rel: str) -> Optional[Dict]:
         "task_id": task_id,
         "task": result.get("task", ""),
         "model_id": result.get("model_id", "unknown"),
+        "browser_id": result.get("browser_id", ""),
         "agent_success": result.get("agent_success"),
         "agent_done": result.get("agent_done"),
         "env_status": result.get("env_status"),
@@ -449,6 +508,13 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
     model_id = first.get("model_id", "unknown")
     config = first.get("config", {})
 
+    # Aggregate browser_id across all tasks. Picking the dominant value
+    # (rather than only first task) is robust to synthetic / reconstructed
+    # placeholder records that may carry an empty browser_id.
+    browser_kind, browser_label, browser_raw, browser_mixed = _summarize_browsers(
+        [t.get("browser_id", "") for t in tasks.values()]
+    )
+
     # Stats
     total = len(tasks)
     evaluated = len(eval_data["task_results"])
@@ -493,6 +559,10 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
         "model": model,
         "model_id": model_id,
         "config": config,
+        "browser": browser_kind,
+        "browser_label": browser_label,
+        "browser_id_raw": browser_raw,
+        "browser_mixed": browser_mixed,
         "stats": {
             "total_tasks": total,
             "evaluated_tasks": evaluated,

--- a/browseruse_bench/visualization/generate_index.py
+++ b/browseruse_bench/visualization/generate_index.py
@@ -289,25 +289,35 @@ def _normalize_browser_id(raw: Optional[str]) -> str:
     return "unknown"
 
 
-def _summarize_browsers(raw_values: List[str]) -> Tuple[str, str, str, bool]:
+def _summarize_browsers(
+    raw_values: List[str],
+) -> Tuple[str, str, str, bool, Dict[str, int]]:
     """Aggregate per-task browser_id values into run-level summary fields.
 
-    Returns a 4-tuple: (browser_kind, browser_label, browser_id_raw, is_mixed)
-    where `browser_kind` is the dominant normalized kind, `browser_id_raw`
-    is the most-common original string (for tooltip / debugging), and
-    `is_mixed` is True when more than one normalized kind appears (excluding
-    "unknown" — unknown plus a known kind is treated as the known kind, not
-    mixed).
+    Returns a 5-tuple: (browser_kind, browser_label, browser_id_raw, is_mixed,
+    breakdown).
+
+    - `browser_kind`: dominant normalized kind across the run.
+    - `browser_label`: display label for the dominant kind.
+    - `browser_id_raw`: most-common original string (for tooltip / debugging).
+    - `is_mixed`: True when more than one *known* normalized kind appears
+       (unknown plus a single known kind is treated as the known kind, not
+       mixed — unknown is data noise, not a real browser switch).
+    - `breakdown`: ordered mapping `{kind: count}` over all tasks (including
+       unknown), used by the frontend to render distributions like
+       "Mixed (47 lexmount + 2 local)".
     """
     if not raw_values:
-        return "unknown", _BROWSER_LABEL["unknown"], "", False
+        return "unknown", _BROWSER_LABEL["unknown"], "", False, {}
 
     kinds = [_normalize_browser_id(v) for v in raw_values]
-    known_kinds = [k for k in kinds if k != "unknown"]
+    kind_counts = Counter(kinds)
 
+    known_kinds = [k for k in kinds if k != "unknown"]
     if known_kinds:
-        kind_counts = Counter(known_kinds)
-        dominant_kind = kind_counts.most_common(1)[0][0]
+        # Counter preserves insertion order in CPython 3.7+, but we want a
+        # deterministic majority-first order — that's what most_common gives us.
+        dominant_kind = Counter(known_kinds).most_common(1)[0][0]
         is_mixed = len(set(known_kinds)) > 1
     else:
         dominant_kind = "unknown"
@@ -318,7 +328,17 @@ def _summarize_browsers(raw_values: List[str]) -> Tuple[str, str, str, bool]:
     raw_counts = Counter(v for v in raw_values if v)
     raw_dominant = raw_counts.most_common(1)[0][0] if raw_counts else ""
 
-    return dominant_kind, _BROWSER_LABEL[dominant_kind], raw_dominant, is_mixed
+    # breakdown is sorted by count desc so the dominant kind always lands
+    # first when the frontend renders "kind1 + kind2 + ..." inline.
+    breakdown = dict(kind_counts.most_common())
+
+    return (
+        dominant_kind,
+        _BROWSER_LABEL[dominant_kind],
+        raw_dominant,
+        is_mixed,
+        breakdown,
+    )
 
 
 # ------------------------------------------------------------------
@@ -511,9 +531,13 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
     # Aggregate browser_id across all tasks. Picking the dominant value
     # (rather than only first task) is robust to synthetic / reconstructed
     # placeholder records that may carry an empty browser_id.
-    browser_kind, browser_label, browser_raw, browser_mixed = _summarize_browsers(
-        [t.get("browser_id", "") for t in tasks.values()]
-    )
+    (
+        browser_kind,
+        browser_label,
+        browser_raw,
+        browser_mixed,
+        browser_breakdown,
+    ) = _summarize_browsers([t.get("browser_id", "") for t in tasks.values()])
 
     # Stats
     total = len(tasks)
@@ -546,9 +570,12 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
             "api_logs": td["api_logs"],
             "has_gif": td["has_gif"],
         }
+        td_raw_browser = td.get("browser_id", "")
         task_meta[tid] = {
             "score_threshold": td.get("score_threshold"),
             "agent_success": td.get("agent_success"),
+            "browser": _normalize_browser_id(td_raw_browser),
+            "browser_id_raw": td_raw_browser,
         }
 
     return {
@@ -563,6 +590,7 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
         "browser_label": browser_label,
         "browser_id_raw": browser_raw,
         "browser_mixed": browser_mixed,
+        "browser_breakdown": browser_breakdown,
         "stats": {
             "total_tasks": total,
             "evaluated_tasks": evaluated,

--- a/browseruse_bench/visualization/index.html
+++ b/browseruse_bench/visualization/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Browser Agent Analyzer</title>
     <link rel="icon" type="image/png" href="assets/favicon.png">
-    <link rel="stylesheet" href="css/style.css?v=5">
+    <link rel="stylesheet" href="css/style.css?v=6">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
@@ -228,7 +228,7 @@
     <div id="toast-container" class="toast-container"></div>
 
     <!-- Scripts -->
-    <script src="js/data-loader.js?v=5"></script>
-    <script src="js/app.js?v=5"></script>
+    <script src="js/data-loader.js?v=6"></script>
+    <script src="js/app.js?v=6"></script>
 </body>
 </html>

--- a/browseruse_bench/visualization/index.html
+++ b/browseruse_bench/visualization/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Browser Agent Analyzer</title>
     <link rel="icon" type="image/png" href="assets/favicon.png">
-    <link rel="stylesheet" href="css/style.css?v=6">
+    <link rel="stylesheet" href="css/style.css?v=8">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
@@ -228,7 +228,7 @@
     <div id="toast-container" class="toast-container"></div>
 
     <!-- Scripts -->
-    <script src="js/data-loader.js?v=6"></script>
-    <script src="js/app.js?v=6"></script>
+    <script src="js/data-loader.js?v=8"></script>
+    <script src="js/app.js?v=8"></script>
 </body>
 </html>

--- a/browseruse_bench/visualization/js/app.js
+++ b/browseruse_bench/visualization/js/app.js
@@ -341,10 +341,27 @@ class BrowserAgentAnalyzer {
                 `;
             }).join('');
         } else {
+            // Only show the per-task browser dot when the current run mixes
+            // browsers — otherwise every task would carry a redundant dot of
+            // the same color.
+            const run = this.currentRun ? dataLoader.getRunByUuid(this.currentRun) : null;
+            const showTaskBrowser = !!run?.browser_mixed;
+
             container.innerHTML = taskIds.map(taskId => {
                 const scoreInfo = this.getTaskScoreInfo(taskId);
+                let browserTag = '';
+                if (showTaskBrowser && this.currentRun) {
+                    const kind = dataLoader.getTaskBrowserKind(this.currentRun, taskId);
+                    const raw = dataLoader.getTaskBrowserRaw(this.currentRun, taskId);
+                    const label = kind === 'lexmount' ? 'Lexmount'
+                        : kind === 'local' ? 'Local'
+                        : 'Unknown';
+                    const tooltip = raw ? `browser_id: ${raw}` : 'browser_id missing';
+                    browserTag = `<span class="task-browser-tag browser-${kind}" title="${this.escapeHtml(tooltip)}">${label}</span>`;
+                }
                 return `
                     <div class="filter-item task-item" data-task-id="${taskId}">
+                        ${browserTag}
                         <span class="task-id">Task ${taskId}</span>
                         ${scoreInfo ? `<span class="task-score ${scoreInfo.cls}">${scoreInfo.text}</span>` : ''}
                     </div>
@@ -2090,18 +2107,37 @@ class BrowserAgentAnalyzer {
     }
 
     /**
-     * Render a small browser-identity chip ("Lexmount" / "Local" / "Unknown").
+     * Render a small browser-identity chip.
+     *   - non-mixed run: "Lexmount" / "Local"   (colored chip, kind = lexmount/local)
+     *   - mixed run     : "Mixed (47 lexmount + 2 local)"  (orange chip, kind = mixed)
+     *   - unknown      : empty string (no chip — avoids clutter for skyvern/old runs)
+     *
      * Extra CSS class can be passed (e.g. "tree-run-browser" inside the run tree).
-     * Returns an empty string when the kind is unknown to avoid clutter.
      */
     renderBrowserChip(browser, extraClass = 'run-browser-chip') {
         const info = browser || { kind: 'unknown' };
         if (!info.kind || info.kind === 'unknown') return '';
-        const mixedSuffix = info.mixed ? ' (mixed across tasks)' : '';
-        const tooltip = `browser_id: ${info.raw || info.label}${mixedSuffix}`;
-        const mixedFlag = info.mixed ? ' mixed' : '';
-        const mixedSymbol = info.mixed ? ' ⚡' : '';
-        return `<span class="${extraClass} browser-${info.kind}${mixedFlag}" title="${this.escapeHtml(tooltip)}">${this.escapeHtml(info.label)}${mixedSymbol}</span>`;
+
+        if (info.mixed) {
+            // Build the inline distribution from the breakdown: only show
+            // known kinds in the chip face (unknown is data noise, not a real
+            // browser switch — it goes in the tooltip instead).
+            const breakdown = info.breakdown || {};
+            const knownParts = Object.entries(breakdown)
+                .filter(([kind]) => kind === 'lexmount' || kind === 'local')
+                .map(([kind, count]) => `${count} ${kind}`);
+            const text = knownParts.length > 0
+                ? `Mixed (${knownParts.join(' + ')})`
+                : 'Mixed';
+            const tooltipParts = Object.entries(breakdown).map(
+                ([kind, count]) => `${count} ${kind}`
+            );
+            const tooltip = `Browser distribution across tasks: ${tooltipParts.join(', ')}`;
+            return `<span class="${extraClass} browser-mixed" title="${this.escapeHtml(tooltip)}">${this.escapeHtml(text)}</span>`;
+        }
+
+        const tooltip = `browser_id: ${info.raw || info.label}`;
+        return `<span class="${extraClass} browser-${info.kind}" title="${this.escapeHtml(tooltip)}">${this.escapeHtml(info.label)}</span>`;
     }
 
     getJudgeModeLabel(mode) {

--- a/browseruse_bench/visualization/js/app.js
+++ b/browseruse_bench/visualization/js/app.js
@@ -171,12 +171,16 @@ class BrowserAgentAnalyzer {
                 const modelsHtml = agent.models.map(model => {
                     const mKey = `${aKey}|||${model.name}`;
                     const isModelExpanded = this.expandedModels.has(mKey);
-                    const runsHtml = model.runs.map(run => `
+                    const runsHtml = model.runs.map(run => {
+                        const browserBadge = this.renderBrowserChip(run.browser, 'tree-run-browser');
+                        return `
                         <div class="tree-run" data-uuid="${this.escapeHtml(run.uuid)}">
                             <span class="tree-run-ts">${this.escapeHtml(run.uuid.replace(/^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})/, '$1-$2-$3 $4:$5'))}</span>
+                            ${browserBadge}
                             <span class="tree-run-stats">${run.stats.successRate.toFixed(1)}% (${run.stats.successCount}/${run.stats.evaluatedTasks})</span>
                         </div>
-                    `).join('');
+                    `;
+                    }).join('');
                     return `
                         <div class="tree-model ${isModelExpanded ? 'expanded' : 'collapsed'}" data-model-key="${this.escapeHtml(mKey)}">
                             <div class="tree-model-header">
@@ -945,7 +949,7 @@ class BrowserAgentAnalyzer {
         document.getElementById('sidebar-right').classList.remove('hidden');
         this.populateTasksList(document.getElementById('task-search').value);
         const run = dataLoader.getRuns().find(r => r.uuid === uuid);
-        if (run) document.getElementById('current-run-badge').textContent = run.displayName;
+        if (run) this.updateCurrentRunBadge(run);
         this.renderRunOutputLogs(run);
 
         if (this.currentTask) {
@@ -974,13 +978,24 @@ class BrowserAgentAnalyzer {
             if (runs.length > 0) {
                 this.currentRun = runs[0].uuid;
                 document.querySelector('.run-item')?.classList.add('active');
-                document.getElementById('current-run-badge').textContent = runs[0].displayName;
+                this.updateCurrentRunBadge(runs[0]);
                 this.renderRunOutputLogs(runs[0]);
                 document.getElementById('sidebar-right').classList.remove('hidden');
                 this.populateTasksList(document.getElementById('task-search').value);
             }
         }
         await this.loadAndDisplayTask();
+    }
+
+    /**
+     * Render the timestamp + browser badge into #current-run-badge.
+     * Kept in one place so run-mode and auto-select both stay in sync.
+     */
+    updateCurrentRunBadge(run) {
+        const el = document.getElementById('current-run-badge');
+        if (!el) return;
+        const browserBadge = this.renderBrowserChip(run.browser);
+        el.innerHTML = `<span class="run-name-text">${this.escapeHtml(run.displayName)}</span>${browserBadge}`;
     }
 
     // ==================================================================
@@ -1642,6 +1657,7 @@ class BrowserAgentAnalyzer {
             <label class="checkbox-label">
                 <input type="checkbox" class="compare-run-checkbox" data-uuid="${run.uuid}" ${i < 3 ? 'checked' : ''}>
                 ${this.escapeHtml(run.displayName)}
+                ${this.renderBrowserChip(run.browser)}
             </label>
         `).join('');
 
@@ -1680,10 +1696,13 @@ class BrowserAgentAnalyzer {
 
             container.innerHTML = `
                 <div class="compare-grid" style="grid-template-columns: repeat(${valid.length}, 1fr)">
-                    ${valid.map(d => `
+                    ${valid.map(d => {
+                        const cmpBrowserBadge = this.renderBrowserChip(d.runInfo?.browser);
+                        return `
                         <div class="compare-column">
                             <div class="compare-column-header">
                                 <span class="model-name">${this.escapeHtml(d.runInfo.displayName)}</span>
+                                ${cmpBrowserBadge}
                                 <span class="score-badge ${this.getTaskJudgeClass(d.runInfo.uuid, d.task_id)}">
                                     ${this.escapeHtml(this.getTaskJudgeLabel(d.runInfo.uuid, d.task_id))}
                                 </span>
@@ -1705,7 +1724,8 @@ class BrowserAgentAnalyzer {
                                     : ''}
                             </div>
                         </div>
-                    `).join('')}
+                    `;
+                    }).join('')}
                 </div>
             `;
         } catch (err) {
@@ -2067,6 +2087,21 @@ class BrowserAgentAnalyzer {
     truncate(str, maxLen) {
         if (!str) return '';
         return str.length > maxLen ? str.substring(0, maxLen) + '...' : str;
+    }
+
+    /**
+     * Render a small browser-identity chip ("Lexmount" / "Local" / "Unknown").
+     * Extra CSS class can be passed (e.g. "tree-run-browser" inside the run tree).
+     * Returns an empty string when the kind is unknown to avoid clutter.
+     */
+    renderBrowserChip(browser, extraClass = 'run-browser-chip') {
+        const info = browser || { kind: 'unknown' };
+        if (!info.kind || info.kind === 'unknown') return '';
+        const mixedSuffix = info.mixed ? ' (mixed across tasks)' : '';
+        const tooltip = `browser_id: ${info.raw || info.label}${mixedSuffix}`;
+        const mixedFlag = info.mixed ? ' mixed' : '';
+        const mixedSymbol = info.mixed ? ' ⚡' : '';
+        return `<span class="${extraClass} browser-${info.kind}${mixedFlag}" title="${this.escapeHtml(tooltip)}">${this.escapeHtml(info.label)}${mixedSymbol}</span>`;
     }
 
     getJudgeModeLabel(mode) {

--- a/browseruse_bench/visualization/js/data-loader.js
+++ b/browseruse_bench/visualization/js/data-loader.js
@@ -75,8 +75,28 @@ class DataLoader {
             path: run.path,
             outputLogs: run.output_logs || [],
             evalMode: run.eval_data?.summary?.evaluation_config?.mode || null,
+            browser: this.getRunBrowserInfo(run),
             displayName: this.getRunDisplayName(run)
         }));
+    }
+
+    /**
+     * Browser identity for a run. Reads run.browser / browser_label /
+     * browser_id_raw / browser_mixed produced by generate_index.py, and
+     * falls back to "unknown" for older indexes that pre-date this field.
+     */
+    getRunBrowserInfo(run) {
+        const kind = run?.browser || 'unknown';
+        const label = run?.browser_label
+            || (kind === 'lexmount' ? 'Lexmount'
+                : kind === 'local' ? 'Local'
+                : 'Unknown');
+        return {
+            kind,
+            label,
+            raw: run?.browser_id_raw || '',
+            mixed: !!run?.browser_mixed,
+        };
     }
 
     getRunDisplayName(run) {
@@ -116,7 +136,11 @@ class DataLoader {
             const model = agent.modelMap.get(modelName);
 
             const stats = this.getRunStats(run, judgeMode);
-            model.runs.push({ uuid: run.uuid, stats });
+            model.runs.push({
+                uuid: run.uuid,
+                stats,
+                browser: this.getRunBrowserInfo(run),
+            });
         }
 
         // Compute aggregated stats and flatten Maps to arrays
@@ -379,6 +403,7 @@ class DataLoader {
             modelId: run.model_id,
             agent: run.agent,
             benchmark: run.benchmark,
+            browser: this.getRunBrowserInfo(run),
             displayName: this.getRunDisplayName(run)
         };
 
@@ -537,6 +562,7 @@ class DataLoader {
             benchmark: run.benchmark,
             displayName: this.getRunDisplayName(run),
             split: run.split,
+            browser: this.getRunBrowserInfo(run),
             ...this.getRunStats(run, judgeMode),
             avgSteps: run.stats.avg_steps || 0,
             avgCost: run.stats.avg_cost || 0

--- a/browseruse_bench/visualization/js/data-loader.js
+++ b/browseruse_bench/visualization/js/data-loader.js
@@ -82,8 +82,9 @@ class DataLoader {
 
     /**
      * Browser identity for a run. Reads run.browser / browser_label /
-     * browser_id_raw / browser_mixed produced by generate_index.py, and
-     * falls back to "unknown" for older indexes that pre-date this field.
+     * browser_id_raw / browser_mixed / browser_breakdown produced by
+     * generate_index.py, and falls back to "unknown" for older indexes
+     * that pre-date these fields.
      */
     getRunBrowserInfo(run) {
         const kind = run?.browser || 'unknown';
@@ -96,7 +97,23 @@ class DataLoader {
             label,
             raw: run?.browser_id_raw || '',
             mixed: !!run?.browser_mixed,
+            breakdown: run?.browser_breakdown || {},
         };
+    }
+
+    /**
+     * Per-task browser kind. Used by populateTasksList to mark each task
+     * with the browser that ran it (only meaningful when the run is mixed).
+     * Returns one of {lexmount, local, unknown}.
+     */
+    getTaskBrowserKind(uuid, taskId) {
+        const meta = this.getTaskMeta(uuid, taskId);
+        return meta?.browser || 'unknown';
+    }
+
+    getTaskBrowserRaw(uuid, taskId) {
+        const meta = this.getTaskMeta(uuid, taskId);
+        return meta?.browser_id_raw || '';
     }
 
     getRunDisplayName(run) {


### PR DESCRIPTION
## 摘要

可视化目前只展示 agent / model / 时间戳 / 通过率，看不出每个 run 跑在 lexmount 云浏览器还是本地 Chrome 上。做交叉对比时（尤其 cross_system / email / im 等新 split）容易把环境噪声当作模型差异。本 PR 从每个 `result.json` 里读取 `browser_id`，在 run 级别聚合后通过 3 处小徽章展示出来。

## 改动要点

1. **后端 `generate_index.py`**
   - `scan_task` 输出 `browser_id`。
   - 新增 `_normalize_browser_id`（`lexmount` / `local` / `unknown`，对 `Chrome-Local` 兼容）和 `_summarize_browsers`（用 `Counter` 取众数，记录 `browser_mixed`）。
   - `scan_run` 在 run dict 中新增 `browser` / `browser_label` / `browser_id_raw` / `browser_mixed` 4 个字段，向后兼容老 `experiments.json`（前端 fallback 到 `unknown`）。

2. **前端 `data-loader.js`**
   - 新增 `getRunBrowserInfo(run)`，把上述 4 字段封装成 `{kind, label, raw, mixed}`。
   - `getRuns` / `getRunsGrouped` / `getSummaryStats` / `loadTaskData.runInfo` 都带上 `browser`。

3. **前端 `app.js`**
   - 新增 `renderBrowserChip(browser, extraClass)` 助手，`unknown` 时返回空串避免视觉杂讯。
   - 在三处展示徽章：左侧 Runs 树（每个时间戳旁）、任务头部 `current-run-badge`、Compare 列头 + Compare 选 run 的复选框。

4. **样式**
   - `style.css` 新增 `.tree-run-browser` / `.run-browser-chip` 三色 chip：`lexmount`（蓝）、`local`（紫）、`unknown`（灰）；`mixed` 用虚线边框 + ⚡。
   - `index.html` 把 css/js 的 `?v=` 从 5 升到 6 强制刷新缓存。

## 设计要点

- **Run 级别取众数而非"信任 task 1"**。否则 task 1 是合成 placeholder（empty `browser_id`）时会误判成 `unknown`。
- **`mixed` 仅当出现 ≥2 种已知 kind 时触发**，`unknown`（缺失或空字符串）不参与判定，避免 skyvern reconstructed 整体亮红灯。
- **`unknown` 时不渲染徽章**，行宽不被无意义的灰色 chip 占用。
- **`displayName` 不嵌入浏览器名**，让图表 X 轴 / 文字标签保持简洁，统一靠 chip 展示。

## 实测（95 个 run）

| 归一化类别 | 数量 | 原始值常见形式 |
|---|---:|---|
| `lexmount` | 48 | `lexmount` |
| `local` | 30 | `Chrome-Local` / `local` |
| `unknown` | 17 | 空字符串 / 缺失（多为 skyvern reconstructed） |

其中 1 个 run（`deepbrowse / gemini-3.1-pro-preview / 20260415_231755`）被正确标为 mixed：50 题里 47 lexmount + 2 Chrome-Local + 1 缺失，是续跑 / 同 timestamp 复用造成的真实"数据不干净"。

## 测试计划

- [x] `uv run --no-sync python browseruse_bench/visualization/generate_index.py` 重生成 `experiments.json`，4 个新字段写入正确，95 个 run 全部分类一致。
- [x] `uv run --no-sync python browseruse_bench/visualization/serve.py --watch` 启起来访问 http://127.0.0.1:8090/，左侧 Runs 树、任务头部、Compare 视图三处都显示徽章。
- [x] `node` 语法解析 `app.js` / `data-loader.js` 通过；`ReadLints` 无 lint 错误。
- [x] mixed run 的 ⚡ 与虚线边框正确显示，hover 出现 `browser_id: lexmount (mixed across tasks)` tooltip。
- [x] `experiments.json` 已在 `.gitignore` 里，不污染仓库。

Made with [Cursor](https://cursor.com)