### PR TITLE
Record runtime config and output logs in experiments

### DIFF
--- a/browseruse_bench/cli/__init__.py
+++ b/browseruse_bench/cli/__init__.py
@@ -11,7 +11,6 @@ from browseruse_bench.cli.run import configure_run_parser, run_command
 from browseruse_bench.cli.server import configure_server_parser, server_command
 from browseruse_bench.cli.service import configure_service_parser, service_command
 from browseruse_bench.cli.skills import configure_skills_parser, skills_command
-from browseruse_bench.cli.submit import configure_submit_parser, submit_command
 from browseruse_bench.cli.viz import configure_viz_parser, viz_command
 from browseruse_bench.utils import (
     REPO_ROOT,
@@ -28,6 +27,13 @@ load_env_file(REPO_ROOT / ".env")
 
 # Setup logger
 logger = setup_logger("bubench")
+
+
+def _submit_dependency_missing(args: argparse.Namespace, config: Dict[str, Any]) -> int:
+    raise SystemExit(
+        "[FAILED] The 'submit' command requires the optional lexbench_sdk dependency. "
+        "Install the submit extras or run a non-submit command."
+    )
 
 
 def _build_parser(config: Dict[str, Any]) -> argparse.ArgumentParser:
@@ -56,8 +62,15 @@ def _build_parser(config: Dict[str, Any]) -> argparse.ArgumentParser:
     run_parser.set_defaults(handler=run_command)
 
     submit_parser = subparsers.add_parser("submit", help="Submit a job to LexBench")
-    configure_submit_parser(submit_parser, config)
-    submit_parser.set_defaults(handler=submit_command)
+    try:
+        from browseruse_bench.cli.submit import configure_submit_parser, submit_command
+    except ModuleNotFoundError as exc:
+        if exc.name != "lexbench_sdk":
+            raise
+        submit_parser.set_defaults(handler=_submit_dependency_missing)
+    else:
+        configure_submit_parser(submit_parser, config)
+        submit_parser.set_defaults(handler=submit_command)
 
     eval_parser = subparsers.add_parser("eval", help="Evaluate benchmark results")
     configure_eval_parser(eval_parser, config)

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -31,6 +31,7 @@ from browseruse_bench.utils import (
     REPO_ROOT,
     DataSource,
     add_common_task_args,
+    add_file_handler,
     apply_skyvern_env,
     check_uv_available,
     ensure_venv,
@@ -305,13 +306,21 @@ class _TaskBriefWriter:
 def _write_run_manifest(
     output_dir: Path,
     *,
-    agent_config: dict[str, Any],
+    config: dict[str, Any] | None = None,
+    agent_config: dict[str, Any] | None = None,
+    resolved_agent_config: dict[str, Any] | None = None,
+    run_context: dict[str, Any] | None = None,
 ) -> None:
-    """Write config_snapshot.json for backward compatibility."""
+    """Write a redacted config snapshot for reproducibility."""
     try:
+        runtime_config = resolved_agent_config or agent_config or config or {}
+        snapshot = {
+            "run": _redact_config_secrets(run_context or {}),
+            "runtime_config": _redact_config_secrets(runtime_config),
+        }
         config_snapshot_path = output_dir / "config_snapshot.json"
         with open(config_snapshot_path, "w", encoding="utf-8") as fh:
-            json.dump(_redact_config_secrets(agent_config), fh, indent=2, ensure_ascii=False)
+            json.dump(snapshot, fh, indent=2, ensure_ascii=False)
         logger.info("Config snapshot written to %s", config_snapshot_path)
     except OSError as exc:
         logger.warning("Failed to write config_snapshot.json: %s", exc)
@@ -597,6 +606,7 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
         output_dir = output_base / timestamp
 
     output_dir.mkdir(parents=True, exist_ok=True)
+    add_file_handler(logger, output_dir / "run.log", format_mode="plain")
 
     logger.info("Running %s on %s", agent_name, benchmark_name)
     logger.info("   Output: %s", output_dir)
@@ -903,7 +913,23 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
         try:
             _write_run_manifest(
                 output_dir,
-                agent_config=agent_config_dict,
+                resolved_agent_config=agent_cfg,
+                run_context={
+                    "agent": agent_name,
+                    "benchmark": benchmark_name,
+                    "split": args.split,
+                    "model_id": model_id,
+                    "timestamp": timestamp,
+                    "model_name_override": getattr(args, "model_name", None),
+                    "browser_id_override": getattr(args, "browser_id", None),
+                    "mode": getattr(args, "mode", None),
+                    "task_ids": getattr(args, "task_ids", None),
+                    "task_id": getattr(args, "id", None),
+                    "count": getattr(args, "count", None),
+                    "region": getattr(args, "region", None),
+                    "concurrency": getattr(args, "concurrency", None),
+                    "agent_config_path": str(getattr(args, "agent_config", None) or ""),
+                },
             )
         except (OSError, KeyError, AttributeError, TypeError) as exc:
             logger.warning("Failed to finalize run manifest: %s", exc)

--- a/browseruse_bench/visualization/css/style.css
+++ b/browseruse_bench/visualization/css/style.css
@@ -576,6 +576,40 @@ body {
     gap: 12px;
 }
 
+.output-logs-section {
+    margin-top: 0;
+    margin-bottom: 24px;
+}
+
+.output-logs-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.output-log-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 34px;
+    padding: 7px 10px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: 0.82rem;
+}
+
+.output-log-item:hover {
+    border-color: var(--accent-blue);
+}
+
+.output-log-source {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
 /* ========================================
    Task Header
    ======================================== */

--- a/browseruse_bench/visualization/generate_index.py
+++ b/browseruse_bench/visualization/generate_index.py
@@ -26,7 +26,6 @@ Usage:
 """
 
 import json
-import os
 import re
 import statistics
 import sys
@@ -207,6 +206,61 @@ def task_rubrics() -> Dict[str, Dict]:
 
 def _natural_sort_key(s: str):
     return [int(c) if c.isdigit() else c.lower() for c in re.split(r"(\d+)", s)]
+
+
+def _relative_repo_path(path: Path) -> Optional[str]:
+    if REPO_ROOT is None:
+        return None
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return None
+
+
+def _collect_run_output_logs(timestamp_dir: Path) -> List[Dict[str, str]]:
+    """Collect run-level logs that should be visible with an experiment."""
+    if REPO_ROOT is None:
+        return []
+
+    candidates: List[tuple[str, Path]] = []
+
+    for path in (timestamp_dir / "run.log", timestamp_dir / "eval.log"):
+        if path.is_file():
+            candidates.append(("experiment", path))
+
+    logs_dir = timestamp_dir / "logs"
+    if logs_dir.is_dir():
+        for path in sorted(logs_dir.glob("*.log"), key=lambda p: _natural_sort_key(p.name)):
+            if path.is_file():
+                candidates.append(("experiment", path))
+
+    eval_log = timestamp_dir / "tasks_eval_result" / "eval.log"
+    if eval_log.is_file():
+        candidates.append(("experiment", eval_log))
+
+    output_logs_dir = REPO_ROOT / "output" / "logs"
+    timestamp = timestamp_dir.name
+    if output_logs_dir.is_dir():
+        for category_dir in sorted(output_logs_dir.iterdir(), key=lambda p: _natural_sort_key(p.name)):
+            if not category_dir.is_dir():
+                continue
+            for path in sorted(category_dir.glob(f"*{timestamp}*.log"), key=lambda p: _natural_sort_key(p.name)):
+                if path.is_file():
+                    candidates.append((f"output/{category_dir.name}", path))
+
+    seen: set[str] = set()
+    logs: List[Dict[str, str]] = []
+    for source, path in candidates:
+        rel_path = _relative_repo_path(path)
+        if not rel_path or rel_path in seen:
+            continue
+        seen.add(rel_path)
+        logs.append({
+            "name": path.name,
+            "path": rel_path,
+            "source": source,
+        })
+    return logs
 
 
 # ------------------------------------------------------------------
@@ -450,6 +504,7 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
         "task_ids": task_ids,
         "task_files": task_files,
         "task_meta": task_meta,
+        "output_logs": _collect_run_output_logs(timestamp_dir),
         "path": run_path_rel,
         "eval_data": eval_data,
     }

--- a/browseruse_bench/visualization/index.html
+++ b/browseruse_bench/visualization/index.html
@@ -59,6 +59,14 @@
                 </div>
             </div>
 
+            <!-- Run Output Logs -->
+            <div id="run-output-logs" class="content-section output-logs-section hidden">
+                <div class="section-toolbar">
+                    <div class="section-label">Output Logs</div>
+                </div>
+                <div id="run-output-logs-list" class="output-logs-list"></div>
+            </div>
+
             <!-- Section: Agent Replay -->
             <div id="replay-section" class="content-section hidden">
                 <div class="section-toolbar">

--- a/browseruse_bench/visualization/js/app.js
+++ b/browseruse_bench/visualization/js/app.js
@@ -371,6 +371,7 @@ class BrowserAgentAnalyzer {
         document.getElementById('task-header').classList.add('hidden');
         document.getElementById('replay-section').classList.add('hidden');
         document.getElementById('eval-panel').classList.add('hidden');
+        document.getElementById('run-output-logs').classList.add('hidden');
 
         // Show tasks sidebar for experiment set tasks
         document.getElementById('sidebar-right').classList.remove('hidden');
@@ -945,6 +946,7 @@ class BrowserAgentAnalyzer {
         this.populateTasksList(document.getElementById('task-search').value);
         const run = dataLoader.getRuns().find(r => r.uuid === uuid);
         if (run) document.getElementById('current-run-badge').textContent = run.displayName;
+        this.renderRunOutputLogs(run);
 
         if (this.currentTask) {
             // Re-highlight the task in the refreshed list
@@ -973,6 +975,7 @@ class BrowserAgentAnalyzer {
                 this.currentRun = runs[0].uuid;
                 document.querySelector('.run-item')?.classList.add('active');
                 document.getElementById('current-run-badge').textContent = runs[0].displayName;
+                this.renderRunOutputLogs(runs[0]);
                 document.getElementById('sidebar-right').classList.remove('hidden');
                 this.populateTasksList(document.getElementById('task-search').value);
             }
@@ -1011,6 +1014,33 @@ class BrowserAgentAnalyzer {
         document.getElementById('task-description').textContent = d.task || '';
         this.renderTaskStatusBadge(String(d.task_id));
         this.renderTaskJudgeSummary(String(d.task_id));
+    }
+
+    renderRunOutputLogs(run) {
+        const section = document.getElementById('run-output-logs');
+        const container = document.getElementById('run-output-logs-list');
+        const logs = run?.outputLogs || [];
+
+        if (logs.length === 0) {
+            section.classList.add('hidden');
+            container.innerHTML = '';
+            return;
+        }
+
+        section.classList.remove('hidden');
+        container.innerHTML = logs.map((log, index) => `
+            <button class="output-log-item" data-log-index="${index}">
+                <span class="output-log-name">${this.escapeHtml(log.name || 'log')}</span>
+                <span class="output-log-source">${this.escapeHtml(log.source || '')}</span>
+            </button>
+        `).join('');
+
+        container.querySelectorAll('.output-log-item').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const log = logs[parseInt(btn.dataset.logIndex, 10)];
+                this.showOutputLogModal(log);
+            });
+        });
     }
 
     renderTaskStatusBadge(taskId) {
@@ -1452,6 +1482,7 @@ class BrowserAgentAnalyzer {
 
         const modal = document.getElementById('api-log-modal');
         modal.classList.remove('hidden');
+        modal.querySelector('.conversation-tabs').classList.remove('hidden');
         document.getElementById('modal-title').textContent = `API Log - Step ${stepNumber}`;
 
         // Prepare parsed data bundle
@@ -1474,6 +1505,26 @@ class BrowserAgentAnalyzer {
         modal.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
         modal.querySelector('.tab-btn').classList.add('active');
         this.renderApiLogTab(bundle, 'memory');
+    }
+
+    async showOutputLogModal(log) {
+        if (!log?.path) return;
+        const text = await dataLoader.loadTextFile(log.path);
+        if (text === null) {
+            this.showError(`Failed to load output log: ${log.name || log.path}`);
+            return;
+        }
+
+        const modal = document.getElementById('api-log-modal');
+        modal.classList.remove('hidden');
+        modal.querySelector('.conversation-tabs').classList.add('hidden');
+        document.getElementById('modal-title').textContent = `Output Log - ${log.name || 'log'}`;
+        document.getElementById('conversation-content').innerHTML = `
+            <div class="conv-section">
+                <h4>${this.escapeHtml(log.source || '')}</h4>
+                <pre>${this.escapeHtml(text)}</pre>
+            </div>
+        `;
     }
 
     renderApiLogTab(bundle, tab) {
@@ -1822,6 +1873,7 @@ class BrowserAgentAnalyzer {
         document.getElementById('stats-view').classList.add('hidden');
         document.getElementById('btn-stats').classList.remove('active');
         document.getElementById('exp-set-view').classList.add('hidden');
+        document.getElementById('run-output-logs').classList.add('hidden');
 
         // Show welcome
         document.getElementById('welcome-screen').classList.remove('hidden');

--- a/browseruse_bench/visualization/js/data-loader.js
+++ b/browseruse_bench/visualization/js/data-loader.js
@@ -20,6 +20,7 @@ class DataLoader {
         this.cache = new Map();
         this.apiLogCache = new Map();
         this.systemPromptCache = new Map();
+        this.textFileCache = new Map();
         this.judgeModes = [
             { value: 'lexjudge_per_task', label: 'LexJudge / Per-task threshold' },
             { value: 'lexjudge_fixed_60', label: 'LexJudge / Fixed 60' },
@@ -72,6 +73,7 @@ class DataLoader {
             config: run.config,
             stats: this.getRunStats(run, judgeMode),
             path: run.path,
+            outputLogs: run.output_logs || [],
             evalMode: run.eval_data?.summary?.evaluation_config?.mode || null,
             displayName: this.getRunDisplayName(run)
         }));
@@ -458,6 +460,21 @@ class DataLoader {
             if (!response.ok) return null;
             const text = await response.text();
             this.systemPromptCache.set(url, text);
+            return text;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    async loadTextFile(path) {
+        if (this.textFileCache.has(path)) {
+            return this.textFileCache.get(path);
+        }
+        try {
+            const response = await fetch(path);
+            if (!response.ok) return null;
+            const text = await response.text();
+            this.textFileCache.set(path, text);
             return text;
         } catch (e) {
             return null;

--- a/browseruse_bench/visualization/serve.py
+++ b/browseruse_bench/visualization/serve.py
@@ -122,17 +122,20 @@ class AnalyzerHandler(SimpleHTTPRequestHandler):
     """Extends SimpleHTTPRequestHandler with API endpoints."""
 
     def translate_path(self, path):
-        # Map /experiments/... requests directly to REPO_ROOT/experiments/
-        # so no symlink is needed inside the package directory.
+        # Map repo-owned artifact directories directly so no symlink is needed
+        # inside the package directory.
         p = posixpath.normpath(urllib.parse.unquote(path.split('?', 1)[0].split('#', 1)[0]))
-        if p == '/experiments' or p.startswith('/experiments/'):
-            rel = p[len('/experiments'):]
-            exp_root = (REPO_ROOT / 'experiments').resolve()
-            final = Path(str(exp_root) + rel).resolve()
+        for prefix in ('experiments', 'output'):
+            route = f'/{prefix}'
+            if p != route and not p.startswith(f'{route}/'):
+                continue
+            rel = p[len(route):]
+            artifact_root = (REPO_ROOT / prefix).resolve()
+            final = Path(str(artifact_root) + rel).resolve()
             # Defense-in-depth: even after normpath, make sure the resolved
-            # path is still confined to REPO_ROOT/experiments/. Fall back to
-            # SCRIPT_DIR (which has no matching file) to produce a 404.
-            if final != exp_root and not final.is_relative_to(exp_root):
+            # path is still confined to the intended artifact directory. Fall
+            # back to SCRIPT_DIR (which has no matching file) to produce a 404.
+            if final != artifact_root and not final.is_relative_to(artifact_root):
                 return str(SCRIPT_DIR)
             return str(final)
         return super().translate_path(path)
@@ -246,7 +249,7 @@ def run_server(
         print(f"  Network access      → http://{host}:{port}")
     print(f"  Bind: {host}:{port}")
     print(f"  Watch mode: {'ON' if watch else 'OFF'}")
-    print(f"  Press Ctrl+C to stop\n")
+    print("  Press Ctrl+C to stop\n")
 
     try:
         server.serve_forever()

--- a/tests/browseruse_bench/test_run_manifest.py
+++ b/tests/browseruse_bench/test_run_manifest.py
@@ -11,29 +11,44 @@ from browseruse_bench.cli.run import _write_run_manifest
 def test_write_run_manifest_redacts_secrets(tmp_path: Path) -> None:
     _write_run_manifest(
         tmp_path,
-        agent_config={
-            "models": {
-                "gpt": {
-                    "api_key": "sk-test",
-                    "base_url": "https://gateway.example/v1",
-                }
-            },
-            "lexmount_api_key": "lexmount-secret",
+        resolved_agent_config={
+            "use_vision": False,
+            "max_steps": 3,
+            "model_id": "gpt-5.4",
+            "api_key": "resolved-secret",
+            "base_url": "https://gateway.example/v1",
+            "browserbase_api_key": "resolved-bb-secret",
+            "browserbase_project_id": "project-1",
             "headers": [{"Authorization": "Bearer token-secret"}],
             "empty_api_key": "",
             "max_tokens": 1000,
             "max_output_tokens": 4000,
             "hf_token": "hf-secret",
         },
+        run_context={
+            "agent": "browser-use",
+            "benchmark": "LexBench-Browser",
+            "model_id": "gpt-5.4",
+        },
     )
 
     snapshot = json.loads((tmp_path / "config_snapshot.json").read_text(encoding="utf-8"))
 
-    assert snapshot["models"]["gpt"]["api_key"] == "<redacted>"
-    assert snapshot["models"]["gpt"]["base_url"] == "https://gateway.example/v1"
-    assert snapshot["lexmount_api_key"] == "<redacted>"
-    assert snapshot["headers"][0]["Authorization"] == "<redacted>"
-    assert snapshot["empty_api_key"] == ""
-    assert snapshot["max_tokens"] == 1000
-    assert snapshot["max_output_tokens"] == 4000
-    assert snapshot["hf_token"] == "<redacted>"
+    assert sorted(snapshot.keys()) == ["run", "runtime_config"]
+    assert "models" not in snapshot
+    assert "browsers" not in snapshot
+    assert "agents" not in snapshot
+    assert snapshot["run"]["agent"] == "browser-use"
+    assert snapshot["run"]["benchmark"] == "LexBench-Browser"
+    assert snapshot["runtime_config"]["use_vision"] is False
+    assert snapshot["runtime_config"]["max_steps"] == 3
+    assert snapshot["runtime_config"]["model_id"] == "gpt-5.4"
+    assert snapshot["runtime_config"]["api_key"] == "<redacted>"
+    assert snapshot["runtime_config"]["base_url"] == "https://gateway.example/v1"
+    assert snapshot["runtime_config"]["browserbase_api_key"] == "<redacted>"
+    assert snapshot["runtime_config"]["browserbase_project_id"] == "project-1"
+    assert snapshot["runtime_config"]["headers"][0]["Authorization"] == "<redacted>"
+    assert snapshot["runtime_config"]["empty_api_key"] == ""
+    assert snapshot["runtime_config"]["max_tokens"] == 1000
+    assert snapshot["runtime_config"]["max_output_tokens"] == 4000
+    assert snapshot["runtime_config"]["hf_token"] == "<redacted>"

--- a/tests/browseruse_bench/test_visualization_generate_index.py
+++ b/tests/browseruse_bench/test_visualization_generate_index.py
@@ -118,6 +118,29 @@ class TestScanRunModelField:
         assert result is not None
         assert result["stats"]["avg_steps"] == 0
 
+    def test_scan_run_includes_experiment_and_output_logs(self, tmp_path, patch_repo_root):
+        run_dir = make_run_dir(tmp_path)
+        (run_dir / "run.log").write_text("experiment run log", encoding="utf-8")
+        output_log_dir = tmp_path / "output" / "logs" / "run"
+        output_log_dir.mkdir(parents=True)
+        (output_log_dir / "20260101_120000.log").write_text("outer run log", encoding="utf-8")
+
+        result = gi.scan_run("bench", "split", "agent", run_dir)
+
+        assert result is not None
+        assert result["output_logs"] == [
+            {
+                "name": "run.log",
+                "path": "20260101_120000/run.log",
+                "source": "experiment",
+            },
+            {
+                "name": "20260101_120000.log",
+                "path": "output/logs/run/20260101_120000.log",
+                "source": "output/run",
+            },
+        ]
+
 
 class TestRepoRootMissing:
     """Regression: import must succeed and generate_index() must fail cleanly when REPO_ROOT is unresolved."""

--- a/tests/browseruse_bench/test_visualization_serve.py
+++ b/tests/browseruse_bench/test_visualization_serve.py
@@ -44,6 +44,10 @@ class TestTranslatePath:
         result = self._translate("/experiments/bench/agent/task/screenshot.png")
         assert result == str(self.repo_root / "experiments") + "/bench/agent/task/screenshot.png"
 
+    def test_output_subpath(self):
+        result = self._translate("/output/logs/run/20260101_120000.log")
+        assert result == str(self.repo_root / "output") + "/logs/run/20260101_120000.log"
+
     def test_experiments_with_query_string(self):
         result = self._translate("/experiments/foo.png?v=1")
         assert result == str(self.repo_root / "experiments") + "/foo.png"
@@ -62,6 +66,10 @@ class TestTranslatePath:
         result = self._translate("/experiments_extra/foo")
         assert result != str(self.repo_root / "experiments") + "_extra/foo"
         assert not result.startswith(str(self.repo_root / "experiments") + "/")
+
+        result = self._translate("/output_extra/foo")
+        assert result != str(self.repo_root / "output") + "_extra/foo"
+        assert not result.startswith(str(self.repo_root / "output") + "/")
 
     def test_non_experiments_path_falls_through(self):
         # /index.html should be served from SCRIPT_DIR, not from experiments


### PR DESCRIPTION
## Summary
- write experiment-local run.log for real bubench runs
- index and display run-level output logs in the visualization UI
- limit config_snapshot.json to the actual run metadata and resolved runtime config
- keep submit's optional lexbench_sdk dependency from breaking other CLI imports

## Tests
- uv run pytest tests/browseruse_bench/test_run_manifest.py tests/browseruse_bench/test_visualization_generate_index.py tests/browseruse_bench/test_visualization_serve.py tests/browseruse_bench/test_cli.py
- uv run ruff check --select F,E9 browseruse_bench/cli/__init__.py browseruse_bench/cli/run.py browseruse_bench/visualization/generate_index.py browseruse_bench/visualization/serve.py tests/browseruse_bench/test_run_manifest.py tests/browseruse_bench/test_visualization_generate_index.py tests/browseruse_bench/test_visualization_serve.py