### PR TITLE
[codex] Add browser-use JSON parsing fallback

### DIFF
--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -88,11 +88,21 @@ def _raw_decode_json_candidate(text: str) -> Any | None:
     return next(_iter_json_candidates(text), None)
 
 
-def _validate_json_candidates(output_model: type[Any], candidates: Iterator[Any]) -> Any:
+def _validate_json_candidates(
+    output_model: type[Any],
+    candidates: Iterator[Any],
+    *validation_args: Any,
+    **validation_kwargs: Any,
+) -> Any:
     validation_error: Exception | None = None
     for candidate in candidates:
         try:
-            return _validate_extracted_json(output_model, candidate)
+            return _validate_extracted_json(
+                output_model,
+                candidate,
+                *validation_args,
+                **validation_kwargs,
+            )
         except Exception as exc:
             validation_error = exc
             continue
@@ -101,9 +111,14 @@ def _validate_json_candidates(output_model: type[Any], candidates: Iterator[Any]
     return None
 
 
-def _validate_extracted_json(output_model: type[Any], parsed: Any) -> Any:
+def _validate_extracted_json(
+    output_model: type[Any],
+    parsed: Any,
+    *validation_args: Any,
+    **validation_kwargs: Any,
+) -> Any:
     try:
-        return output_model.model_validate(parsed)
+        return output_model.model_validate(parsed, *validation_args, **validation_kwargs)
     except Exception:
         if isinstance(parsed, dict):
             for key in ("AgentOutput", "agent_output", "arguments", "input"):
@@ -112,7 +127,11 @@ def _validate_extracted_json(output_model: type[Any], parsed: Any) -> Any:
                     value = _raw_decode_json_candidate(value)
                 if isinstance(value, dict):
                     try:
-                        return output_model.model_validate(value)
+                        return output_model.model_validate(
+                            value,
+                            *validation_args,
+                            **validation_kwargs,
+                        )
                     except Exception:
                         continue
         raise
@@ -131,7 +150,12 @@ def _patch_output_model_json_parser(output_model: type[Any] | None) -> None:
         except Exception:
             if not isinstance(json_data, str):
                 raise
-            parsed = _validate_json_candidates(cls, _iter_json_candidates(json_data))
+            parsed = _validate_json_candidates(
+                cls,
+                _iter_json_candidates(json_data),
+                *args,
+                **kwargs,
+            )
             if parsed is None:
                 raise
             return parsed

--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import tempfile
 import time
 from collections.abc import Callable, Iterator
@@ -27,6 +28,7 @@ from browser_use import ChatGoogle as BrowserUseSDKChatGoogle
 from browser_use import ChatOpenAI as BrowserUseSDKChatOpenAI
 from browser_use.browser import session as browser_use_session_module
 from browser_use.browser.profile import ProxySettings as BrowserUseProxySettings
+from pydantic import BaseModel as _PydanticBaseModel
 
 from browseruse_bench.agents.base import BaseAgent
 from browseruse_bench.agents.registry import register_agent
@@ -49,6 +51,108 @@ _BROWSER_USE_CDP_CONNECT_TIMEOUT_LABEL = f"{BROWSER_USE_CDP_CONNECT_TIMEOUT_SECO
 
 
 _MAX_STEPS_ERROR = "Failed to complete task in maximum steps"
+_JSON_FENCE_RE = re.compile(r"```(?:json|JSON)?\s*(.*?)```", re.DOTALL)
+_PATCHED_MODEL_VALIDATE_JSON_ATTR = "_browseruse_bench_robust_json_patched"
+
+
+def _iter_json_candidates(text: str) -> Iterator[Any]:
+    decoder = json.JSONDecoder()
+    stripped = text.strip()
+    if not stripped:
+        return
+
+    try:
+        yield json.loads(stripped)
+        return
+    except json.JSONDecodeError:
+        pass
+
+    for match in _JSON_FENCE_RE.finditer(stripped):
+        fenced = match.group(1).strip()
+        try:
+            yield json.loads(fenced)
+        except json.JSONDecodeError:
+            yield from _iter_json_candidates(fenced)
+
+    for index, char in enumerate(stripped):
+        if char not in "{[":
+            continue
+        try:
+            candidate, _ = decoder.raw_decode(stripped[index:])
+            yield candidate
+        except json.JSONDecodeError:
+            continue
+
+
+def _raw_decode_json_candidate(text: str) -> Any | None:
+    return next(_iter_json_candidates(text), None)
+
+
+def _validate_json_candidates(output_model: type[Any], candidates: Iterator[Any]) -> Any:
+    validation_error: Exception | None = None
+    for candidate in candidates:
+        try:
+            return _validate_extracted_json(output_model, candidate)
+        except Exception as exc:
+            validation_error = exc
+            continue
+    if validation_error is not None:
+        raise validation_error
+    return None
+
+
+def _validate_extracted_json(output_model: type[Any], parsed: Any) -> Any:
+    try:
+        return output_model.model_validate(parsed)
+    except Exception:
+        if isinstance(parsed, dict):
+            for key in ("AgentOutput", "agent_output", "arguments", "input"):
+                value = parsed.get(key)
+                if isinstance(value, str):
+                    value = _raw_decode_json_candidate(value)
+                if isinstance(value, dict):
+                    try:
+                        return output_model.model_validate(value)
+                    except Exception:
+                        continue
+        raise
+
+
+def _patch_output_model_json_parser(output_model: type[Any] | None) -> None:
+    if output_model is None or _PATCHED_MODEL_VALIDATE_JSON_ATTR in output_model.__dict__:
+        return
+
+    original_validate_json = output_model.model_validate_json.__func__
+
+    @classmethod
+    def robust_model_validate_json(cls: type[Any], json_data: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return original_validate_json(cls, json_data, *args, **kwargs)
+        except Exception:
+            if not isinstance(json_data, str):
+                raise
+            parsed = _validate_json_candidates(cls, _iter_json_candidates(json_data))
+            if parsed is None:
+                raise
+            return parsed
+
+    output_model.model_validate_json = robust_model_validate_json  # type: ignore[method-assign]
+    setattr(output_model, _PATCHED_MODEL_VALIDATE_JSON_ATTR, True)
+
+
+def _iter_output_model_bases(model: type[Any] | None) -> Iterator[type[Any]]:
+    if model is None:
+        return
+    for klass in getattr(model, "__mro__", ()):
+        if klass is _PydanticBaseModel or klass is object:
+            break
+        yield klass
+
+
+def _patch_agent_output_json_parsers(agent: Any) -> None:
+    for attr in ("AgentOutput", "DoneAgentOutput"):
+        for model in _iter_output_model_bases(getattr(agent, attr, None)):
+            _patch_output_model_json_parser(model)
 
 
 def _get_config_value(agent_config: dict[str, Any], *keys: str, default: Any = None) -> Any:
@@ -294,6 +398,7 @@ class BrowserUseAgent(BaseAgent):
                 use_vision=use_vision,
                 use_judge=_get_config_value(agent_config, "use_judge", "USE_JUDGE", default=False),
             )
+            _patch_agent_output_json_parsers(agent)
 
             history = await asyncio.wait_for(agent.run(max_steps=max_steps), timeout=timeout)
         except TimeoutError:

--- a/tests/browseruse_bench/test_browser_use_agent.py
+++ b/tests/browseruse_bench/test_browser_use_agent.py
@@ -162,6 +162,10 @@ class _OutputForParserTest(BaseModel):
     action: list[dict[str, Any]]
 
 
+class _OutputForValidationKwargsTest(BaseModel):
+    count: int
+
+
 def test_patch_output_model_json_parser_accepts_markdown_fence() -> None:
     browser_use_module._patch_output_model_json_parser(_OutputForParserTest)
 
@@ -209,6 +213,31 @@ def test_patch_output_model_json_parser_still_rejects_schema_mismatch() -> None:
 
     with pytest.raises(ValidationError):
         _OutputForParserTest.model_validate_json('{"memory": "missing action"}')
+
+
+def test_patch_output_model_json_parser_preserves_validation_kwargs() -> None:
+    browser_use_module._patch_output_model_json_parser(_OutputForValidationKwargsTest)
+
+    with pytest.raises(ValidationError):
+        _OutputForValidationKwargsTest.model_validate_json('prefix {"count": "1"}', strict=True)
+
+    parsed = _OutputForValidationKwargsTest.model_validate_json('prefix {"count": "1"}')
+    assert parsed.count == 1
+
+
+def test_patch_output_model_json_parser_preserves_validation_kwargs_for_wrapped_json() -> None:
+    browser_use_module._patch_output_model_json_parser(_OutputForValidationKwargsTest)
+
+    with pytest.raises(ValidationError):
+        _OutputForValidationKwargsTest.model_validate_json(
+            '{"arguments": "{\\"count\\": \\"1\\"}"}',
+            strict=True,
+        )
+
+    parsed = _OutputForValidationKwargsTest.model_validate_json(
+        '{"arguments": "{\\"count\\": \\"1\\"}"}'
+    )
+    assert parsed.count == 1
 
 
 def test_create_browser_instance_rejects_cloud_transport_for_unknown_backend() -> None:

--- a/tests/browseruse_bench/test_browser_use_agent.py
+++ b/tests/browseruse_bench/test_browser_use_agent.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from browseruse_bench.agents import browser_use as browser_use_module
 from browseruse_bench.agents.browser_use import BrowserUseAgent
@@ -154,6 +155,60 @@ def test_browser_use_browser_rewrites_sdk_cdp_timeout_message(
 
     with pytest.raises(RuntimeError, match="timed out after 30s"):
         asyncio.run(browser.start())
+
+
+class _OutputForParserTest(BaseModel):
+    memory: str
+    action: list[dict[str, Any]]
+
+
+def test_patch_output_model_json_parser_accepts_markdown_fence() -> None:
+    browser_use_module._patch_output_model_json_parser(_OutputForParserTest)
+
+    parsed = _OutputForParserTest.model_validate_json(
+        '```json\n{"memory": "ok", "action": [{"wait": {"seconds": 5}}]}\n```'
+    )
+
+    assert parsed.memory == "ok"
+    assert parsed.action == [{"wait": {"seconds": 5}}]
+
+
+def test_patch_output_model_json_parser_accepts_natural_language_prefix() -> None:
+    browser_use_module._patch_output_model_json_parser(_OutputForParserTest)
+
+    parsed = _OutputForParserTest.model_validate_json(
+        'The page is still loading.\n{"memory": "loaded", "action": [{"wait": {"seconds": 3}}]}'
+    )
+
+    assert parsed.memory == "loaded"
+
+
+def test_patch_output_model_json_parser_accepts_trailing_text() -> None:
+    browser_use_module._patch_output_model_json_parser(_OutputForParserTest)
+
+    parsed = _OutputForParserTest.model_validate_json(
+        '{"memory": "done", "action": [{"done": {"text": "ok"}}]}\nExtra explanation.'
+    )
+
+    assert parsed.action == [{"done": {"text": "ok"}}]
+
+
+def test_patch_output_model_json_parser_skips_non_matching_json_candidate() -> None:
+    browser_use_module._patch_output_model_json_parser(_OutputForParserTest)
+
+    parsed = _OutputForParserTest.model_validate_json(
+        'I observed {"not": "agent output"} before deciding.\n'
+        '{"memory": "chosen", "action": [{"wait": {"seconds": 1}}]}'
+    )
+
+    assert parsed.memory == "chosen"
+
+
+def test_patch_output_model_json_parser_still_rejects_schema_mismatch() -> None:
+    browser_use_module._patch_output_model_json_parser(_OutputForParserTest)
+
+    with pytest.raises(ValidationError):
+        _OutputForParserTest.model_validate_json('{"memory": "missing action"}')
 
 
 def test_create_browser_instance_rejects_cloud_transport_for_unknown_backend() -> None:


### PR DESCRIPTION
## Summary

- Add a robust JSON parsing fallback for browser-use AgentOutput validation.
- Accept clean JSON, fenced JSON, and JSON embedded in natural-language model output.
- Keep Pydantic schema validation strict so malformed or schema-mismatched outputs still fail.
- Add focused tests for fenced JSON, natural-language prefixes, trailing text, candidate skipping, and schema mismatch rejection.

## Validation

- `git diff --cached --check`
- `python3 -m compileall -q browseruse_bench/agents/browser_use.py tests/browseruse_bench/test_browser_use_agent.py`
- Parser smoke test with stubbed browser-use SDK passed locally.

Note: full pytest was not run because this machine lacks the project uv environment; system Python 3.8 cannot import enum.StrEnum and Python 3.11 has no pytest installed.
