### PR TITLE
Case-insensitive CLI selector parameters (--data, --agent, --model, --browser-id, --split, --model-id)

### DIFF
--- a/browseruse_bench/browsers/registry.py
+++ b/browseruse_bench/browsers/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from browseruse_bench.browsers.base import BrowserBackend
+from browseruse_bench.utils.config_loader import resolve_key_case_insensitive
 
 _BACKEND_FACTORIES: dict[str, Callable[[], BrowserBackend]] = {}
 _DEFAULTS_REGISTERED = False
@@ -80,9 +81,18 @@ def _register_default_backends() -> None:
     _DEFAULTS_REGISTERED = True
 
 
+def canonical_browser_id(browser_id: str) -> str:
+    """Return the registered backend id matching *browser_id* case-insensitively.
+
+    Falls back to the original *browser_id* when no backend matches.
+    """
+    _register_default_backends()
+    return resolve_key_case_insensitive(browser_id, _BACKEND_FACTORIES)
+
+
 def get_backend(browser_id: str) -> BrowserBackend:
     _register_default_backends()
-    factory = _BACKEND_FACTORIES.get(browser_id)
+    factory = _BACKEND_FACTORIES.get(canonical_browser_id(browser_id))
     if factory is None:
         available = ", ".join(sorted(_BACKEND_FACTORIES.keys()))
         raise ValueError(f"Unknown browser backend: '{browser_id}'. Available: {available}")

--- a/browseruse_bench/cli/eval.py
+++ b/browseruse_bench/cli/eval.py
@@ -17,17 +17,19 @@ from browseruse_bench.utils import (
     add_eval_args,
     classify_failures_batch,
     find_latest_tasks_dir,
-    get_default_split,
     get_env_var,
     handle_cli_errors,
     load_config_file,
     load_data_info,
     load_env_file,
     load_evaluation_model,
+    normalize_agent_name,
     normalize_benchmark_name,
     normalized_results_file,
     resolve_agent_inline_config,
+    resolve_dir_name_case_insensitive,
     resolve_output_model_id,
+    resolve_split,
     setup_logger,
 )
 
@@ -195,8 +197,7 @@ def run_evaluation(
     # Resolve split (use default if not specified)
     benchmark_path = _benchmark_data_dir(benchmark_name)
     data_info = load_data_info(benchmark_path)
-    if not args.split:
-        args.split = get_default_split(data_info) or "All"
+    args.split = resolve_split(args.split, data_info)
 
     if not args.model_id:
         inline_cfg = resolve_agent_inline_config(agent_name, config)
@@ -212,6 +213,7 @@ def run_evaluation(
 
     # Path structure: experiments/{benchmark}/{split}/{agent}/{model_id}
     output_base = _experiments_root(benchmark_name) / args.split
+    args.model_id = resolve_dir_name_case_insensitive(args.model_id, output_base / agent_name)
     agent_output_dir = output_base / agent_name / args.model_id
 
     if args.timestamp:
@@ -396,8 +398,9 @@ def configure_eval_parser(parser: argparse.ArgumentParser, config: Dict[str, Any
 def eval_command(args: argparse.Namespace, config: Dict[str, Any]) -> int:
     """Entry point for the eval subcommand."""
     extra_args = getattr(args, "extra_args", [])
+    agent_name = normalize_agent_name(args.agent, config)
     benchmark_name = normalize_benchmark_name(args.data)
-    return run_evaluation(args.agent, benchmark_name, config, args, extra_args)
+    return run_evaluation(agent_name, benchmark_name, config, args, extra_args)
 
 
 @handle_cli_errors

--- a/browseruse_bench/cli/eval.py
+++ b/browseruse_bench/cli/eval.py
@@ -24,6 +24,7 @@ from browseruse_bench.utils import (
     load_data_info,
     load_env_file,
     load_evaluation_model,
+    normalize_benchmark_name,
     normalized_results_file,
     resolve_agent_inline_config,
     resolve_output_model_id,
@@ -395,7 +396,8 @@ def configure_eval_parser(parser: argparse.ArgumentParser, config: Dict[str, Any
 def eval_command(args: argparse.Namespace, config: Dict[str, Any]) -> int:
     """Entry point for the eval subcommand."""
     extra_args = getattr(args, "extra_args", [])
-    return run_evaluation(args.agent, args.data, config, args, extra_args)
+    benchmark_name = normalize_benchmark_name(args.data)
+    return run_evaluation(args.agent, benchmark_name, config, args, extra_args)
 
 
 @handle_cli_errors

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -48,6 +48,7 @@ from browseruse_bench.utils import (
     load_dataset_file,
     load_env_file,
     load_tasks_with_benchmark_support,
+    normalize_benchmark_name,
     resolve_agent_entry,
     resolve_agent_inline_config,
     resolve_agent_venv_path,
@@ -965,7 +966,8 @@ def run_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
             f"Hint: Configure {model_hint} in that file."
         )
     args._inline_agent_config = inline
-    return run_agent(args.agent, args.data, config, args)
+    benchmark_name = normalize_benchmark_name(args.data)
+    return run_agent(args.agent, benchmark_name, config, args)
 
 
 @handle_cli_errors

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -939,12 +939,22 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
     return 0 if failed_count == 0 else 1
 
 
+def _canonicalize_cli_browser_id(browser_id: str | None, source_cfg: dict[str, Any]) -> str | None:
+    """Canonicalize --browser-id to the registered backend id.
+
+    An exact key of the config's browsers section wins — even one shadowing a
+    backend id with different casing — so the inline-config exact-match
+    preference is never bypassed.
+    """
+    if not browser_id or browser_id in (source_cfg.get("browsers") or {}):
+        return browser_id
+    return canonical_browser_id(browser_id)
+
+
 def run_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
     """Entry point for the run subcommand."""
     logger.info("Starting run command")
     args.agent = normalize_agent_name(args.agent, config)
-    if args.browser_id:
-        args.browser_id = canonical_browser_id(args.browser_id)
     source_cfg = config
     source_label = "root config.yaml"
     if args.agent_config is not None:
@@ -955,6 +965,8 @@ def run_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
             raise SystemExit(f"[FAILED] --agent-config file not found: {cfg_path}")
         source_cfg = load_config_file(cfg_path)
         source_label = str(cfg_path)
+
+    args.browser_id = _canonicalize_cli_browser_id(args.browser_id, source_cfg)
 
     # --agent-config only overrides the inline runtime config (models/browsers/agents defaults).
     # Benchmark definitions and the agent registry keep coming from the root config,

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -25,6 +25,7 @@ from browseruse_bench.browsers.providers.lexmount import (
     LOGIN_CONTEXT_ID_ENV_KEY,
     normalize_profile_keys,
 )
+from browseruse_bench.browsers.registry import canonical_browser_id
 from browseruse_bench.browsers.session_state import SESSION_STATE_ENV_KEY
 from browseruse_bench.utils import (
     IS_WINDOWS,
@@ -48,10 +49,12 @@ from browseruse_bench.utils import (
     load_dataset_file,
     load_env_file,
     load_tasks_with_benchmark_support,
+    normalize_agent_name,
     normalize_benchmark_name,
     resolve_agent_entry,
     resolve_agent_inline_config,
     resolve_agent_venv_path,
+    resolve_split,
     setup_logger,
 )
 
@@ -568,8 +571,7 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
     benchmark_path = REPO_ROOT / "browseruse_bench" / "data" / benchmark_name
     data_info = load_data_info(benchmark_path)
 
-    if not args.split:
-        args.split = get_default_split(data_info) or "All"
+    args.split = resolve_split(args.split, data_info)
 
     # Resolve data file
     data_file = resolve_data_file(benchmark_path, args.split)
@@ -940,6 +942,9 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
 def run_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
     """Entry point for the run subcommand."""
     logger.info("Starting run command")
+    args.agent = normalize_agent_name(args.agent, config)
+    if args.browser_id:
+        args.browser_id = canonical_browser_id(args.browser_id)
     source_cfg = config
     source_label = "root config.yaml"
     if args.agent_config is not None:

--- a/browseruse_bench/cli/submit.py
+++ b/browseruse_bench/cli/submit.py
@@ -14,8 +14,11 @@ from browseruse_bench.utils import (
     REPO_ROOT,
     handle_cli_errors,
     load_config_file,
+    load_data_info,
     load_env_file,
+    normalize_agent_name,
     normalize_benchmark_name,
+    normalize_split_name,
     resolve_agent_inline_config,
     setup_logger,
 )
@@ -647,10 +650,13 @@ def submit_job(
 
 def submit_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
     """Entry point for the submit subcommand."""
-    del config
     logger.info("Starting submit command")
+    agent_name = normalize_agent_name(args.agent, config)
     benchmark_name = normalize_benchmark_name(args.data)
-    return submit_job(args.agent, benchmark_name, args)
+    if args.split:
+        data_info = load_data_info(REPO_ROOT / "browseruse_bench" / "data" / benchmark_name)
+        args.split = normalize_split_name(args.split, data_info)
+    return submit_job(agent_name, benchmark_name, args)
 
 
 @handle_cli_errors

--- a/browseruse_bench/cli/submit.py
+++ b/browseruse_bench/cli/submit.py
@@ -15,6 +15,7 @@ from browseruse_bench.utils import (
     handle_cli_errors,
     load_config_file,
     load_env_file,
+    normalize_benchmark_name,
     resolve_agent_inline_config,
     setup_logger,
 )
@@ -648,7 +649,8 @@ def submit_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
     """Entry point for the submit subcommand."""
     del config
     logger.info("Starting submit command")
-    return submit_job(args.agent, args.data, args)
+    benchmark_name = normalize_benchmark_name(args.data)
+    return submit_job(args.agent, benchmark_name, args)
 
 
 @handle_cli_errors

--- a/browseruse_bench/cli/submit.py
+++ b/browseruse_bench/cli/submit.py
@@ -398,21 +398,25 @@ def _resolve_agent_api_key(agent_name: str, agent_cfg: dict[str, Any]) -> str | 
 
 
 
-def _load_submit_agent_config(agent_name: str, config_path: Path | None) -> dict[str, Any]:
+def _resolve_submit_config_path(config_path: Path | None) -> Path | None:
+    """Resolve the root-config file submit reads: explicit path, cwd, then repo root."""
     if config_path is None:
         cwd_root = Path.cwd() / "config.yaml"
         if cwd_root.exists():
-            config_path = cwd_root
-        else:
-            default_root = REPO_ROOT / "config.yaml"
-            if not default_root.exists():
-                return {}
-            config_path = default_root
-    elif not config_path.is_absolute():
+            return cwd_root
+        default_root = REPO_ROOT / "config.yaml"
+        return default_root if default_root.exists() else None
+    if not config_path.is_absolute():
         config_path = Path.cwd() / config_path
-
     if not config_path.exists():
         raise SystemExit(f"[FAILED] --agent-config file not found: {config_path}")
+    return config_path
+
+
+def _load_submit_agent_config(agent_name: str, config_path: Path | None) -> dict[str, Any]:
+    config_path = _resolve_submit_config_path(config_path)
+    if config_path is None:
+        return {}
 
     config = load_config_file(config_path)
     if not isinstance(config, dict):
@@ -650,8 +654,16 @@ def submit_job(
 
 def submit_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
     """Entry point for the submit subcommand."""
+    del config
     logger.info("Starting submit command")
-    agent_name = normalize_agent_name(args.agent, config)
+    # Normalize against the same config file the job payload is built from
+    # (explicit --agent-config, then cwd, then repo root) so custom agents
+    # defined only in a cwd config.yaml still resolve case-insensitively.
+    submit_config_path = _resolve_submit_config_path(getattr(args, "agent_config", None))
+    submit_config = load_config_file(submit_config_path) if submit_config_path else {}
+    if not isinstance(submit_config, dict):
+        submit_config = {}
+    agent_name = normalize_agent_name(args.agent, submit_config)
     benchmark_name = normalize_benchmark_name(args.data)
     if args.split:
         data_info = load_data_info(REPO_ROOT / "browseruse_bench" / "data" / benchmark_name)

--- a/browseruse_bench/utils/__init__.py
+++ b/browseruse_bench/utils/__init__.py
@@ -27,10 +27,14 @@ from browseruse_bench.utils.config_loader import (
     load_config_file,
     load_data_info,
     load_eval_config,
+    normalize_agent_name,
     normalize_benchmark_name,
+    normalize_split_name,
     resolve_agent_entry,
     resolve_agent_inline_config,
+    resolve_dir_name_case_insensitive,
     resolve_output_model_id,
+    resolve_split,
 )
 from browseruse_bench.utils.constants import (
     BENCHMARKS_DIR,

--- a/browseruse_bench/utils/__init__.py
+++ b/browseruse_bench/utils/__init__.py
@@ -27,6 +27,7 @@ from browseruse_bench.utils.config_loader import (
     load_config_file,
     load_data_info,
     load_eval_config,
+    normalize_benchmark_name,
     resolve_agent_entry,
     resolve_agent_inline_config,
     resolve_output_model_id,

--- a/browseruse_bench/utils/config_loader.py
+++ b/browseruse_bench/utils/config_loader.py
@@ -20,6 +20,7 @@ from browseruse_bench.utils.repo_root import REPO_ROOT
 
 logger = logging.getLogger(__name__)
 _EVAL_STRUCTURAL_KEYS = {"api_key", "base_url"}
+_AGENT_REGISTRY_PATH = REPO_ROOT / "configs" / "agent_registry.yaml"
 
 
 def _skyvern_temp_database_string() -> str:
@@ -141,8 +142,26 @@ def get_default_version(data_info: dict[str, Any]) -> str | None:
     return None
 
 
+def resolve_dir_name_case_insensitive(name: str, parent: Path) -> str:
+    """Return the actual child directory name matching *name* case-insensitively.
+
+    Prefers an exact name match over a case-insensitive one; falls back to the
+    original *name* when *parent* is missing or no directory matches.
+    """
+    if not parent.is_dir():
+        return name
+    entries = [entry.name for entry in parent.iterdir() if entry.is_dir()]
+    if name in entries:
+        return name
+    name_lower = name.lower()
+    for entry_name in entries:
+        if entry_name.lower() == name_lower:
+            return entry_name
+    return name
+
+
 def normalize_benchmark_name(benchmark_name: str) -> str:
-    """Normalize benchmark name to match actual directory in case-insensitive manner.
+    """Normalize benchmark name to the actual dataset directory, case-insensitively.
 
     Args:
         benchmark_name: Benchmark name (case-insensitive).
@@ -150,16 +169,79 @@ def normalize_benchmark_name(benchmark_name: str) -> str:
     Returns:
         str: Canonical benchmark directory name, or original input if not found.
     """
-    data_dir = REPO_ROOT / "browseruse_bench" / "data"
-    if not data_dir.exists():
-        return benchmark_name
+    return resolve_dir_name_case_insensitive(
+        benchmark_name, REPO_ROOT / "browseruse_bench" / "data"
+    )
 
-    benchmark_lower = benchmark_name.lower()
-    for entry in data_dir.iterdir():
-        if entry.is_dir() and entry.name.lower() == benchmark_lower:
-            return entry.name
 
-    return benchmark_name
+def resolve_key_case_insensitive(name: Any, mapping: dict[str, Any]) -> Any:
+    """Return the canonical mapping key matching *name* case-insensitively.
+
+    Prefers an exact key match over a case-insensitive one. Non-string names
+    pass through unchanged (YAML keys can parse as float/bool); falls back to
+    the original *name* when no match is found.
+    """
+    if not isinstance(name, str) or name in mapping:
+        return name
+    name_lower = name.lower()
+    for key in mapping:
+        if isinstance(key, str) and key.lower() == name_lower:
+            return key
+    return name
+
+
+def _select_canonical(name: Any, mapping: Any) -> Any:
+    """Canonicalize a selected config key, tolerating absent selection/mapping."""
+    if not name or not isinstance(mapping, dict):
+        return name
+    return resolve_key_case_insensitive(name, mapping)
+
+
+def normalize_agent_name(agent: str, root_config: dict[str, Any]) -> str:
+    """Normalize agent name to the canonical registry key, case-insensitively.
+
+    The checked-in agent registry defines the canonical casing (it matches the
+    code-registered agent names used by the runner subprocess); the root config
+    ``agents`` keys are the fallback for custom agents.
+
+    Args:
+        agent: Agent name (case-insensitive).
+        root_config: Root configuration dictionary with an ``agents`` section.
+
+    Returns:
+        str: Canonical agent name, or original input if not found.
+    """
+    registry = load_config_file(_AGENT_REGISTRY_PATH)
+    canonical = resolve_key_case_insensitive(agent, registry)
+    if canonical in registry:
+        return canonical
+    return resolve_key_case_insensitive(agent, root_config.get("agents", {}) or {})
+
+
+def normalize_split_name(split: str, data_info: dict[str, Any]) -> str:
+    """Normalize split name to the canonical data_info key, case-insensitively.
+
+    Args:
+        split: Split name (case-insensitive).
+        data_info: Content of data_info.json.
+
+    Returns:
+        str: Canonical split key, or original input if not found.
+    """
+    splits = data_info.get("split")
+    if not isinstance(splits, dict) and "version_split" in data_info:
+        version = get_default_version(data_info)
+        splits = data_info.get("version_split", {}).get(version, {}) if version else {}
+    if not isinstance(splits, dict):
+        return split
+    return resolve_key_case_insensitive(split, splits)
+
+
+def resolve_split(split: str | None, data_info: dict[str, Any]) -> str:
+    """Resolve a user-provided split case-insensitively or fall back to the default."""
+    if split:
+        return normalize_split_name(split, data_info)
+    return get_default_split(data_info) or "All"
 
 
 def get_default_split(data_info: dict[str, Any]) -> str | None:
@@ -212,8 +294,7 @@ def load_agent_registry(agent: str) -> dict[str, Any]:
     Returns:
         Dict[str, Any]: Registry info (venv, path, entrypoint, supported_benchmarks).
     """
-    registry_path = REPO_ROOT / "configs" / "agent_registry.yaml"
-    all_registries = load_config_file(registry_path)
+    all_registries = load_config_file(_AGENT_REGISTRY_PATH)
     return all_registries.get(agent, {})
 
 
@@ -222,11 +303,7 @@ def _resolve_agent_key(agent: str, agents: dict[str, Any]) -> str:
 
     Falls back to the original *agent* string when no match is found.
     """
-    agent_lower = agent.lower()
-    for key in agents:
-        if key.lower() == agent_lower:
-            return key
-    return agent
+    return resolve_key_case_insensitive(agent, agents)
 
 
 def resolve_agent_entry(agent: str, root_config: dict[str, Any]) -> dict[str, Any]:
@@ -294,12 +371,16 @@ def resolve_agent_inline_config(
     shared_models = root_config.get("models", {})
     shared_browsers = root_config.get("browsers", {})
     if isinstance(shared_models, dict) and isinstance(shared_browsers, dict) and shared_models:
-        active_model = model_name or agent_entry.get("active_model") or root_config.get("default", {}).get("model")
-        active_browser = (
+        active_model = _select_canonical(
+            model_name or agent_entry.get("active_model") or root_config.get("default", {}).get("model"),
+            shared_models,
+        )
+        active_browser = _select_canonical(
             browser_id
             or agent_entry.get("active_browser")
             or root_config.get("default", {}).get("browser")
-            or root_config.get("default", {}).get("browser_id")
+            or root_config.get("default", {}).get("browser_id"),
+            shared_browsers,
         )
         if not (active_model and active_model in shared_models):
             return None
@@ -309,8 +390,8 @@ def resolve_agent_inline_config(
             browser_cfg = {"browser_id": active_browser}
         return {**defaults, **model_cfg, **browser_cfg}
 
-    active_model = model_name or agent_entry.get("active_model")
     models = agent_entry.get("models", {})
+    active_model = _select_canonical(model_name or agent_entry.get("active_model"), models)
     if not (active_model and models and active_model in models):
         return None
     browser = agent_entry.get("browser", {})

--- a/browseruse_bench/utils/config_loader.py
+++ b/browseruse_bench/utils/config_loader.py
@@ -141,6 +141,27 @@ def get_default_version(data_info: dict[str, Any]) -> str | None:
     return None
 
 
+def normalize_benchmark_name(benchmark_name: str) -> str:
+    """Normalize benchmark name to match actual directory in case-insensitive manner.
+
+    Args:
+        benchmark_name: Benchmark name (case-insensitive).
+
+    Returns:
+        str: Canonical benchmark directory name, or original input if not found.
+    """
+    data_dir = REPO_ROOT / "browseruse_bench" / "data"
+    if not data_dir.exists():
+        return benchmark_name
+
+    benchmark_lower = benchmark_name.lower()
+    for entry in data_dir.iterdir():
+        if entry.is_dir() and entry.name.lower() == benchmark_lower:
+            return entry.name
+
+    return benchmark_name
+
+
 def get_default_split(data_info: dict[str, Any]) -> str | None:
     """Get default split.
 

--- a/tests/browseruse_bench/test_browsers_registry.py
+++ b/tests/browseruse_bench/test_browsers_registry.py
@@ -1,0 +1,49 @@
+"""Tests for browseruse_bench.browsers.registry backend lookup."""
+
+from __future__ import annotations
+
+import pytest
+
+from browseruse_bench.browsers import registry as browsers_registry
+
+
+@pytest.fixture()
+def fake_backend(monkeypatch: pytest.MonkeyPatch) -> object:
+    """Register a single fake backend without importing provider SDKs."""
+    sentinel = object()
+    monkeypatch.setattr(
+        browsers_registry, "_BACKEND_FACTORIES", {"Chrome-Local": lambda: sentinel}
+    )
+    monkeypatch.setattr(browsers_registry, "_DEFAULTS_REGISTERED", True)
+    return sentinel
+
+
+def test_get_backend_exact_match(fake_backend: object) -> None:
+    assert browsers_registry.get_backend("Chrome-Local") is fake_backend
+
+
+def test_get_backend_case_insensitive_match(fake_backend: object) -> None:
+    assert browsers_registry.get_backend("chrome-local") is fake_backend
+    assert browsers_registry.get_backend("CHROME-LOCAL") is fake_backend
+
+
+def test_get_backend_unknown_raises(fake_backend: object) -> None:
+    with pytest.raises(ValueError, match="Unknown browser backend"):
+        browsers_registry.get_backend("no-such-backend")
+
+
+def test_canonical_browser_id(fake_backend: object) -> None:
+    assert browsers_registry.canonical_browser_id("chrome-local") == "Chrome-Local"
+    assert browsers_registry.canonical_browser_id("Chrome-Local") == "Chrome-Local"
+    assert browsers_registry.canonical_browser_id("no-such-backend") == "no-such-backend"
+
+
+def test_canonical_browser_id_prefers_exact_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        browsers_registry,
+        "_BACKEND_FACTORIES",
+        {"Chrome-Local": lambda: None, "chrome-local": lambda: None},
+    )
+    monkeypatch.setattr(browsers_registry, "_DEFAULTS_REGISTERED", True)
+    assert browsers_registry.canonical_browser_id("chrome-local") == "chrome-local"
+    assert browsers_registry.canonical_browser_id("Chrome-Local") == "Chrome-Local"

--- a/tests/browseruse_bench/test_config_loader.py
+++ b/tests/browseruse_bench/test_config_loader.py
@@ -13,10 +13,18 @@ from browseruse_bench.utils import (
     get_default_version,
     load_config_file,
     load_data_info,
+    normalize_agent_name,
+    normalize_benchmark_name,
+    normalize_split_name,
     resolve_agent_entry,
     resolve_agent_inline_config,
+    resolve_dir_name_case_insensitive,
+    resolve_split,
 )
-from browseruse_bench.utils.config_loader import load_eval_config
+from browseruse_bench.utils.config_loader import (
+    load_eval_config,
+    resolve_key_case_insensitive,
+)
 
 
 class TestLoadConfigFile:
@@ -265,6 +273,120 @@ def test_resolve_agent_inline_config_legacy_browser_override() -> None:
     assert inline["browser_id"] == "browserbase"
     assert inline["lexmount_api_key"] == "$LEXMOUNT_API_KEY"
     assert inline["model_id"] == "gpt-5.4"
+
+
+class TestCaseInsensitiveNormalization:
+    """Tests for case-insensitive CLI parameter normalization."""
+
+    def test_normalize_benchmark_name_matches_directory(self) -> None:
+        assert normalize_benchmark_name("lexbench-browser") == "LexBench-Browser"
+        assert normalize_benchmark_name("ONLINE-MIND2WEB") == "Online-Mind2Web"
+        assert normalize_benchmark_name("LexBench-Browser") == "LexBench-Browser"
+
+    def test_normalize_benchmark_name_unknown_passthrough(self) -> None:
+        assert normalize_benchmark_name("no-such-benchmark") == "no-such-benchmark"
+
+    def test_resolve_key_case_insensitive_prefers_exact_match(self) -> None:
+        assert resolve_key_case_insensitive("gpt", {"GPT": 1, "gpt": 2}) == "gpt"
+        assert resolve_key_case_insensitive("GPT", {"GPT": 1, "gpt": 2}) == "GPT"
+
+    def test_resolve_key_case_insensitive_non_string_passthrough(self) -> None:
+        # YAML can parse unquoted keys/values as float or bool; never crash on them.
+        assert resolve_key_case_insensitive(4.1, {4.1: {}}) == 4.1
+        assert resolve_key_case_insensitive(True, {"gpt": {}}) is True
+
+    def test_resolve_dir_name_case_insensitive(self, tmp_path: Path) -> None:
+        (tmp_path / "GPT-5.4").mkdir()
+        assert resolve_dir_name_case_insensitive("gpt-5.4", tmp_path) == "GPT-5.4"
+        assert resolve_dir_name_case_insensitive("GPT-5.4", tmp_path) == "GPT-5.4"
+        assert resolve_dir_name_case_insensitive("missing", tmp_path) == "missing"
+        assert resolve_dir_name_case_insensitive("x", tmp_path / "absent") == "x"
+
+    def test_normalize_agent_name_prefers_registry_canonical_casing(self) -> None:
+        # The checked-in agent registry defines the canonical names; a config
+        # key with divergent casing must not override them (the subprocess
+        # registry lookup is exact-match on the code-registered names).
+        assert normalize_agent_name("skyvern", {"agents": {"Skyvern": {}}}) == "skyvern"
+        assert normalize_agent_name("AGENT-TARS", {}) == "Agent-TARS"
+        assert normalize_agent_name("BROWSER-USE", {"agents": {}}) == "browser-use"
+
+    def test_normalize_agent_name_falls_back_to_config_for_custom_agents(self) -> None:
+        config = {"agents": {"My-Agent": {}}}
+        assert normalize_agent_name("my-agent", config) == "My-Agent"
+
+    def test_normalize_agent_name_unknown_passthrough(self) -> None:
+        assert normalize_agent_name("no-such-agent", {"agents": {}}) == "no-such-agent"
+        assert normalize_agent_name("no-such-agent", {}) == "no-such-agent"
+
+    def test_normalize_split_name_matches_split_key(self) -> None:
+        data_info = {"split": {"All": "tasks.json", "L1": "l1.json"}}
+        assert normalize_split_name("all", data_info) == "All"
+        assert normalize_split_name("l1", data_info) == "L1"
+        assert normalize_split_name("All", data_info) == "All"
+
+    def test_normalize_split_name_legacy_version_split(self) -> None:
+        data_info = {
+            "default_version": "20251230",
+            "version_split": {"20251230": {"All": "tasks.json"}},
+        }
+        assert normalize_split_name("ALL", data_info) == "All"
+
+    def test_normalize_split_name_unknown_passthrough(self) -> None:
+        assert normalize_split_name("nope", {"split": {"All": "tasks.json"}}) == "nope"
+        assert normalize_split_name("All", {}) == "All"
+
+    def test_resolve_split_normalizes_or_defaults(self) -> None:
+        data_info = {"default_split": "L1", "split": {"All": "t.json", "L1": "l1.json"}}
+        assert resolve_split("all", data_info) == "All"
+        assert resolve_split(None, data_info) == "L1"
+        assert resolve_split(None, {}) == "All"
+
+    def test_resolve_agent_inline_config_tolerates_non_string_model_keys(self) -> None:
+        config = {
+            "default": {"model": 4.1, "browser": "local"},
+            "models": {4.1: {"model_id": "gpt-4.1"}},
+            "browsers": {"local": {"browser_id": "local"}},
+            "agents": {"browser-use": {}},
+        }
+
+        inline = resolve_agent_inline_config("browser-use", config)
+
+        assert inline is not None
+        assert inline["model_id"] == "gpt-4.1"
+
+    def test_resolve_agent_inline_config_case_insensitive_model_and_browser(self) -> None:
+        config = {
+            "default": {"model": "gpt", "browser": "lexmount"},
+            "models": {"GPT": {"model_id": "gpt-5.4"}},
+            "browsers": {"Lexmount": {"browser_id": "lexmount"}},
+            "agents": {"browser-use": {"timeout": 600}},
+        }
+
+        inline = resolve_agent_inline_config(
+            "BROWSER-USE", config, model_name="gpt", browser_id="LEXMOUNT"
+        )
+
+        assert inline == {
+            "timeout": 600,
+            "model_id": "gpt-5.4",
+            "browser_id": "lexmount",
+        }
+
+    def test_resolve_agent_inline_config_case_insensitive_legacy_model(self) -> None:
+        config = {
+            "agents": {
+                "browser-use": {
+                    "active_model": "gpt",
+                    "browser": {"browser_id": "lexmount"},
+                    "models": {"GPT": {"model_id": "gpt-5.4"}},
+                },
+            },
+        }
+
+        inline = resolve_agent_inline_config("browser-use", config, model_name="Gpt")
+
+        assert inline is not None
+        assert inline["model_id"] == "gpt-5.4"
 
 
 def test_resolve_agent_entry_uses_registry_venvs_for_builtin_agents(tmp_path: Path) -> None:

--- a/tests/browseruse_bench/test_job_submission.py
+++ b/tests/browseruse_bench/test_job_submission.py
@@ -255,6 +255,52 @@ agents:
     assert agent_cfg["api_key"] == "cwd-openai-key"
 
 
+def test_resolve_submit_config_path_prefers_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yaml").write_text("default: {}", encoding="utf-8")
+    assert submit_cli._resolve_submit_config_path(None) == tmp_path / "config.yaml"
+    explicit = tmp_path / "alt.yaml"
+    explicit.write_text("default: {}", encoding="utf-8")
+    assert submit_cli._resolve_submit_config_path(Path("alt.yaml")) == explicit
+
+
+def test_submit_command_normalizes_custom_agent_against_cwd_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Custom agents defined only in the cwd config.yaml resolve case-insensitively."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        """
+agents:
+  My-Agent:
+    active_model: gpt
+    models:
+      gpt:
+        model_id: gpt-4.1
+""".strip(),
+        encoding="utf-8",
+    )
+    captured: dict[str, str] = {}
+
+    def fake_submit_job(agent_name: str, benchmark_name: str, args: argparse.Namespace) -> int:
+        captured["agent"] = agent_name
+        captured["benchmark"] = benchmark_name
+        return 0
+
+    monkeypatch.setattr(submit_cli, "submit_job", fake_submit_job)
+    args = _make_args()
+    args.agent = "my-agent"
+    args.data = "lexbench-browser"
+
+    assert submit_cli.submit_command(args, {}) == 0
+    assert captured["agent"] == "My-Agent"
+    assert captured["benchmark"] == "LexBench-Browser"
+
+
 def test_load_submit_env_prefers_cwd_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/browseruse_bench/test_run_routing.py
+++ b/tests/browseruse_bench/test_run_routing.py
@@ -7,7 +7,10 @@ from pathlib import Path
 import pytest
 
 from browseruse_bench.browsers import login_contexts as lc
-from browseruse_bench.cli.run import resolve_lexmount_routing_for_task
+from browseruse_bench.cli.run import (
+    _canonicalize_cli_browser_id,
+    resolve_lexmount_routing_for_task,
+)
 
 
 @pytest.fixture
@@ -129,3 +132,17 @@ def test_routing_matches_profile_case_insensitively(tmp_index: Path) -> None:
         cfg, {"task_id": "2", "website_region": "EN", "login_required": False}
     )
     assert profile == "en"
+
+
+def test_canonicalize_cli_browser_id_prefers_exact_config_key() -> None:
+    """An exact config browsers key wins over registered backend id casing."""
+    cfg = {"browsers": {"LEXMOUNT": {"browser_id": "lexmount"}, "lexmount": {}}}
+    assert _canonicalize_cli_browser_id("LEXMOUNT", cfg) == "LEXMOUNT"
+    assert _canonicalize_cli_browser_id("lexmount", cfg) == "lexmount"
+
+
+def test_canonicalize_cli_browser_id_falls_back_to_backend_registry() -> None:
+    assert _canonicalize_cli_browser_id("LEXMOUNT", {}) == "lexmount"
+    assert _canonicalize_cli_browser_id("LEXMOUNT", {"browsers": None}) == "lexmount"
+    assert _canonicalize_cli_browser_id(None, {}) is None
+    assert _canonicalize_cli_browser_id("no-such-backend", {}) == "no-such-backend"


### PR DESCRIPTION
## Summary

Make every CLI selector parameter match config/dataset keys case-insensitively, canonicalizing to the declared key so downstream consumers (literal agent-name comparisons, experiments paths, the subprocess agent-registry lookup, lexmount login-context routing) all see the canonical value.

| Parameter | Matched against | Example |
|---|---|---|
| `--data` | dataset directories under `browseruse_bench/data/` | `lexbench-browser` → `LexBench-Browser` |
| `--agent` | checked-in `configs/agent_registry.yaml`, then config `agents` keys (custom agents) | `AGENT-TARS` → `Agent-TARS` |
| `--model-name` | config `models` keys | `GPT` → `gpt` |
| `--browser-id` | backend registry + config `browsers` keys | `LEXMOUNT` → `lexmount` |
| `--split` | `data_info.json` split keys | `all` → `All` |
| `--model-id` (eval) | existing run directories | `GPT-5.4` → `gpt-5.4` |

## Implementation notes

- `resolve_key_case_insensitive` (config_loader): shared helper, exact-match preferred over case-insensitive, non-string YAML keys (float/bool) pass through unchanged.
- `normalize_agent_name` resolves against the checked-in agent registry **first** so the canonical casing always matches the code-registered agent names used by `get_agent` in the runner subprocess — independent of the git-ignored root config.yaml (matters for `bubench submit` run from another cwd).
- `run_command` canonicalizes `--browser-id` via the new `canonical_browser_id` (browsers registry) at CLI entry, so the inline config's `browser_id` is canonical on all paths — including the legacy and unknown-key fallthrough paths — and lexmount login-context/profile routing (`browser_id == "lexmount"`) still engages for mixed-case input.
- `resolve_split` shared helper (normalize-or-default) used by run/eval; submit normalizes without injecting a local default (server keeps defaulting absent split).
- `resolve_dir_name_case_insensitive` backs both `normalize_benchmark_name` and eval's `--model-id` directory matching.

## Testing

- `uv run pytest tests/` → 402 passed (16 new tests covering normalization helpers, exact-match preference, non-string key tolerance, browser registry canonicalization). Only failure is the pre-existing claude-code live smoke test (proxy lacks the model).
- Real smoke per AGENTS.md: `bubench run --agent BROWSER-USE --data lexbench-browser --split ALL --browser-id BROWSER-USE-CLOUD --mode single` → 1/1 success, exit 0, 559.9s wall-clock, log line `Starting a browser-use agent ... provider=openai and model=gpt-5.4`; run manifest records canonical `browser-use` / `LexBench-Browser` / `All` / `browser-use-cloud`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)