### PR TITLE
Add codex agent (OpenAI Codex CLI with Playwright MCP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Agent SDKs ship as **mutually exclusive extras** (declared in `pyproject.toml` u
 
 ## High-level architecture
 
-The repo orchestrates browser agents (`browser-use`, `skyvern`, `agent-tars`, `claude-code`, `openai-cua`, `deepbrowse`) against benchmarks (`LexBench-Browser`, `Online-Mind2Web`, `BrowseComp`) on browser backends (`Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `cdp`).
+The repo orchestrates browser agents (`browser-use`, `skyvern`, `agent-tars`, `claude-code`, `codex`, `openai-cua`, `deepbrowse`) against benchmarks (`LexBench-Browser`, `Online-Mind2Web`, `BrowseComp`) on browser backends (`Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `cdp`).
 
 - **CLI** ([browseruse_bench/cli/](browseruse_bench/cli/)) — argparse subcommands (`run`, `eval`, `submit`, `leaderboard`, `server`, `service`, `skills`, `viz`, `login`). [__init__.py](browseruse_bench/cli/__init__.py) preloads `.env` from `REPO_ROOT` and reads `config.yaml`. The top-level `scripts/*.py` files are thin shims — edit the CLI module, not the script.
 - **Agents** ([browseruse_bench/agents/](browseruse_bench/agents/)) — [base.py](browseruse_bench/agents/base.py) (`BaseAgent` ABC), one file per agent, plus [registry.py](browseruse_bench/agents/registry.py). Agents self-register via `@register_agent` on a unique `name`. Do not import agent SDKs at registry level.

--- a/browseruse_bench/agents/__init__.py
+++ b/browseruse_bench/agents/__init__.py
@@ -29,6 +29,11 @@ except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.claude_code: %s", exc)
 
 try:
+    from browseruse_bench.agents import codex  # noqa: F401
+except ImportError as exc:
+    logger.warning("Skipping optional agent module browseruse_bench.agents.codex: %s", exc)
+
+try:
     from browseruse_bench.agents import browser_use  # noqa: F401
 except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.browser_use: %s", exc)

--- a/browseruse_bench/agents/codex.py
+++ b/browseruse_bench/agents/codex.py
@@ -264,7 +264,28 @@ class CodexAgent(CLIAgent):
             agent_config=agent_config,
         ) as session_context:
             cdp_url = session_context.cdp_url if session_context.transport == "cdp" else None
+            if not cdp_url:
+                return self._unsupported_backend_result(
+                    task_info["task_id"], browser_id, session_context.transport
+                )
             return self._execute(task_info, agent_config, task_workspace, cdp_url=cdp_url)
+
+    def _unsupported_backend_result(
+        self, task_id: str, browser_id: str, transport: str
+    ) -> AgentResult:
+        """Fail fast instead of silently self-launching a local browser."""
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status="failed",  # type: ignore[arg-type]
+            agent_done="error",  # type: ignore[arg-type]
+            error=(
+                f"Browser backend '{browser_id}' (transport={transport}) provides no CDP "
+                "endpoint, so the codex agent cannot attach Playwright MCP to it. "
+                "Use a CDP-capable backend (e.g. lexmount, cdp) or browser_id=local."
+            ),
+            metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+        )
 
     def _execute(
         self,

--- a/browseruse_bench/agents/codex.py
+++ b/browseruse_bench/agents/codex.py
@@ -1,0 +1,435 @@
+"""
+CodexAgent - Browser automation using OpenAI Codex CLI with Playwright MCP.
+
+This agent executes tasks by invoking `codex exec` in non-interactive mode
+(--json JSONL event stream) with a Playwright MCP server injected via -c
+config overrides for browser control.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from browseruse_bench.agents.cli_agent import CLIAgent
+from browseruse_bench.agents.registry import register_agent
+from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
+from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
+from browseruse_bench.utils import IS_WINDOWS
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RULES = (
+    "You are a browser automation agent. "
+    "You MUST use ONLY the Playwright MCP tools (server 'playwright') for ALL browser "
+    "interactions. Do NOT run shell commands, do NOT read or write files, and do NOT "
+    "use skills or any non-Playwright tools."
+    "\n\nTask completion rules:\n"
+    "- If you can see enough information to answer the task from the current page (e.g., "
+    "ratings, names, prices visible in search results), provide your answer IMMEDIATELY "
+    "without clicking into individual items to get more detail.\n"
+    "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
+    "close that tab, return to the previous page, and use the data already collected to answer.\n"
+    "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+    "\n\nScreenshot rules:\n"
+    "- When taking screenshots, do NOT specify a filename parameter.\n"
+    "- Take a screenshot with browser_take_screenshot after navigating to the main page "
+    "and after finding the answer."
+)
+
+# JSONL item types that represent an agent step (tool usage).
+_STEP_ITEM_TYPES = {"mcp_tool_call", "command_execution"}
+
+
+def _parse_events(stdout_lines: list[str]) -> tuple[str, list[dict[str, Any]], dict[str, int], str | None]:
+    """Parse `codex exec --json` JSONL output.
+
+    Returns ``(answer, items, usage_totals, error_message)``:
+    - *answer*: text of the last completed ``agent_message`` item.
+    - *items*: all completed items (agent_message / mcp_tool_call / ...).
+    - *usage_totals*: token usage accumulated across ``turn.completed`` events.
+    - *error_message*: message from the last ``error`` / ``turn.failed`` event.
+    """
+    answer = ""
+    items: list[dict[str, Any]] = []
+    usage_totals = {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+    error_message: str | None = None
+
+    for raw_line in stdout_lines:
+        line = raw_line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        event_type = obj.get("type")
+        if event_type == "item.completed":
+            item = obj.get("item")
+            if isinstance(item, dict):
+                items.append(item)
+                if item.get("type") == "agent_message" and item.get("text"):
+                    answer = str(item["text"])
+        elif event_type == "turn.completed":
+            _accumulate_usage(usage_totals, obj.get("usage"))
+        elif event_type in ("turn.failed", "error"):
+            error_message = _extract_error_message(obj) or error_message
+
+    return answer, items, usage_totals, error_message
+
+
+def _accumulate_usage(totals: dict[str, int], usage: Any) -> None:
+    if not isinstance(usage, dict):
+        return
+    for key in totals:
+        value = usage.get(key)
+        if isinstance(value, int | float):
+            totals[key] += int(value)
+
+
+def _extract_error_message(obj: dict[str, Any]) -> str | None:
+    error = obj.get("error")
+    if isinstance(error, dict) and error.get("message"):
+        return str(error["message"])
+    if obj.get("message"):
+        return str(obj["message"])
+    return None
+
+
+def _describe_item(item: dict[str, Any]) -> str | None:
+    """Map a completed step item to a short action description."""
+    item_type = item.get("type")
+    if item_type == "command_execution":
+        return f"Shell: {str(item.get('command', ''))[:80]}"
+    if item_type != "mcp_tool_call":
+        return None
+    tool = str(item.get("tool", ""))
+    arguments = item.get("arguments")
+    if not isinstance(arguments, dict):
+        arguments = {}
+    if "navigate" in tool:
+        return f"Navigate to {arguments.get('url', '')}"
+    if "click" in tool:
+        return f"Click: {arguments.get('element', arguments.get('ref', ''))}"
+    if "type" in tool or "fill" in tool:
+        return f"Type: {str(arguments.get('text', arguments.get('value', '')))[:60]}"
+    if "screenshot" in tool:
+        return "Take screenshot"
+    if "snapshot" in tool:
+        return "Take snapshot"
+    if "press" in tool:
+        return f"Press key: {arguments.get('key', '')}"
+    return tool or None
+
+
+def _extract_actions(items: list[dict[str, Any]]) -> list[str]:
+    actions: list[str] = []
+    for item in items:
+        description = _describe_item(item)
+        if description:
+            actions.append(description)
+    return actions
+
+
+def _collect_screenshots(task_workspace: Path, trajectory_dir: Path) -> list[str]:
+    """Copy Playwright MCP screenshots into trajectory/.
+
+    Screenshots land in .playwright-mcp/ by default, or in the workspace root
+    when the model passes an explicit filename despite the rules.
+    """
+    candidates: list[Path] = []
+    for parent in (task_workspace / ".playwright-mcp", task_workspace):
+        if parent.is_dir():
+            candidates += [
+                p for p in parent.iterdir() if p.suffix.lower() in (".png", ".jpeg", ".jpg")
+            ]
+    images = sorted(candidates, key=lambda p: p.stat().st_mtime)
+    saved: list[str] = []
+    for index, image in enumerate(images, 1):
+        fname = f"screenshot-{index}{image.suffix.lower()}"
+        try:
+            trajectory_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(image, trajectory_dir / fname)
+            saved.append(fname)
+        except OSError as exc:
+            logger.warning("Failed to copy screenshot %s: %s", image.name, exc)
+    return saved
+
+
+def _write_api_logs(
+    task_id: str,
+    model_id: str,
+    rules: str,
+    items: list[dict[str, Any]],
+    api_logs_dir: Path,
+) -> None:
+    """Write api_logs/step_NNN.json + system_prompt.txt for step items."""
+    api_logs_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        (api_logs_dir / "system_prompt.txt").write_text(rules, encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Failed to write system_prompt.txt: %s", exc)
+
+    step_items = [item for item in items if item.get("type") in _STEP_ITEM_TYPES]
+    for step_number, item in enumerate(step_items, 1):
+        step_data = {
+            "metadata": {
+                "task_id": task_id,
+                "step_number": step_number,
+                "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
+                "model_id": model_id,
+            },
+            "output": {"actions": [{"tool": item.get("tool") or item.get("command"), "input": item.get("arguments")}]},
+            "action_results": [_item_result_summary(item)],
+        }
+        try:
+            (api_logs_dir / f"step_{step_number:03d}.json").write_text(
+                json.dumps(step_data, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        except (OSError, TypeError) as exc:
+            logger.warning("Failed to write step %d log: %s", step_number, exc)
+
+
+def _item_result_summary(item: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {"status": item.get("status")}
+    result = item.get("result")
+    if isinstance(result, dict):
+        texts = [
+            block.get("text", "")
+            for block in result.get("content", [])
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        if texts:
+            summary["extracted_content"] = "\n".join(texts)
+    error = item.get("error")
+    if isinstance(error, dict) and error.get("message"):
+        summary["error"] = error["message"]
+    if item.get("aggregated_output"):
+        summary["extracted_content"] = str(item["aggregated_output"])[:2000]
+    return summary
+
+
+def _toml_value(value: Any) -> str:
+    """Render a -c override value as TOML (JSON syntax is TOML-compatible here)."""
+    return json.dumps(value, ensure_ascii=False)
+
+
+@register_agent
+class CodexAgent(CLIAgent):
+    """
+    Browser automation agent using OpenAI Codex CLI with Playwright MCP.
+
+    Codex is invoked as an external process via `codex exec --json`. The
+    Playwright MCP server is injected with -c overrides; the user-level
+    ~/.codex/config.toml is ignored (auth.json is still used), so install
+    Codex and log in first:
+      npm install -g @openai/codex && codex login
+    """
+
+    name = "codex"
+
+    def run_task(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+    ) -> AgentResult | dict[str, Any]:
+        """Execute a browser automation task using Codex CLI."""
+        warn_if_local_proxy_unsupported(agent_config, self.name)
+        task_id = task_info["task_id"]
+        prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
+        rules = agent_config.get("system_prompt") or _DEFAULT_RULES
+        model = agent_config.get("model_id") or agent_config.get("model", "gpt-5.5")
+        timeout = self._resolve_timeout(task_id, agent_config)
+
+        trajectory_dir = task_workspace / "trajectory"
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+        last_message_file = task_workspace / "last_message.txt"
+        cmd = self._build_command(
+            full_prompt=f"{rules}\n\n{prompt}",
+            model=model,
+            agent_config=agent_config,
+            task_workspace=task_workspace,
+            last_message_file=last_message_file,
+        )
+
+        env = {**os.environ}
+        if agent_config.get("api_key"):
+            env["OPENAI_API_KEY"] = str(agent_config["api_key"])
+        if agent_config.get("base_url"):
+            env["OPENAI_BASE_URL"] = str(agent_config["base_url"])
+
+        logger.info("Executing Codex for task %s (model=%s, timeout=%ds)", task_id, model, timeout)
+        t_start = time.monotonic()
+        try:
+            returncode, stdout_lines, execution_error = self._run_subprocess(
+                cmd,
+                timeout=timeout,
+                task_workspace=task_workspace,
+                cwd=task_workspace,
+                env=env,
+                collect_stdout=True,
+                stdout_line_hook=_stdout_hook,
+                stderr_line_hook=_stderr_hook,
+            )
+        except FileNotFoundError:
+            return AgentResult(
+                task_id=task_id,
+                timestamp=datetime.now(UTC),
+                env_status="failed",  # type: ignore[arg-type]
+                agent_done="error",  # type: ignore[arg-type]
+                error=(
+                    "Executable 'codex' not found. "
+                    "Please install Codex CLI: npm install -g @openai/codex"
+                ),
+                metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+            )
+        duration_ms = int((time.monotonic() - t_start) * 1000)
+
+        return self._finalize_result(
+            task_id=task_id,
+            model=model,
+            rules=rules,
+            stdout_lines=stdout_lines,
+            returncode=returncode,
+            execution_error=execution_error,
+            duration_ms=duration_ms,
+            task_workspace=task_workspace,
+            trajectory_dir=trajectory_dir,
+            last_message_file=last_message_file,
+        )
+
+    @staticmethod
+    def _resolve_timeout(task_id: str, agent_config: dict[str, Any]) -> int:
+        timeout_val = agent_config.get("timeout_seconds") or agent_config.get("timeout", 600)
+        try:
+            return int(timeout_val)
+        except (TypeError, ValueError) as exc:
+            logger.warning("Invalid timeout for task %s (%r): %s", task_id, timeout_val, exc)
+            return 600
+
+    @staticmethod
+    def _build_command(
+        full_prompt: str,
+        model: str,
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        last_message_file: Path,
+    ) -> list[str]:
+        sandbox = agent_config.get("sandbox_mode", "read-only")
+        mcp_command = agent_config.get("playwright_mcp_command", "npx")
+        mcp_args = list(agent_config.get("playwright_mcp_args", ["@playwright/mcp@latest"]))
+        # --timeout-action 30000: raise from the 5000ms default (screenshots time
+        # out on pages with slow external font CDNs).
+        mcp_args += ["--timeout-action", "30000"]
+        mcp_startup_timeout = int(agent_config.get("mcp_startup_timeout", 120))
+        mcp_tool_timeout = int(agent_config.get("mcp_tool_timeout", 120))
+
+        exe = "codex.cmd" if IS_WINDOWS else "codex"
+        return [
+            exe, "exec", full_prompt,
+            "--json",
+            "--model", model,
+            "--sandbox", sandbox,
+            "--cd", str(task_workspace),
+            "--skip-git-repo-check",   # task workspaces are not git repositories
+            "--ephemeral",             # do not persist session files
+            "--ignore-user-config",    # hermetic: skip ~/.codex/config.toml (auth still works)
+            "--output-last-message", str(last_message_file),
+            "-c", f"mcp_servers.playwright.command={_toml_value(mcp_command)}",
+            "-c", f"mcp_servers.playwright.args={_toml_value(mcp_args)}",
+            # "approve": auto-approve MCP tool calls; exec mode has no
+            # interactive reviewer, so "prompt"/"auto" cancel every call.
+            "-c", 'mcp_servers.playwright.default_tools_approval_mode="approve"',
+            "-c", f"mcp_servers.playwright.startup_timeout_sec={mcp_startup_timeout}",
+            "-c", f"mcp_servers.playwright.tool_timeout_sec={mcp_tool_timeout}",
+        ]
+
+    def _finalize_result(
+        self,
+        task_id: str,
+        model: str,
+        rules: str,
+        stdout_lines: list[str],
+        returncode: int,
+        execution_error: str | None,
+        duration_ms: int,
+        task_workspace: Path,
+        trajectory_dir: Path,
+        last_message_file: Path,
+    ) -> AgentResult:
+        answer, items, usage_totals, error_message = _parse_events(stdout_lines)
+        if not answer and last_message_file.is_file():
+            answer = last_message_file.read_text(encoding="utf-8").strip()
+
+        if execution_error and "Timeout" in execution_error:
+            logger.error("Codex task %s timed out", task_id)
+        env_status, agent_done = self._map_exit_status(
+            returncode, execution_error, has_result=bool(answer)
+        )
+        if env_status == "success" and agent_done == "done" and error_message and not answer:
+            env_status, agent_done = "failed", "error"
+        if env_status == "failed" and not answer:
+            answer = f"[Task Failed: {execution_error or error_message or 'No output from Codex'}]"
+
+        saved_screenshots = _collect_screenshots(task_workspace, trajectory_dir)
+        steps = sum(1 for item in items if item.get("type") in _STEP_ITEM_TYPES)
+        if items:
+            try:
+                _write_api_logs(task_id, model, rules, items, task_workspace / "api_logs")
+            except (OSError, TypeError, ValueError) as exc:
+                logger.warning("Failed to generate api_logs for task %s: %s", task_id, exc)
+
+        total_tokens = usage_totals["input_tokens"] + usage_totals["output_tokens"]
+        usage = AgentUsage(
+            total_prompt_tokens=usage_totals["input_tokens"],
+            total_prompt_cached_tokens=usage_totals["cached_input_tokens"],
+            total_completion_tokens=usage_totals["output_tokens"],
+            total_tokens=total_tokens,
+        ) if total_tokens else None
+
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status=env_status,  # type: ignore[arg-type]
+            agent_done=agent_done,  # type: ignore[arg-type]
+            answer=answer,
+            error=(execution_error or error_message) if env_status == "failed" else None,
+            action_history=_extract_actions(items),
+            screenshots=saved_screenshots,
+            model_id=model,
+            metrics=AgentMetrics(end_to_end_ms=duration_ms, steps=steps, usage=usage),
+        )
+
+
+def _stdout_hook(line: str) -> None:
+    clean = line.strip()
+    if not clean.startswith("{"):
+        return
+    try:
+        obj = json.loads(clean)
+    except json.JSONDecodeError:
+        return
+    if obj.get("type") == "item.completed":
+        item = obj.get("item", {})
+        if isinstance(item, dict) and item.get("type") == "mcp_tool_call":
+            logger.info("[Codex] Tool: %s", item.get("tool", ""))
+    elif obj.get("type") == "turn.completed":
+        usage = obj.get("usage", {})
+        if isinstance(usage, dict):
+            logger.info(
+                "[Codex] Turn done: in=%s out=%s tokens",
+                usage.get("input_tokens"), usage.get("output_tokens"),
+            )
+
+
+def _stderr_hook(line: str) -> None:
+    clean = line.strip()
+    if clean and "error" in clean.lower():
+        logger.warning("[Codex] %s", clean)

--- a/browseruse_bench/agents/codex.py
+++ b/browseruse_bench/agents/codex.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from browseruse_bench.agents.cli_agent import CLIAgent
 from browseruse_bench.agents.registry import register_agent
+from browseruse_bench.browsers import open_browser_session
 from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
 from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
 from browseruse_bench.utils import IS_WINDOWS
@@ -46,6 +47,10 @@ _DEFAULT_RULES = (
 # JSONL item types that represent an agent step (tool usage).
 _STEP_ITEM_TYPES = {"mcp_tool_call", "command_execution"}
 
+# Browser ids where Playwright MCP launches its own local browser instead of
+# connecting to a managed backend session over CDP.
+_SELF_LAUNCH_BROWSER_IDS = {"", "local", "Chrome-Local"}
+
 
 def _parse_events(stdout_lines: list[str]) -> tuple[str, list[dict[str, Any]], dict[str, int], str | None]:
     """Parse `codex exec --json` JSONL output.
@@ -54,7 +59,9 @@ def _parse_events(stdout_lines: list[str]) -> tuple[str, list[dict[str, Any]], d
     - *answer*: text of the last completed ``agent_message`` item.
     - *items*: all completed items (agent_message / mcp_tool_call / ...).
     - *usage_totals*: token usage accumulated across ``turn.completed`` events.
-    - *error_message*: message from the last ``error`` / ``turn.failed`` event.
+    - *error_message*: message from an ``error`` / ``turn.failed`` event that was
+      not followed by a ``turn.completed`` (a later completed turn means the
+      error was transient and the run recovered).
     """
     answer = ""
     items: list[dict[str, Any]] = []
@@ -78,6 +85,7 @@ def _parse_events(stdout_lines: list[str]) -> tuple[str, list[dict[str, Any]], d
                     answer = str(item["text"])
         elif event_type == "turn.completed":
             _accumulate_usage(usage_totals, obj.get("usage"))
+            error_message = None
         elif event_type in ("turn.failed", "error"):
             error_message = _extract_error_message(obj) or error_message
 
@@ -240,8 +248,31 @@ class CodexAgent(CLIAgent):
         agent_config: dict[str, Any],
         task_workspace: Path,
     ) -> AgentResult | dict[str, Any]:
-        """Execute a browser automation task using Codex CLI."""
-        warn_if_local_proxy_unsupported(agent_config, self.name)
+        """Execute a browser automation task using Codex CLI.
+
+        With a managed browser backend configured (e.g. lexmount, cdp), the
+        backend session is opened first and its CDP endpoint is handed to
+        Playwright MCP, so login contexts/proxies injected by cli/run.py apply.
+        """
+        browser_id = str(agent_config.get("browser_id") or "")
+        if browser_id in _SELF_LAUNCH_BROWSER_IDS:
+            warn_if_local_proxy_unsupported(agent_config, self.name)
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=None)
+        with open_browser_session(
+            browser_id=browser_id,
+            agent_name=self.name,
+            agent_config=agent_config,
+        ) as session_context:
+            cdp_url = session_context.cdp_url if session_context.transport == "cdp" else None
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=cdp_url)
+
+    def _execute(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        cdp_url: str | None,
+    ) -> AgentResult:
         task_id = task_info["task_id"]
         prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
         rules = agent_config.get("system_prompt") or _DEFAULT_RULES
@@ -257,6 +288,7 @@ class CodexAgent(CLIAgent):
             agent_config=agent_config,
             task_workspace=task_workspace,
             last_message_file=last_message_file,
+            cdp_url=cdp_url,
         )
 
         env = {**os.environ}
@@ -321,6 +353,7 @@ class CodexAgent(CLIAgent):
         agent_config: dict[str, Any],
         task_workspace: Path,
         last_message_file: Path,
+        cdp_url: str | None = None,
     ) -> list[str]:
         sandbox = agent_config.get("sandbox_mode", "read-only")
         mcp_command = agent_config.get("playwright_mcp_command", "npx")
@@ -328,6 +361,8 @@ class CodexAgent(CLIAgent):
         # --timeout-action 30000: raise from the 5000ms default (screenshots time
         # out on pages with slow external font CDNs).
         mcp_args += ["--timeout-action", "30000"]
+        if cdp_url:
+            mcp_args += ["--cdp-endpoint", cdp_url]
         mcp_startup_timeout = int(agent_config.get("mcp_startup_timeout", 120))
         mcp_tool_timeout = int(agent_config.get("mcp_tool_timeout", 120))
 
@@ -373,7 +408,9 @@ class CodexAgent(CLIAgent):
         env_status, agent_done = self._map_exit_status(
             returncode, execution_error, has_result=bool(answer)
         )
-        if env_status == "success" and agent_done == "done" and error_message and not answer:
+        # An unrecovered error/turn.failed event marks the run failed even when
+        # an earlier partial agent_message produced answer text.
+        if agent_done != "timeout" and error_message:
             env_status, agent_done = "failed", "error"
         if env_status == "failed" and not answer:
             answer = f"[Task Failed: {execution_error or error_message or 'No output from Codex'}]"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -154,6 +154,12 @@ models:
     model_id: openai/gpt-5.4
     api_key: $OPENROUTER_API_KEY
     base_url: https://openrouter.ai/api/v1/chat/completions
+  # Codex CLI model. Only supported by the codex agent; auth comes from
+  # `codex login` (ChatGPT account) or OPENAI_API_KEY.
+  codex:
+    model_type: OPENAI
+    model_id: gpt-5.5
+    api_key: $OPENAI_API_KEY
 browsers:
   lexmount:
     browser_id: lexmount
@@ -224,6 +230,10 @@ agents:
     max_turns: 50
     timeout: 300
     allowed_tools: mcp__playwright*
+  codex:
+    active_model: codex
+    timeout: 600
+    sandbox_mode: read-only
   deepbrowse:
     use_vision: auto
     max_steps: 50

--- a/configs/agent_registry.yaml
+++ b/configs/agent_registry.yaml
@@ -42,6 +42,17 @@ claude-code:
     - WebVoyager
     - Odysseys
 
+codex:
+  path: browseruse_bench/agents
+  entrypoint: browseruse_bench/runner/agent_runner.py
+  venv: .venv
+  supported_benchmarks:
+    - Online-Mind2Web
+    - BrowseComp
+    - LexBench-Browser
+    - WebVoyager
+    - Odysseys
+
 deepbrowse:
   path: browseruse_bench/agents
   entrypoint: browseruse_bench/runner/agent_runner.py

--- a/tests/browseruse_bench/test_codex_agent.py
+++ b/tests/browseruse_bench/test_codex_agent.py
@@ -79,6 +79,14 @@ class TestParseEvents:
         _, _, _, error = _parse_events(lines)
         assert error == "turn exploded"
 
+    def test_transient_error_cleared_by_completed_turn(self) -> None:
+        lines = [
+            _line({"type": "error", "message": "stream disconnected, retrying"}),
+            _line({"type": "turn.completed", "usage": {"input_tokens": 1, "cached_input_tokens": 0, "output_tokens": 1}}),
+        ]
+        _, _, _, error = _parse_events(lines)
+        assert error is None
+
     def test_invalid_and_non_json_lines_skipped(self) -> None:
         lines = ["not json\n", "{broken\n", _line({"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}})]
         answer, _, _, _ = _parse_events(lines)
@@ -187,6 +195,22 @@ class TestCodexAgentRunTask:
         assert result.agent_done == "error"
         assert "model not supported" in (result.error or "")
 
+    def test_turn_failed_after_partial_message_is_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A partial narration before the failure must not mask the error.
+        stream = [
+            _line({"type": "item.completed", "item": {"type": "agent_message", "text": "I will navigate now"}}),
+            _line({"type": "turn.failed", "error": {"message": "tool crashed"}}),
+        ]
+        agent = CodexAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, stream, None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "tool crashed" in (result.error or "")
+        assert result.answer == "I will navigate now"
+
     def test_answer_falls_back_to_last_message_file(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -226,3 +250,51 @@ class TestCodexAgentRunTask:
         assert 'mcp_servers.playwright.default_tools_approval_mode="approve"' in joined
         assert 'mcp_servers.playwright.command="npx"' in joined
         assert "@playwright/mcp@latest" in joined
+        assert "--cdp-endpoint" not in joined
+
+    def test_command_includes_cdp_endpoint_when_session_provided(self, tmp_path: Path) -> None:
+        cmd = CodexAgent._build_command(
+            full_prompt="do it",
+            model="gpt-test",
+            agent_config={},
+            task_workspace=tmp_path,
+            last_message_file=tmp_path / "last_message.txt",
+            cdp_url="ws://127.0.0.1:9222/devtools/browser/abc",
+        )
+        joined = " ".join(cmd)
+        assert "--cdp-endpoint" in joined
+        assert "ws://127.0.0.1:9222/devtools/browser/abc" in joined
+
+    def test_managed_browser_opens_backend_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import codex as codex_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        opened: dict[str, str] = {}
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            opened["browser_id"] = browser_id
+            yield BrowserSessionContext(
+                backend_id=browser_id, transport="cdp", cdp_url="ws://cdp.example/1"
+            )
+
+        monkeypatch.setattr(codex_module, "open_browser_session", fake_session)
+        captured_cmd: list[str] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            captured_cmd.extend(cmd)
+            return 0, self._stream(), None
+
+        agent = CodexAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        config = {**AGENT_CONFIG, "browser_id": "lexmount"}
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+        joined = " ".join(captured_cmd)
+        assert opened["browser_id"] == "lexmount"
+        assert "--cdp-endpoint" in joined
+        assert "ws://cdp.example/1" in joined
+        assert result.env_status == "success"

--- a/tests/browseruse_bench/test_codex_agent.py
+++ b/tests/browseruse_bench/test_codex_agent.py
@@ -298,3 +298,30 @@ class TestCodexAgentRunTask:
         assert "--cdp-endpoint" in joined
         assert "ws://cdp.example/1" in joined
         assert result.env_status == "success"
+
+    def test_non_cdp_backend_fails_fast(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Cloud-native sessions expose no CDP endpoint; the run must fail
+        # loudly instead of silently self-launching a local browser.
+        import contextlib
+
+        from browseruse_bench.agents import codex as codex_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            yield BrowserSessionContext(backend_id=browser_id, transport="cloud_native")
+
+        monkeypatch.setattr(codex_module, "open_browser_session", fake_session)
+        agent = CodexAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            lambda *a, **kw: pytest.fail("subprocess must not be launched"),
+        )
+        config = {**AGENT_CONFIG, "browser_id": "browser-use-cloud"}
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "browser-use-cloud" in (result.error or "")
+        assert "cloud_native" in (result.error or "")

--- a/tests/browseruse_bench/test_codex_agent.py
+++ b/tests/browseruse_bench/test_codex_agent.py
@@ -1,0 +1,228 @@
+"""Tests for CodexAgent: _parse_events, screenshot collection, and run_task."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from browseruse_bench.agents.codex import (
+    CodexAgent,
+    _collect_screenshots,
+    _extract_actions,
+    _parse_events,
+)
+from browseruse_bench.schemas import AgentResult
+
+
+def _line(obj: dict[str, Any]) -> str:
+    return json.dumps(obj) + "\n"
+
+
+def _mcp_item(tool: str, arguments: dict[str, Any] | None = None, status: str = "completed") -> dict[str, Any]:
+    return {
+        "id": "item_x",
+        "type": "mcp_tool_call",
+        "server": "playwright",
+        "tool": tool,
+        "arguments": arguments or {},
+        "result": None,
+        "error": None,
+        "status": status,
+    }
+
+
+TASK_INFO: dict[str, Any] = {
+    "task_id": "t1",
+    "task_text": "Go to example.com",
+    "url": "https://example.com",
+}
+
+AGENT_CONFIG: dict[str, Any] = {
+    "model_id": "gpt-test",
+    "timeout": 10,
+}
+
+
+class TestParseEvents:
+    def test_empty_input(self) -> None:
+        answer, items, usage, error = _parse_events([])
+        assert answer == ""
+        assert items == []
+        assert usage == {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+        assert error is None
+
+    def test_last_agent_message_wins(self) -> None:
+        lines = [
+            _line({"type": "item.completed", "item": {"type": "agent_message", "text": "first"}}),
+            _line({"type": "item.completed", "item": {"type": "agent_message", "text": "final answer"}}),
+        ]
+        answer, items, _, _ = _parse_events(lines)
+        assert answer == "final answer"
+        assert len(items) == 2
+
+    def test_usage_accumulated_across_turns(self) -> None:
+        lines = [
+            _line({"type": "turn.completed", "usage": {"input_tokens": 100, "cached_input_tokens": 40, "output_tokens": 10}}),
+            _line({"type": "turn.completed", "usage": {"input_tokens": 50, "cached_input_tokens": 0, "output_tokens": 5}}),
+        ]
+        _, _, usage, _ = _parse_events(lines)
+        assert usage == {"input_tokens": 150, "cached_input_tokens": 40, "output_tokens": 15}
+
+    def test_error_events_captured(self) -> None:
+        lines = [
+            _line({"type": "error", "message": "model not supported"}),
+            _line({"type": "turn.failed", "error": {"message": "turn exploded"}}),
+        ]
+        _, _, _, error = _parse_events(lines)
+        assert error == "turn exploded"
+
+    def test_invalid_and_non_json_lines_skipped(self) -> None:
+        lines = ["not json\n", "{broken\n", _line({"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}})]
+        answer, _, _, _ = _parse_events(lines)
+        assert answer == "ok"
+
+
+class TestExtractActions:
+    def test_mcp_tool_calls_mapped(self) -> None:
+        items = [
+            _mcp_item("browser_navigate", {"url": "https://example.com"}),
+            _mcp_item("browser_click", {"element": "Login button"}),
+            _mcp_item("browser_take_screenshot"),
+            {"id": "i", "type": "command_execution", "command": "ls -la", "status": "completed"},
+            {"id": "j", "type": "agent_message", "text": "not an action"},
+        ]
+        actions = _extract_actions(items)
+        assert actions == [
+            "Navigate to https://example.com",
+            "Click: Login button",
+            "Take screenshot",
+            "Shell: ls -la",
+        ]
+
+
+class TestCollectScreenshots:
+    def test_copies_images_in_mtime_order(self, tmp_path: Path) -> None:
+        mcp_dir = tmp_path / ".playwright-mcp"
+        mcp_dir.mkdir()
+        (mcp_dir / "b.png").write_bytes(b"png-b")
+        (mcp_dir / "a.png").write_bytes(b"png-a")
+        (mcp_dir / "notes.yml").write_text("not an image")
+        import os
+
+        os.utime(mcp_dir / "b.png", (1, 1))
+        os.utime(mcp_dir / "a.png", (2, 2))
+
+        trajectory = tmp_path / "trajectory"
+        saved = _collect_screenshots(tmp_path, trajectory)
+
+        assert saved == ["screenshot-1.png", "screenshot-2.png"]
+        assert (trajectory / "screenshot-1.png").read_bytes() == b"png-b"
+        assert (trajectory / "screenshot-2.png").read_bytes() == b"png-a"
+
+    def test_workspace_root_images_also_collected(self, tmp_path: Path) -> None:
+        # The model may pass an explicit filename, landing the image in the
+        # workspace root instead of .playwright-mcp/.
+        (tmp_path / "named-shot.png").write_bytes(b"png-root")
+        saved = _collect_screenshots(tmp_path, tmp_path / "trajectory")
+        assert saved == ["screenshot-1.png"]
+
+    def test_no_images_returns_empty(self, tmp_path: Path) -> None:
+        assert _collect_screenshots(tmp_path, tmp_path / "trajectory") == []
+
+
+class TestCodexAgentRunTask:
+    def _stream(self) -> list[str]:
+        return [
+            _line({"type": "thread.started", "thread_id": "th_1"}),
+            _line({"type": "turn.started"}),
+            _line({"type": "item.completed", "item": _mcp_item("browser_navigate", {"url": "https://example.com"})}),
+            _line({"type": "item.completed", "item": {"type": "agent_message", "text": "The price is $42"}}),
+            _line({"type": "turn.completed", "usage": {"input_tokens": 100, "cached_input_tokens": 0, "output_tokens": 20}}),
+        ]
+
+    def test_successful_run_returns_answer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = CodexAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, self._stream(), None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert isinstance(result, AgentResult)
+        assert result.answer == "The price is $42"
+        assert result.env_status == "success"
+        assert result.agent_done == "done"
+        assert result.metrics.steps == 1
+        assert result.metrics.usage is not None
+        assert result.metrics.usage.total_prompt_tokens == 100
+        assert result.metrics.usage.total_completion_tokens == 20
+        assert result.action_history == ["Navigate to https://example.com"]
+
+    def test_timeout_keeps_partial_answer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        stream = [
+            _line({"type": "item.completed", "item": {"type": "agent_message", "text": "rating is 4.5 stars"}}),
+        ]
+        agent = CodexAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (-1, stream, "Timeout after 10 seconds")
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "success"
+        assert result.agent_done == "timeout"
+        assert "4.5 stars" in result.answer
+
+    def test_turn_failed_without_answer_is_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        stream = [
+            _line({"type": "turn.failed", "error": {"message": "model not supported"}}),
+        ]
+        agent = CodexAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, stream, None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "model not supported" in (result.error or "")
+
+    def test_answer_falls_back_to_last_message_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        (tmp_path / "last_message.txt").write_text("answer from file", encoding="utf-8")
+        agent = CodexAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, [], None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.answer == "answer from file"
+        assert result.env_status == "success"
+
+    def test_executable_not_found_returns_error_result(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = CodexAgent()
+
+        def _raise(*a: Any, **kw: Any) -> None:
+            raise FileNotFoundError("codex not found")
+
+        monkeypatch.setattr(agent, "_run_subprocess", _raise)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "not found" in (result.error or "").lower()
+
+    def test_command_includes_mcp_overrides(self, tmp_path: Path) -> None:
+        cmd = CodexAgent._build_command(
+            full_prompt="do it",
+            model="gpt-test",
+            agent_config={},
+            task_workspace=tmp_path,
+            last_message_file=tmp_path / "last_message.txt",
+        )
+        joined = " ".join(cmd)
+        assert cmd[:3] == ["codex", "exec", "do it"]
+        assert "--json" in cmd
+        assert "--ignore-user-config" in cmd
+        assert 'mcp_servers.playwright.default_tools_approval_mode="approve"' in joined
+        assert 'mcp_servers.playwright.command="npx"' in joined
+        assert "@playwright/mcp@latest" in joined


### PR DESCRIPTION
## Summary

Adds `codex` as a new browser agent, following the `claude-code` CLIAgent pattern: it invokes `codex exec --json` non-interactively and drives the browser exclusively through a Playwright MCP server injected with `-c` config overrides.

## Implementation notes

- **Hermetic launch**: `--ignore-user-config` (so a user's `~/.codex/config.toml` cannot affect benchmark runs; `auth.json` is still honored), `--ephemeral`, `--skip-git-repo-check`, task workspace as cwd, `read-only` sandbox by default (`agents.codex.sandbox_mode`).
- **MCP approval gate**: `mcp_servers.playwright.default_tools_approval_mode="approve"` is load-bearing — in exec mode there is no interactive reviewer, so the default elicitation-based MCP tool approval auto-cancels every tool call (`user cancelled MCP tool call`). Verified against codex-cli 0.130.0.
- **Event parsing**: consumes the JSONL stream (`item.completed` / `turn.completed` / `turn.failed` / `error`) for the final answer (last `agent_message`), action history (`mcp_tool_call` / `command_execution` items), and per-turn token usage; falls back to the `--output-last-message` file when the stream has no answer (e.g. timeout).
- **Artifacts**: screenshots are collected from `.playwright-mcp/` and the workspace root into `trajectory/`; `api_logs/step_NNN.json` + `system_prompt.txt` are written per step, matching the claude-code layout.
- **Registration**: `agents/__init__.py` try-import, `configs/agent_registry.yaml` (venv `.venv`, no extra needed — no Python SDK dependency), `config.example.yaml` (`agents.codex` + `models.codex`), CLAUDE.md agent list.

## Prerequisites

```bash
npm install -g @openai/codex
codex login        # ChatGPT account, or OPENAI_API_KEY via models.codex.api_key
```

## Testing

- `uv run pytest tests/` → 419 passed (15 new tests: event parsing, usage accumulation, error mapping, action extraction, screenshot collection incl. workspace-root fallback, run_task via mocked subprocess, command construction). Only failure is the pre-existing claude-code live smoke test (proxy lacks the model).
- Real smoke per AGENTS.md, run twice: `bubench run --agent codex --data LexBench-Browser --mode single` → 1/1 success both times; second run `steps=7`, correct answer, `screenshots=['screenshot-1.png','screenshot-2.png']`, token usage recorded (`in=264k out=804` on first run). Log evidence: `[Codex] Tool: browser_take_screenshot`, `[Codex] Turn done: in=264261 out=804 tokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)