### PR TITLE
Add cursor agent (Cursor CLI with Playwright MCP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Agent SDKs ship as **mutually exclusive extras** (declared in `pyproject.toml` u
 
 ## High-level architecture
 
-The repo orchestrates browser agents (`browser-use`, `skyvern`, `agent-tars`, `claude-code`, `codex`, `openai-cua`, `deepbrowse`) against benchmarks (`LexBench-Browser`, `Online-Mind2Web`, `BrowseComp`) on browser backends (`Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `cdp`).
+The repo orchestrates browser agents (`browser-use`, `skyvern`, `agent-tars`, `claude-code`, `codex`, `cursor`, `openai-cua`, `deepbrowse`) against benchmarks (`LexBench-Browser`, `Online-Mind2Web`, `BrowseComp`) on browser backends (`Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `cdp`).
 
 - **CLI** ([browseruse_bench/cli/](browseruse_bench/cli/)) — argparse subcommands (`run`, `eval`, `submit`, `leaderboard`, `server`, `service`, `skills`, `viz`, `login`). [__init__.py](browseruse_bench/cli/__init__.py) preloads `.env` from `REPO_ROOT` and reads `config.yaml`. The top-level `scripts/*.py` files are thin shims — edit the CLI module, not the script.
 - **Agents** ([browseruse_bench/agents/](browseruse_bench/agents/)) — [base.py](browseruse_bench/agents/base.py) (`BaseAgent` ABC), one file per agent, plus [registry.py](browseruse_bench/agents/registry.py). Agents self-register via `@register_agent` on a unique `name`. Do not import agent SDKs at registry level.

--- a/browseruse_bench/agents/__init__.py
+++ b/browseruse_bench/agents/__init__.py
@@ -34,6 +34,11 @@ except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.codex: %s", exc)
 
 try:
+    from browseruse_bench.agents import cursor  # noqa: F401
+except ImportError as exc:
+    logger.warning("Skipping optional agent module browseruse_bench.agents.cursor: %s", exc)
+
+try:
     from browseruse_bench.agents import browser_use  # noqa: F401
 except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.browser_use: %s", exc)

--- a/browseruse_bench/agents/codex.py
+++ b/browseruse_bench/agents/codex.py
@@ -11,13 +11,21 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shutil
 import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from browseruse_bench.agents.cli_agent import CLIAgent
+from browseruse_bench.agents.playwright_mcp import (
+    DEFAULT_BROWSER_RULES,
+    SELF_LAUNCH_BROWSER_IDS,
+    STEP_ITEM_TYPES,
+    build_playwright_mcp_args,
+    collect_screenshots,
+    extract_actions,
+    write_api_logs,
+)
 from browseruse_bench.agents.registry import register_agent
 from browseruse_bench.browsers import open_browser_session
 from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
@@ -25,31 +33,6 @@ from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
 from browseruse_bench.utils import IS_WINDOWS
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_RULES = (
-    "You are a browser automation agent. "
-    "You MUST use ONLY the Playwright MCP tools (server 'playwright') for ALL browser "
-    "interactions. Do NOT run shell commands, do NOT read or write files, and do NOT "
-    "use skills or any non-Playwright tools."
-    "\n\nTask completion rules:\n"
-    "- If you can see enough information to answer the task from the current page (e.g., "
-    "ratings, names, prices visible in search results), provide your answer IMMEDIATELY "
-    "without clicking into individual items to get more detail.\n"
-    "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
-    "close that tab, return to the previous page, and use the data already collected to answer.\n"
-    "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
-    "\n\nScreenshot rules:\n"
-    "- When taking screenshots, do NOT specify a filename parameter.\n"
-    "- Take a screenshot with browser_take_screenshot after navigating to the main page "
-    "and after finding the answer."
-)
-
-# JSONL item types that represent an agent step (tool usage).
-_STEP_ITEM_TYPES = {"mcp_tool_call", "command_execution"}
-
-# Browser ids where Playwright MCP launches its own local browser instead of
-# connecting to a managed backend session over CDP.
-_SELF_LAUNCH_BROWSER_IDS = {"", "local", "Chrome-Local"}
 
 
 def _parse_events(stdout_lines: list[str]) -> tuple[str, list[dict[str, Any]], dict[str, int], str | None]:
@@ -110,119 +93,6 @@ def _extract_error_message(obj: dict[str, Any]) -> str | None:
     return None
 
 
-def _describe_item(item: dict[str, Any]) -> str | None:
-    """Map a completed step item to a short action description."""
-    item_type = item.get("type")
-    if item_type == "command_execution":
-        return f"Shell: {str(item.get('command', ''))[:80]}"
-    if item_type != "mcp_tool_call":
-        return None
-    tool = str(item.get("tool", ""))
-    arguments = item.get("arguments")
-    if not isinstance(arguments, dict):
-        arguments = {}
-    if "navigate" in tool:
-        return f"Navigate to {arguments.get('url', '')}"
-    if "click" in tool:
-        return f"Click: {arguments.get('element', arguments.get('ref', ''))}"
-    if "type" in tool or "fill" in tool:
-        return f"Type: {str(arguments.get('text', arguments.get('value', '')))[:60]}"
-    if "screenshot" in tool:
-        return "Take screenshot"
-    if "snapshot" in tool:
-        return "Take snapshot"
-    if "press" in tool:
-        return f"Press key: {arguments.get('key', '')}"
-    return tool or None
-
-
-def _extract_actions(items: list[dict[str, Any]]) -> list[str]:
-    actions: list[str] = []
-    for item in items:
-        description = _describe_item(item)
-        if description:
-            actions.append(description)
-    return actions
-
-
-def _collect_screenshots(task_workspace: Path, trajectory_dir: Path) -> list[str]:
-    """Copy Playwright MCP screenshots into trajectory/.
-
-    Screenshots land in .playwright-mcp/ by default, or in the workspace root
-    when the model passes an explicit filename despite the rules.
-    """
-    candidates: list[Path] = []
-    for parent in (task_workspace / ".playwright-mcp", task_workspace):
-        if parent.is_dir():
-            candidates += [
-                p for p in parent.iterdir() if p.suffix.lower() in (".png", ".jpeg", ".jpg")
-            ]
-    images = sorted(candidates, key=lambda p: p.stat().st_mtime)
-    saved: list[str] = []
-    for index, image in enumerate(images, 1):
-        fname = f"screenshot-{index}{image.suffix.lower()}"
-        try:
-            trajectory_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(image, trajectory_dir / fname)
-            saved.append(fname)
-        except OSError as exc:
-            logger.warning("Failed to copy screenshot %s: %s", image.name, exc)
-    return saved
-
-
-def _write_api_logs(
-    task_id: str,
-    model_id: str,
-    rules: str,
-    items: list[dict[str, Any]],
-    api_logs_dir: Path,
-) -> None:
-    """Write api_logs/step_NNN.json + system_prompt.txt for step items."""
-    api_logs_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        (api_logs_dir / "system_prompt.txt").write_text(rules, encoding="utf-8")
-    except OSError as exc:
-        logger.warning("Failed to write system_prompt.txt: %s", exc)
-
-    step_items = [item for item in items if item.get("type") in _STEP_ITEM_TYPES]
-    for step_number, item in enumerate(step_items, 1):
-        step_data = {
-            "metadata": {
-                "task_id": task_id,
-                "step_number": step_number,
-                "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
-                "model_id": model_id,
-            },
-            "output": {"actions": [{"tool": item.get("tool") or item.get("command"), "input": item.get("arguments")}]},
-            "action_results": [_item_result_summary(item)],
-        }
-        try:
-            (api_logs_dir / f"step_{step_number:03d}.json").write_text(
-                json.dumps(step_data, ensure_ascii=False, indent=2), encoding="utf-8"
-            )
-        except (OSError, TypeError) as exc:
-            logger.warning("Failed to write step %d log: %s", step_number, exc)
-
-
-def _item_result_summary(item: dict[str, Any]) -> dict[str, Any]:
-    summary: dict[str, Any] = {"status": item.get("status")}
-    result = item.get("result")
-    if isinstance(result, dict):
-        texts = [
-            block.get("text", "")
-            for block in result.get("content", [])
-            if isinstance(block, dict) and block.get("type") == "text"
-        ]
-        if texts:
-            summary["extracted_content"] = "\n".join(texts)
-    error = item.get("error")
-    if isinstance(error, dict) and error.get("message"):
-        summary["error"] = error["message"]
-    if item.get("aggregated_output"):
-        summary["extracted_content"] = str(item["aggregated_output"])[:2000]
-    return summary
-
-
 def _toml_value(value: Any) -> str:
     """Render a -c override value as TOML (JSON syntax is TOML-compatible here)."""
     return json.dumps(value, ensure_ascii=False)
@@ -255,7 +125,7 @@ class CodexAgent(CLIAgent):
         Playwright MCP, so login contexts/proxies injected by cli/run.py apply.
         """
         browser_id = str(agent_config.get("browser_id") or "")
-        if browser_id in _SELF_LAUNCH_BROWSER_IDS:
+        if browser_id in SELF_LAUNCH_BROWSER_IDS:
             warn_if_local_proxy_unsupported(agent_config, self.name)
             return self._execute(task_info, agent_config, task_workspace, cdp_url=None)
         with open_browser_session(
@@ -296,7 +166,7 @@ class CodexAgent(CLIAgent):
     ) -> AgentResult:
         task_id = task_info["task_id"]
         prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
-        rules = agent_config.get("system_prompt") or _DEFAULT_RULES
+        rules = agent_config.get("system_prompt") or DEFAULT_BROWSER_RULES
         model = agent_config.get("model_id") or agent_config.get("model", "gpt-5.5")
         timeout = self._resolve_timeout(task_id, agent_config)
 
@@ -378,12 +248,7 @@ class CodexAgent(CLIAgent):
     ) -> list[str]:
         sandbox = agent_config.get("sandbox_mode", "read-only")
         mcp_command = agent_config.get("playwright_mcp_command", "npx")
-        mcp_args = list(agent_config.get("playwright_mcp_args", ["@playwright/mcp@latest"]))
-        # --timeout-action 30000: raise from the 5000ms default (screenshots time
-        # out on pages with slow external font CDNs).
-        mcp_args += ["--timeout-action", "30000"]
-        if cdp_url:
-            mcp_args += ["--cdp-endpoint", cdp_url]
+        mcp_args = build_playwright_mcp_args(agent_config, cdp_url)
         mcp_startup_timeout = int(agent_config.get("mcp_startup_timeout", 120))
         mcp_tool_timeout = int(agent_config.get("mcp_tool_timeout", 120))
 
@@ -436,11 +301,11 @@ class CodexAgent(CLIAgent):
         if env_status == "failed" and not answer:
             answer = f"[Task Failed: {execution_error or error_message or 'No output from Codex'}]"
 
-        saved_screenshots = _collect_screenshots(task_workspace, trajectory_dir)
-        steps = sum(1 for item in items if item.get("type") in _STEP_ITEM_TYPES)
+        saved_screenshots = collect_screenshots(task_workspace, trajectory_dir)
+        steps = sum(1 for item in items if item.get("type") in STEP_ITEM_TYPES)
         if items:
             try:
-                _write_api_logs(task_id, model, rules, items, task_workspace / "api_logs")
+                write_api_logs(task_id, model, rules, items, task_workspace / "api_logs")
             except (OSError, TypeError, ValueError) as exc:
                 logger.warning("Failed to generate api_logs for task %s: %s", task_id, exc)
 
@@ -459,7 +324,7 @@ class CodexAgent(CLIAgent):
             agent_done=agent_done,  # type: ignore[arg-type]
             answer=answer,
             error=(execution_error or error_message) if env_status == "failed" else None,
-            action_history=_extract_actions(items),
+            action_history=extract_actions(items),
             screenshots=saved_screenshots,
             model_id=model,
             metrics=AgentMetrics(end_to_end_ms=duration_ms, steps=steps, usage=usage),

--- a/browseruse_bench/agents/cursor.py
+++ b/browseruse_bench/agents/cursor.py
@@ -1,0 +1,438 @@
+"""
+CursorAgent - Browser automation using Cursor CLI with Playwright MCP.
+
+This agent executes tasks by invoking `cursor-agent -p` in non-interactive mode
+(--output-format stream-json) with a Playwright MCP server injected via a
+workspace-level .cursor/mcp.json for browser control.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from browseruse_bench.agents.cli_agent import CLIAgent
+from browseruse_bench.agents.playwright_mcp import (
+    DEFAULT_BROWSER_RULES,
+    SELF_LAUNCH_BROWSER_IDS,
+    STEP_ITEM_TYPES,
+    build_playwright_mcp_args,
+    collect_screenshots,
+    extract_actions,
+    write_api_logs,
+)
+from browseruse_bench.agents.registry import register_agent
+from browseruse_bench.browsers import open_browser_session
+from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
+from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
+from browseruse_bench.utils import IS_WINDOWS
+
+logger = logging.getLogger(__name__)
+
+# Maps stream-json usage keys to the shared usage-total keys.
+_USAGE_KEY_MAP = {
+    "inputTokens": "input_tokens",
+    "cacheReadTokens": "cached_input_tokens",
+    "outputTokens": "output_tokens",
+}
+
+
+def _text_of_message(message: dict[str, Any]) -> str:
+    content = message.get("content", [])
+    if not isinstance(content, list):
+        return ""
+    parts = [
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    return "".join(parts).strip()
+
+
+def _normalize_mcp_call(started_args: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a started mcpToolCall args block to the shared item shape."""
+    arguments = started_args.get("args")
+    return {
+        "type": "mcp_tool_call",
+        "tool": str(started_args.get("toolName", "")),
+        "arguments": arguments if isinstance(arguments, dict) else {},
+        "status": "in_progress",
+    }
+
+
+def _apply_mcp_result(item: dict[str, Any], result: dict[str, Any]) -> None:
+    """Fold a completed mcpToolCall result into the normalized item."""
+    success = result.get("success")
+    if isinstance(success, dict):
+        item["status"] = "completed"
+        texts = [
+            block["text"].get("text", "")
+            for block in success.get("content", [])
+            if isinstance(block, dict) and isinstance(block.get("text"), dict)
+        ]
+        item["result"] = {"content": [{"type": "text", "text": "\n".join(texts)}]}
+        return
+    item["status"] = "failed"
+    rejected = result.get("rejected")
+    reason = rejected.get("reason") if isinstance(rejected, dict) else None
+    item["error"] = {"message": str(reason or "MCP tool call failed")}
+
+
+def _normalize_tool_call(obj: dict[str, Any], pending: dict[str, dict[str, Any]]) -> dict[str, Any] | None:
+    """Track started/completed tool_call events; return the item when completed.
+
+    Cursor splits a tool call across two events: `started` carries the args,
+    `completed` carries only the result, joined by call_id.
+    """
+    call_id = str(obj.get("call_id", ""))
+    tool_call = obj.get("tool_call")
+    if not isinstance(tool_call, dict):
+        return None
+    mcp = tool_call.get("mcpToolCall")
+    shell = tool_call.get("shellToolCall")
+    if obj.get("subtype") == "started":
+        if isinstance(mcp, dict) and isinstance(mcp.get("args"), dict):
+            pending[call_id] = _normalize_mcp_call(mcp["args"])
+        elif isinstance(shell, dict) and isinstance(shell.get("args"), dict):
+            pending[call_id] = {
+                "type": "command_execution",
+                "command": str(shell["args"].get("command", "")),
+                "status": "in_progress",
+            }
+        return None
+    if obj.get("subtype") != "completed":
+        return None
+    item = pending.pop(call_id, None) or {"type": "mcp_tool_call", "tool": "", "arguments": {}}
+    if isinstance(mcp, dict) and isinstance(mcp.get("result"), dict):
+        _apply_mcp_result(item, mcp["result"])
+    elif isinstance(shell, dict):
+        item["status"] = "completed"
+    return item
+
+
+def _parse_stream(stdout_lines: list[str]) -> tuple[str, list[dict[str, Any]], dict[str, int], dict[str, Any]]:
+    """Parse `cursor-agent --output-format stream-json` JSONL output.
+
+    Returns ``(answer, items, usage_totals, result_obj)``:
+    - *answer*: text of the last ``assistant`` message.
+    - *items*: completed tool calls normalized to the shared step-item shape.
+    - *usage_totals*: token usage from the final ``result`` event.
+    - *result_obj*: the final ``result`` event (empty when it never arrived).
+    """
+    answer = ""
+    items: list[dict[str, Any]] = []
+    usage_totals = {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+    result_obj: dict[str, Any] = {}
+    pending: dict[str, dict[str, Any]] = {}
+
+    for raw_line in stdout_lines:
+        line = raw_line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        event_type = obj.get("type")
+        if event_type == "assistant":
+            text = _text_of_message(obj.get("message", {}))
+            if text:
+                answer = text
+        elif event_type == "tool_call":
+            item = _normalize_tool_call(obj, pending)
+            if item:
+                items.append(item)
+        elif event_type == "result":
+            result_obj = obj
+            usage = obj.get("usage")
+            if isinstance(usage, dict):
+                for src_key, dst_key in _USAGE_KEY_MAP.items():
+                    value = usage.get(src_key)
+                    if isinstance(value, int | float):
+                        usage_totals[dst_key] += int(value)
+
+    return answer, items, usage_totals, result_obj
+
+
+@register_agent
+class CursorAgent(CLIAgent):
+    """
+    Browser automation agent using Cursor CLI with Playwright MCP.
+
+    Cursor is invoked as an external process via `cursor-agent -p`. The
+    Playwright MCP server and the permission policy (allow MCP, deny shell)
+    are written to workspace-level .cursor/ config files; --force is required
+    because non-interactive mode auto-rejects MCP tool approvals otherwise.
+    Install and authenticate first:
+      curl https://cursor.com/install -fsS | bash
+      cursor-agent login   # or CURSOR_API_KEY
+    """
+
+    name = "cursor"
+
+    def run_task(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+    ) -> AgentResult | dict[str, Any]:
+        """Execute a browser automation task using Cursor CLI.
+
+        With a managed browser backend configured (e.g. lexmount, cdp), the
+        backend session is opened first and its CDP endpoint is handed to
+        Playwright MCP, so login contexts/proxies injected by cli/run.py apply.
+        """
+        browser_id = str(agent_config.get("browser_id") or "")
+        if browser_id in SELF_LAUNCH_BROWSER_IDS:
+            warn_if_local_proxy_unsupported(agent_config, self.name)
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=None)
+        with open_browser_session(
+            browser_id=browser_id,
+            agent_name=self.name,
+            agent_config=agent_config,
+        ) as session_context:
+            cdp_url = session_context.cdp_url if session_context.transport == "cdp" else None
+            if not cdp_url:
+                return self._unsupported_backend_result(
+                    task_info["task_id"], browser_id, session_context.transport
+                )
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=cdp_url)
+
+    def _unsupported_backend_result(
+        self, task_id: str, browser_id: str, transport: str
+    ) -> AgentResult:
+        """Fail fast instead of silently self-launching a local browser."""
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status="failed",  # type: ignore[arg-type]
+            agent_done="error",  # type: ignore[arg-type]
+            error=(
+                f"Browser backend '{browser_id}' (transport={transport}) provides no CDP "
+                "endpoint, so the cursor agent cannot attach Playwright MCP to it. "
+                "Use a CDP-capable backend (e.g. lexmount, cdp) or browser_id=local."
+            ),
+            metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+        )
+
+    def _execute(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        cdp_url: str | None,
+    ) -> AgentResult:
+        task_id = task_info["task_id"]
+        prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
+        rules = agent_config.get("system_prompt") or DEFAULT_BROWSER_RULES
+        model = agent_config.get("model_id") or agent_config.get("model", "gpt-5.2")
+        timeout = self._resolve_timeout(task_id, agent_config)
+
+        trajectory_dir = task_workspace / "trajectory"
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+        self._write_workspace_config(agent_config, task_workspace, cdp_url)
+        cmd = self._build_command(f"{rules}\n\n{prompt}", model, task_workspace, agent_config)
+
+        env = {**os.environ}
+        if agent_config.get("api_key"):
+            env["CURSOR_API_KEY"] = str(agent_config["api_key"])
+
+        logger.info("Executing Cursor for task %s (model=%s, timeout=%ds)", task_id, model, timeout)
+        t_start = time.monotonic()
+        try:
+            returncode, stdout_lines, execution_error = self._run_subprocess(
+                cmd,
+                timeout=timeout,
+                task_workspace=task_workspace,
+                cwd=task_workspace,
+                env=env,
+                collect_stdout=True,
+                stdout_line_hook=_stdout_hook,
+                stderr_line_hook=_stderr_hook,
+            )
+        except FileNotFoundError:
+            return AgentResult(
+                task_id=task_id,
+                timestamp=datetime.now(UTC),
+                env_status="failed",  # type: ignore[arg-type]
+                agent_done="error",  # type: ignore[arg-type]
+                error=(
+                    "Executable 'cursor-agent' not found. "
+                    "Please install Cursor CLI: curl https://cursor.com/install -fsS | bash"
+                ),
+                metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+            )
+        duration_ms = int((time.monotonic() - t_start) * 1000)
+
+        return self._finalize_result(
+            task_id=task_id,
+            model=model,
+            rules=rules,
+            stdout_lines=stdout_lines,
+            returncode=returncode,
+            execution_error=execution_error,
+            duration_ms=duration_ms,
+            task_workspace=task_workspace,
+            trajectory_dir=trajectory_dir,
+        )
+
+    @staticmethod
+    def _resolve_timeout(task_id: str, agent_config: dict[str, Any]) -> int:
+        timeout_val = agent_config.get("timeout_seconds") or agent_config.get("timeout", 600)
+        try:
+            return int(timeout_val)
+        except (TypeError, ValueError) as exc:
+            logger.warning("Invalid timeout for task %s (%r): %s", task_id, timeout_val, exc)
+            return 600
+
+    @staticmethod
+    def _write_workspace_config(
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        cdp_url: str | None,
+    ) -> None:
+        """Write .cursor/mcp.json (Playwright server) and .cursor/cli.json (permissions)."""
+        cursor_dir = task_workspace / ".cursor"
+        cursor_dir.mkdir(parents=True, exist_ok=True)
+        mcp_config = {
+            "mcpServers": {
+                "playwright": {
+                    "command": agent_config.get("playwright_mcp_command", "npx"),
+                    "args": build_playwright_mcp_args(agent_config, cdp_url),
+                }
+            }
+        }
+        (cursor_dir / "mcp.json").write_text(
+            json.dumps(mcp_config, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        # --force auto-approves tool calls unless explicitly denied, so deny all
+        # shell here; browsing happens exclusively through the MCP server.
+        permissions = {
+            "permissions": {
+                "allow": ["Mcp(playwright)"],
+                "deny": ["Shell(**)"],
+            }
+        }
+        (cursor_dir / "cli.json").write_text(
+            json.dumps(permissions, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    @staticmethod
+    def _build_command(
+        full_prompt: str,
+        model: str,
+        task_workspace: Path,
+        agent_config: dict[str, Any] | None = None,
+    ) -> list[str]:
+        default_exe = "cursor-agent.cmd" if IS_WINDOWS else "cursor-agent"
+        exe = str((agent_config or {}).get("cursor_agent_command") or default_exe)
+        return [
+            exe,
+            "-p", full_prompt,
+            "--output-format", "stream-json",
+            "--model", model,
+            "--workspace", str(task_workspace),
+            "--trust",          # headless mode: trust the task workspace
+            "--approve-mcps",   # auto-approve the injected MCP server
+            # Required: non-interactive runs auto-reject MCP tool approvals
+            # otherwise ("User rejected MCP: ..."). Shell stays blocked via the
+            # deny rule in .cursor/cli.json.
+            "--force",
+        ]
+
+    def _finalize_result(
+        self,
+        task_id: str,
+        model: str,
+        rules: str,
+        stdout_lines: list[str],
+        returncode: int,
+        execution_error: str | None,
+        duration_ms: int,
+        task_workspace: Path,
+        trajectory_dir: Path,
+    ) -> AgentResult:
+        answer, items, usage_totals, result_obj = _parse_stream(stdout_lines)
+        if not answer and isinstance(result_obj.get("result"), str):
+            answer = result_obj["result"].strip()
+
+        if execution_error and "Timeout" in execution_error:
+            logger.error("Cursor task %s timed out", task_id)
+        env_status, agent_done = self._map_exit_status(
+            returncode, execution_error, has_result=bool(answer)
+        )
+        error_message = self._result_error(result_obj)
+        if agent_done != "timeout" and error_message:
+            env_status, agent_done = "failed", "error"
+        if env_status == "failed" and not answer:
+            answer = f"[Task Failed: {execution_error or error_message or 'No output from Cursor'}]"
+
+        saved_screenshots = collect_screenshots(task_workspace, trajectory_dir)
+        steps = sum(1 for item in items if item.get("type") in STEP_ITEM_TYPES)
+        if items:
+            try:
+                write_api_logs(task_id, model, rules, items, task_workspace / "api_logs")
+            except (OSError, TypeError, ValueError) as exc:
+                logger.warning("Failed to generate api_logs for task %s: %s", task_id, exc)
+
+        total_tokens = usage_totals["input_tokens"] + usage_totals["output_tokens"]
+        usage = AgentUsage(
+            total_prompt_tokens=usage_totals["input_tokens"],
+            total_prompt_cached_tokens=usage_totals["cached_input_tokens"],
+            total_completion_tokens=usage_totals["output_tokens"],
+            total_tokens=total_tokens,
+        ) if total_tokens else None
+
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status=env_status,  # type: ignore[arg-type]
+            agent_done=agent_done,  # type: ignore[arg-type]
+            answer=answer,
+            error=(execution_error or error_message) if env_status == "failed" else None,
+            action_history=extract_actions(items),
+            screenshots=saved_screenshots,
+            model_id=model,
+            metrics=AgentMetrics(end_to_end_ms=duration_ms, steps=steps, usage=usage),
+        )
+
+    @staticmethod
+    def _result_error(result_obj: dict[str, Any]) -> str | None:
+        """Extract an error message from the final result event, if any."""
+        if not result_obj:
+            return None
+        if result_obj.get("is_error") or result_obj.get("subtype") != "success":
+            return str(result_obj.get("result") or "Cursor reported an error result")
+        return None
+
+
+def _stdout_hook(line: str) -> None:
+    clean = line.strip()
+    if not clean.startswith("{"):
+        return
+    try:
+        obj = json.loads(clean)
+    except json.JSONDecodeError:
+        return
+    if obj.get("type") == "tool_call" and obj.get("subtype") == "started":
+        mcp = obj.get("tool_call", {}).get("mcpToolCall", {})
+        if isinstance(mcp, dict) and isinstance(mcp.get("args"), dict):
+            logger.info("[Cursor] Tool: %s", mcp["args"].get("toolName", ""))
+    elif obj.get("type") == "result":
+        usage = obj.get("usage", {})
+        if isinstance(usage, dict):
+            logger.info(
+                "[Cursor] Done: in=%s out=%s tokens",
+                usage.get("inputTokens"), usage.get("outputTokens"),
+            )
+
+
+def _stderr_hook(line: str) -> None:
+    clean = line.strip()
+    if clean and "error" in clean.lower():
+        logger.warning("[Cursor] %s", clean)

--- a/browseruse_bench/agents/cursor.py
+++ b/browseruse_bench/agents/cursor.py
@@ -241,6 +241,14 @@ class CursorAgent(CLIAgent):
         env = {**os.environ}
         if agent_config.get("api_key"):
             env["CURSOR_API_KEY"] = str(agent_config["api_key"])
+        # Isolate from the operator's global ~/.cursor (MCP servers, rules):
+        # only the workspace-injected Playwright MCP server may be loaded.
+        # Requires API-key auth; set isolate_user_config: false to keep the
+        # global config dir (and OAuth login state) instead.
+        if agent_config.get("isolate_user_config", True):
+            config_dir = task_workspace / ".cursor-config"
+            config_dir.mkdir(parents=True, exist_ok=True)
+            env["CURSOR_CONFIG_DIR"] = str(config_dir)
 
         logger.info("Executing Cursor for task %s (model=%s, timeout=%ds)", task_id, model, timeout)
         t_start = time.monotonic()
@@ -310,12 +318,13 @@ class CursorAgent(CLIAgent):
         (cursor_dir / "mcp.json").write_text(
             json.dumps(mcp_config, ensure_ascii=False, indent=2), encoding="utf-8"
         )
-        # --force auto-approves tool calls unless explicitly denied, so deny all
-        # shell here; browsing happens exclusively through the MCP server.
+        # --force auto-approves tool calls unless explicitly denied, so deny
+        # shell, web-fetch, and file tools here; browsing happens exclusively
+        # through the MCP server.
         permissions = {
             "permissions": {
                 "allow": ["Mcp(playwright)"],
-                "deny": ["Shell(**)"],
+                "deny": ["Shell(**)", "WebFetch(**)", "Read(**)", "Write(**)"],
             }
         }
         (cursor_dir / "cli.json").write_text(
@@ -367,6 +376,11 @@ class CursorAgent(CLIAgent):
             returncode, execution_error, has_result=bool(answer)
         )
         error_message = self._result_error(result_obj)
+        # A normal run always ends with a terminal result event; exiting
+        # without one (e.g. MCP startup failure after a partial preamble)
+        # is a failure even when some assistant text was emitted.
+        if not result_obj and not error_message:
+            error_message = "Cursor exited without a terminal result event"
         if agent_done != "timeout" and error_message:
             env_status, agent_done = "failed", "error"
         if env_status == "failed" and not answer:

--- a/browseruse_bench/agents/playwright_mcp.py
+++ b/browseruse_bench/agents/playwright_mcp.py
@@ -1,0 +1,172 @@
+"""
+Shared helpers for CLI agents that drive the browser via Playwright MCP.
+
+Used by the codex and cursor agents: browser rules, MCP server argument
+construction, screenshot collection, action descriptions, and api_logs output.
+The normalized step-item shape is::
+
+    {"type": "mcp_tool_call", "tool": ..., "arguments": {...},
+     "status": ..., "result": {"content": [{"type": "text", "text": ...}]},
+     "error": {"message": ...}}
+    {"type": "command_execution", "command": ..., "status": ...}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BROWSER_RULES = (
+    "You are a browser automation agent. "
+    "You MUST use ONLY the Playwright MCP tools (server 'playwright') for ALL browser "
+    "interactions. Do NOT run shell commands, do NOT read or write files, and do NOT "
+    "use skills or any non-Playwright tools."
+    "\n\nTask completion rules:\n"
+    "- If you can see enough information to answer the task from the current page (e.g., "
+    "ratings, names, prices visible in search results), provide your answer IMMEDIATELY "
+    "without clicking into individual items to get more detail.\n"
+    "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
+    "close that tab, return to the previous page, and use the data already collected to answer.\n"
+    "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+    "\n\nScreenshot rules:\n"
+    "- When taking screenshots, do NOT specify a filename parameter.\n"
+    "- Take a screenshot with browser_take_screenshot after navigating to the main page "
+    "and after finding the answer."
+)
+
+# JSONL item types that represent an agent step (tool usage).
+STEP_ITEM_TYPES = {"mcp_tool_call", "command_execution"}
+
+# Browser ids where Playwright MCP launches its own local browser instead of
+# connecting to a managed backend session over CDP.
+SELF_LAUNCH_BROWSER_IDS = {"", "local", "Chrome-Local"}
+
+
+def build_playwright_mcp_args(agent_config: dict[str, Any], cdp_url: str | None) -> list[str]:
+    """Build the Playwright MCP server argument list from agent config."""
+    mcp_args = list(agent_config.get("playwright_mcp_args", ["@playwright/mcp@latest"]))
+    # --timeout-action 30000: raise from the 5000ms default (screenshots time
+    # out on pages with slow external font CDNs).
+    mcp_args += ["--timeout-action", "30000"]
+    if cdp_url:
+        mcp_args += ["--cdp-endpoint", cdp_url]
+    return mcp_args
+
+
+def collect_screenshots(task_workspace: Path, trajectory_dir: Path) -> list[str]:
+    """Copy Playwright MCP screenshots into trajectory/.
+
+    Screenshots land in .playwright-mcp/ by default, or in the workspace root
+    when the model passes an explicit filename despite the rules.
+    """
+    candidates: list[Path] = []
+    for parent in (task_workspace / ".playwright-mcp", task_workspace):
+        if parent.is_dir():
+            candidates += [
+                p for p in parent.iterdir() if p.suffix.lower() in (".png", ".jpeg", ".jpg")
+            ]
+    images = sorted(candidates, key=lambda p: p.stat().st_mtime)
+    saved: list[str] = []
+    for index, image in enumerate(images, 1):
+        fname = f"screenshot-{index}{image.suffix.lower()}"
+        try:
+            trajectory_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(image, trajectory_dir / fname)
+            saved.append(fname)
+        except OSError as exc:
+            logger.warning("Failed to copy screenshot %s: %s", image.name, exc)
+    return saved
+
+
+def describe_item(item: dict[str, Any]) -> str | None:
+    """Map a completed step item to a short action description."""
+    item_type = item.get("type")
+    if item_type == "command_execution":
+        return f"Shell: {str(item.get('command', ''))[:80]}"
+    if item_type != "mcp_tool_call":
+        return None
+    tool = str(item.get("tool", ""))
+    arguments = item.get("arguments")
+    if not isinstance(arguments, dict):
+        arguments = {}
+    if "navigate" in tool:
+        return f"Navigate to {arguments.get('url', '')}"
+    if "click" in tool:
+        return f"Click: {arguments.get('element', arguments.get('ref', ''))}"
+    if "type" in tool or "fill" in tool:
+        return f"Type: {str(arguments.get('text', arguments.get('value', '')))[:60]}"
+    if "screenshot" in tool:
+        return "Take screenshot"
+    if "snapshot" in tool:
+        return "Take snapshot"
+    if "press" in tool:
+        return f"Press key: {arguments.get('key', '')}"
+    return tool or None
+
+
+def extract_actions(items: list[dict[str, Any]]) -> list[str]:
+    actions: list[str] = []
+    for item in items:
+        description = describe_item(item)
+        if description:
+            actions.append(description)
+    return actions
+
+
+def write_api_logs(
+    task_id: str,
+    model_id: str,
+    rules: str,
+    items: list[dict[str, Any]],
+    api_logs_dir: Path,
+) -> None:
+    """Write api_logs/step_NNN.json + system_prompt.txt for step items."""
+    api_logs_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        (api_logs_dir / "system_prompt.txt").write_text(rules, encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Failed to write system_prompt.txt: %s", exc)
+
+    step_items = [item for item in items if item.get("type") in STEP_ITEM_TYPES]
+    for step_number, item in enumerate(step_items, 1):
+        step_data = {
+            "metadata": {
+                "task_id": task_id,
+                "step_number": step_number,
+                "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
+                "model_id": model_id,
+            },
+            "output": {"actions": [{"tool": item.get("tool") or item.get("command"), "input": item.get("arguments")}]},
+            "action_results": [item_result_summary(item)],
+        }
+        try:
+            (api_logs_dir / f"step_{step_number:03d}.json").write_text(
+                json.dumps(step_data, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        except (OSError, TypeError) as exc:
+            logger.warning("Failed to write step %d log: %s", step_number, exc)
+
+
+def item_result_summary(item: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {"status": item.get("status")}
+    result = item.get("result")
+    if isinstance(result, dict):
+        texts = [
+            block.get("text", "")
+            for block in result.get("content", [])
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        if texts:
+            summary["extracted_content"] = "\n".join(texts)
+    error = item.get("error")
+    if isinstance(error, dict) and error.get("message"):
+        summary["error"] = error["message"]
+    if item.get("aggregated_output"):
+        summary["extracted_content"] = str(item["aggregated_output"])[:2000]
+    return summary

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -160,6 +160,13 @@ models:
     model_type: OPENAI
     model_id: gpt-5.5
     api_key: $OPENAI_API_KEY
+  # Cursor CLI model. Only supported by the cursor agent; model calls are
+  # routed through Cursor's backend, so auth is `cursor-agent login` or
+  # CURSOR_API_KEY (a Cursor key, not an OpenAI key).
+  cursor:
+    model_type: OPENAI
+    model_id: gpt-5.2
+    api_key: $CURSOR_API_KEY
 browsers:
   lexmount:
     browser_id: lexmount
@@ -234,6 +241,9 @@ agents:
     active_model: codex
     timeout: 600
     sandbox_mode: read-only
+  cursor:
+    active_model: cursor
+    timeout: 600
   deepbrowse:
     use_vision: auto
     max_steps: 50

--- a/configs/agent_registry.yaml
+++ b/configs/agent_registry.yaml
@@ -53,6 +53,17 @@ codex:
     - WebVoyager
     - Odysseys
 
+cursor:
+  path: browseruse_bench/agents
+  entrypoint: browseruse_bench/runner/agent_runner.py
+  venv: .venv
+  supported_benchmarks:
+    - Online-Mind2Web
+    - BrowseComp
+    - LexBench-Browser
+    - WebVoyager
+    - Odysseys
+
 deepbrowse:
   path: browseruse_bench/agents
   entrypoint: browseruse_bench/runner/agent_runner.py

--- a/tests/browseruse_bench/test_codex_agent.py
+++ b/tests/browseruse_bench/test_codex_agent.py
@@ -8,11 +8,12 @@ from typing import Any
 
 import pytest
 
-from browseruse_bench.agents.codex import (
-    CodexAgent,
-    _collect_screenshots,
-    _extract_actions,
-    _parse_events,
+from browseruse_bench.agents.codex import CodexAgent, _parse_events
+from browseruse_bench.agents.playwright_mcp import (
+    collect_screenshots as _collect_screenshots,
+)
+from browseruse_bench.agents.playwright_mcp import (
+    extract_actions as _extract_actions,
 )
 from browseruse_bench.schemas import AgentResult
 

--- a/tests/browseruse_bench/test_cursor_agent.py
+++ b/tests/browseruse_bench/test_cursor_agent.py
@@ -170,7 +170,9 @@ class TestCursorAgentRunTask:
 
         permissions = json.loads((tmp_path / ".cursor" / "cli.json").read_text())
         assert permissions["permissions"]["allow"] == ["Mcp(playwright)"]
-        assert permissions["permissions"]["deny"] == ["Shell(**)"]
+        assert permissions["permissions"]["deny"] == [
+            "Shell(**)", "WebFetch(**)", "Read(**)", "Write(**)",
+        ]
 
     def test_command_flags(self, tmp_path: Path) -> None:
         cmd = CursorAgent._build_command("do it", "gpt-test", tmp_path)
@@ -204,6 +206,37 @@ class TestCursorAgentRunTask:
         assert result.env_status == "success"
         assert result.agent_done == "timeout"
         assert "4.5 stars" in result.answer
+
+    def test_missing_result_event_is_error_despite_partial_text(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A crash after a preamble (e.g. MCP startup failure) must not be
+        # recorded as success just because some assistant text was emitted.
+        stream = [_assistant("I'll navigate to the page now")]
+        agent = CursorAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (1, stream, None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "terminal result" in (result.error or "")
+
+    def test_isolates_user_config_dir_by_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        captured_env: dict[str, str] = {}
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            captured_env.update(kw.get("env") or {})
+            return 0, self._stream(), None
+
+        agent = CursorAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert captured_env["CURSOR_CONFIG_DIR"] == str(tmp_path / ".cursor-config")
+
+        captured_env.clear()
+        agent.run_task(TASK_INFO, {**AGENT_CONFIG, "isolate_user_config": False}, tmp_path)
+        assert str(tmp_path / ".cursor-config") != captured_env.get("CURSOR_CONFIG_DIR", "")
 
     def test_executable_not_found_returns_error_result(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/browseruse_bench/test_cursor_agent.py
+++ b/tests/browseruse_bench/test_cursor_agent.py
@@ -1,0 +1,274 @@
+"""Tests for CursorAgent: _parse_stream, tool-call normalization, and run_task."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from browseruse_bench.agents.cursor import CursorAgent, _parse_stream
+from browseruse_bench.schemas import AgentResult
+
+
+def _line(obj: dict[str, Any]) -> str:
+    return json.dumps(obj) + "\n"
+
+
+def _assistant(text: str) -> str:
+    return _line({
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _mcp_started(call_id: str, tool: str, arguments: dict[str, Any]) -> str:
+    return _line({
+        "type": "tool_call",
+        "subtype": "started",
+        "call_id": call_id,
+        "tool_call": {"mcpToolCall": {"args": {
+            "name": f"playwright-{tool}",
+            "args": arguments,
+            "toolName": tool,
+            "providerIdentifier": "playwright",
+        }}},
+    })
+
+
+def _mcp_completed(call_id: str, text: str | None = None, rejected: str | None = None) -> str:
+    if rejected is not None:
+        result: dict[str, Any] = {"rejected": {"reason": rejected, "isReadonly": False}}
+    else:
+        result = {"success": {"content": [{"text": {"text": text or ""}}], "isError": False}}
+    return _line({
+        "type": "tool_call",
+        "subtype": "completed",
+        "call_id": call_id,
+        "tool_call": {"mcpToolCall": {"result": result}},
+    })
+
+
+def _result(text: str, is_error: bool = False, subtype: str = "success") -> str:
+    return _line({
+        "type": "result",
+        "subtype": subtype,
+        "duration_ms": 1500,
+        "is_error": is_error,
+        "result": text,
+        "usage": {"inputTokens": 100, "outputTokens": 20, "cacheReadTokens": 40, "cacheWriteTokens": 0},
+    })
+
+
+TASK_INFO: dict[str, Any] = {
+    "task_id": "t1",
+    "task_text": "Go to example.com",
+    "url": "https://example.com",
+}
+
+AGENT_CONFIG: dict[str, Any] = {
+    "model_id": "gpt-test",
+    "timeout": 10,
+}
+
+
+class TestParseStream:
+    def test_empty_input(self) -> None:
+        answer, items, usage, result_obj = _parse_stream([])
+        assert answer == ""
+        assert items == []
+        assert usage == {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+        assert result_obj == {}
+
+    def test_last_assistant_message_wins(self) -> None:
+        lines = [_assistant("first"), _assistant("final answer"), _result("first final answer")]
+        answer, _, usage, result_obj = _parse_stream(lines)
+        assert answer == "final answer"
+        assert usage == {"input_tokens": 100, "cached_input_tokens": 40, "output_tokens": 20}
+        assert result_obj["is_error"] is False
+
+    def test_tool_call_started_completed_joined_by_call_id(self) -> None:
+        lines = [
+            _mcp_started("c1", "browser_navigate", {"url": "https://example.com"}),
+            _mcp_completed("c1", text="Page Title: Example Domain"),
+        ]
+        _, items, _, _ = _parse_stream(lines)
+        assert len(items) == 1
+        item = items[0]
+        assert item["type"] == "mcp_tool_call"
+        assert item["tool"] == "browser_navigate"
+        assert item["arguments"] == {"url": "https://example.com"}
+        assert item["status"] == "completed"
+        assert item["result"]["content"][0]["text"] == "Page Title: Example Domain"
+
+    def test_rejected_tool_call_marked_failed(self) -> None:
+        lines = [
+            _mcp_started("c1", "browser_navigate", {"url": "https://example.com"}),
+            _mcp_completed("c1", rejected="User rejected MCP: playwright-browser_navigate"),
+        ]
+        _, items, _, _ = _parse_stream(lines)
+        assert items[0]["status"] == "failed"
+        assert "rejected" in items[0]["error"]["message"]
+
+    def test_shell_tool_call_normalized(self) -> None:
+        lines = [
+            _line({
+                "type": "tool_call", "subtype": "started", "call_id": "s1",
+                "tool_call": {"shellToolCall": {"args": {"command": "whoami"}}},
+            }),
+            _line({
+                "type": "tool_call", "subtype": "completed", "call_id": "s1",
+                "tool_call": {"shellToolCall": {"result": {"permissionDenied": {"command": "whoami"}}}},
+            }),
+        ]
+        _, items, _, _ = _parse_stream(lines)
+        assert items[0]["type"] == "command_execution"
+        assert items[0]["command"] == "whoami"
+
+    def test_invalid_lines_skipped(self) -> None:
+        lines = ["not json\n", "{broken\n", _assistant("ok")]
+        answer, _, _, _ = _parse_stream(lines)
+        assert answer == "ok"
+
+
+class TestCursorAgentRunTask:
+    def _stream(self) -> list[str]:
+        return [
+            _mcp_started("c1", "browser_navigate", {"url": "https://example.com"}),
+            _mcp_completed("c1", text="Page Title: Example Domain"),
+            _assistant("The price is $42"),
+            _result("The price is $42"),
+        ]
+
+    def test_successful_run_returns_answer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = CursorAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, self._stream(), None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert isinstance(result, AgentResult)
+        assert result.answer == "The price is $42"
+        assert result.env_status == "success"
+        assert result.agent_done == "done"
+        assert result.metrics.steps == 1
+        assert result.metrics.usage is not None
+        assert result.metrics.usage.total_prompt_tokens == 100
+        assert result.metrics.usage.total_prompt_cached_tokens == 40
+        assert result.action_history == ["Navigate to https://example.com"]
+
+    def test_workspace_config_written(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = CursorAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, self._stream(), None))
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+
+        mcp_config = json.loads((tmp_path / ".cursor" / "mcp.json").read_text())
+        assert mcp_config["mcpServers"]["playwright"]["command"] == "npx"
+        assert "@playwright/mcp@latest" in mcp_config["mcpServers"]["playwright"]["args"]
+
+        permissions = json.loads((tmp_path / ".cursor" / "cli.json").read_text())
+        assert permissions["permissions"]["allow"] == ["Mcp(playwright)"]
+        assert permissions["permissions"]["deny"] == ["Shell(**)"]
+
+    def test_command_flags(self, tmp_path: Path) -> None:
+        cmd = CursorAgent._build_command("do it", "gpt-test", tmp_path)
+        assert cmd[:3] == ["cursor-agent", "-p", "do it"]
+        assert "--force" in cmd
+        assert "--trust" in cmd
+        assert "--approve-mcps" in cmd
+        i = cmd.index("--output-format")
+        assert cmd[i:i + 2] == ["--output-format", "stream-json"]
+
+    def test_error_result_marks_failed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        stream = [_assistant("partial narration"), _result("boom", is_error=True, subtype="error")]
+        agent = CursorAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, stream, None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert result.answer == "partial narration"
+
+    def test_timeout_keeps_partial_answer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        stream = [_assistant("rating is 4.5 stars")]
+        agent = CursorAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (-1, stream, "Timeout after 10 seconds")
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "success"
+        assert result.agent_done == "timeout"
+        assert "4.5 stars" in result.answer
+
+    def test_executable_not_found_returns_error_result(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = CursorAgent()
+
+        def _raise(*a: Any, **kw: Any) -> None:
+            raise FileNotFoundError("cursor-agent not found")
+
+        monkeypatch.setattr(agent, "_run_subprocess", _raise)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "not found" in (result.error or "").lower()
+
+    def test_managed_browser_opens_backend_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import cursor as cursor_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        opened: dict[str, str] = {}
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            opened["browser_id"] = browser_id
+            yield BrowserSessionContext(
+                backend_id=browser_id, transport="cdp", cdp_url="ws://cdp.example/1"
+            )
+
+        monkeypatch.setattr(cursor_module, "open_browser_session", fake_session)
+        agent = CursorAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, self._stream(), None))
+        config = {**AGENT_CONFIG, "browser_id": "lexmount"}
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+
+        mcp_config = json.loads((tmp_path / ".cursor" / "mcp.json").read_text())
+        args = mcp_config["mcpServers"]["playwright"]["args"]
+        assert opened["browser_id"] == "lexmount"
+        assert "--cdp-endpoint" in args
+        assert "ws://cdp.example/1" in args
+        assert result.env_status == "success"
+
+    def test_non_cdp_backend_fails_fast(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import cursor as cursor_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            yield BrowserSessionContext(backend_id=browser_id, transport="cloud_native")
+
+        monkeypatch.setattr(cursor_module, "open_browser_session", fake_session)
+        agent = CursorAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            lambda *a, **kw: pytest.fail("subprocess must not be launched"),
+        )
+        config = {**AGENT_CONFIG, "browser_id": "browser-use-cloud"}
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "browser-use-cloud" in (result.error or "")


### PR DESCRIPTION
## Summary

Adds `cursor` as a new browser agent: invokes `cursor-agent -p` non-interactively (`--output-format stream-json`) and drives the browser exclusively through a Playwright MCP server injected via workspace-level `.cursor/mcp.json`. Follows the same contract as the `codex` agent (PR #41), with the shared Playwright-MCP plumbing extracted into `agents/playwright_mcp.py`.

## Implementation notes

- **MCP approval gate**: `--force` is load-bearing — non-interactive runs auto-reject every MCP tool call otherwise (`User rejected MCP: playwright-browser_navigate`; verified the permission rules in `.cursor/cli.json` alone don't unlock MCP calls). Shell stays blocked via `deny: ["Shell(**)"]`, which still applies under `--force` — empirically verified (`shellToolCall` → `permissionDenied`).
- **Managed browsers**: CDP backends (lexmount, cdp) are opened via `open_browser_session` and attached with `--cdp-endpoint`; non-CDP cloud-native backends fail fast with a clear error instead of silently self-launching a local browser.
- **Event parsing**: `tool_call` events arrive as `started` (args) + `completed` (result) pairs joined by `call_id`; they are normalized to the shared step-item shape. Answer = last `assistant` message (the final `result.result` field concatenates all narration, so it is only a fallback). Unrecovered error results (`is_error` / `subtype != success`) mark the run failed even with partial answer text.
- **Dedup**: rules text, MCP args construction, screenshot collection, action descriptions, and api_logs moved from `codex.py` to `agents/playwright_mcp.py` and reused by both agents — mechanical refactor, codex behavior unchanged (all 20 codex tests pass unchanged plus a fresh regression smoke).
- **Auth**: `cursor-agent login` or `CURSOR_API_KEY` (`models.cursor.api_key`). The Cursor CLI routes model calls through Cursor's backend; it has no `OPENAI_API_KEY`/BYOK support (verified: zero occurrences in the CLI bundle).

## Prerequisites

```bash
curl https://cursor.com/install -fsS | bash
cursor-agent login        # or CURSOR_API_KEY in .env
```

## Testing

- `uv run pytest tests/` → 445 passed (16 new cursor tests: stream parsing, started/completed join, rejected calls, shell normalization, workspace config writing, command flags, error mapping, timeout, managed/unsupported backends). Only failure is the pre-existing claude-code live smoke test.
- Real smokes per AGENTS.md:
  - `bubench run --agent cursor --data LexBench-Browser --mode single` → 1/1 success through a lexmount session (`Lexmount session created: wss://...`), steps=8, 2 screenshots, correct answer, usage recorded (56k in / 1.9k out).
  - Codex regression (shared-helper refactor touches its runtime path): `bubench run --agent codex --data LexBench-Browser --mode single` → 1/1 success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)