### PR TITLE
Add openclaw agent (OpenClaw CLI with built-in browser tool)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Agent SDKs ship as **mutually exclusive extras** (declared in `pyproject.toml` u
 
 ## High-level architecture
 
-The repo orchestrates browser agents (`browser-use`, `skyvern`, `agent-tars`, `claude-code`, `codex`, `cursor`, `openai-cua`, `deepbrowse`) against benchmarks (`LexBench-Browser`, `Online-Mind2Web`, `BrowseComp`) on browser backends (`Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `cdp`).
+The repo orchestrates browser agents (`browser-use`, `skyvern`, `agent-tars`, `claude-code`, `codex`, `cursor`, `openclaw`, `openai-cua`, `deepbrowse`) against benchmarks (`LexBench-Browser`, `Online-Mind2Web`, `BrowseComp`) on browser backends (`Chrome-Local`, `lexmount`, `browser-use-cloud`, `agentbay`, `cdp`).
 
 - **CLI** ([browseruse_bench/cli/](browseruse_bench/cli/)) — argparse subcommands (`run`, `eval`, `submit`, `leaderboard`, `server`, `service`, `skills`, `viz`, `login`). [__init__.py](browseruse_bench/cli/__init__.py) preloads `.env` from `REPO_ROOT` and reads `config.yaml`. The top-level `scripts/*.py` files are thin shims — edit the CLI module, not the script.
 - **Agents** ([browseruse_bench/agents/](browseruse_bench/agents/)) — [base.py](browseruse_bench/agents/base.py) (`BaseAgent` ABC), one file per agent, plus [registry.py](browseruse_bench/agents/registry.py). Agents self-register via `@register_agent` on a unique `name`. Do not import agent SDKs at registry level.

--- a/browseruse_bench/agents/__init__.py
+++ b/browseruse_bench/agents/__init__.py
@@ -39,6 +39,11 @@ except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.cursor: %s", exc)
 
 try:
+    from browseruse_bench.agents import openclaw  # noqa: F401
+except ImportError as exc:
+    logger.warning("Skipping optional agent module browseruse_bench.agents.openclaw: %s", exc)
+
+try:
     from browseruse_bench.agents import browser_use  # noqa: F401
 except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.browser_use: %s", exc)

--- a/browseruse_bench/agents/cli_agent.py
+++ b/browseruse_bench/agents/cli_agent.py
@@ -11,9 +11,10 @@ from this class instead of BaseAgent directly. It provides:
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 from threading import Thread
-from typing import Any, Callable, TextIO
+from typing import TextIO
 
 from browseruse_bench.agents.base import BaseAgent
 
@@ -37,6 +38,7 @@ class CLIAgent(BaseAgent):
         collect_stdout: bool = True,
         stdout_line_hook: Callable[[str], None] | None = None,
         stderr_line_hook: Callable[[str], None] | None = None,
+        stop_predicate: Callable[[list[str]], bool] | None = None,
     ) -> tuple[int, list[str], str | None]:
         """Launch *cmd*, draining stdout/stderr to files in *task_workspace*.
 
@@ -54,10 +56,17 @@ class CLIAgent(BaseAgent):
                             child process and parsed later (e.g. Agent-TARS).
             stdout_line_hook: Called with each raw stdout line for live logging.
             stderr_line_hook: Called with each raw stderr line for live logging.
+            stop_predicate: Called with the collected stdout lines after each
+                            line; returning True terminates the process early
+                            with a zero exit status. For CLIs whose useful
+                            output is complete before the process exits (e.g.
+                            a child service keeps it alive). Requires
+                            collect_stdout=True.
 
         Returns:
             ``(returncode, stdout_lines, execution_error)``
-            - *returncode*: process exit code, or -1 on timeout/error.
+            - *returncode*: process exit code, or -1 on timeout/error; 0 when
+              stopped early via *stop_predicate*.
             - *stdout_lines*: collected lines (empty when collect_stdout=False).
             - *execution_error*: human-readable error string, or None on success.
 
@@ -70,6 +79,7 @@ class CLIAgent(BaseAgent):
         stdout_lines: list[str] = []
         execution_error: str | None = None
         returncode = -1
+        stopped_early = False
 
         try:
             with (
@@ -90,6 +100,7 @@ class CLIAgent(BaseAgent):
                 )
 
                 def _drain_stdout(stream: TextIO, fh: TextIO) -> None:
+                    nonlocal stopped_early
                     for line in iter(stream.readline, ""):
                         if not line:
                             continue
@@ -99,6 +110,10 @@ class CLIAgent(BaseAgent):
                             stdout_lines.append(line)
                         if stdout_line_hook:
                             stdout_line_hook(line)
+                        if stop_predicate and not stopped_early and stop_predicate(stdout_lines):
+                            stopped_early = True
+                            process.terminate()
+                            return
 
                 def _drain_stderr(stream: TextIO, fh: TextIO) -> None:
                     for line in iter(stream.readline, ""):
@@ -127,6 +142,10 @@ class CLIAgent(BaseAgent):
 
                 t_out.join(timeout=5)
                 t_err.join(timeout=5)
+
+                if stopped_early:
+                    returncode = 0
+                    execution_error = None
 
         except FileNotFoundError:
             raise

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -102,13 +102,32 @@ def _fold_message(
     item = by_call_id.get(str(message.get("toolCallId", "")))
     if item is None:
         return
-    texts = [
-        block.get("text", "")
-        for block in message.get("content", [])
-        if isinstance(block, dict) and block.get("type") == "text"
-    ]
+    texts: list[str] = []
+    for block in message.get("content", []):
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            texts.append(block.get("text", ""))
+            continue
+        media_path = _image_block_path(block)
+        if media_path:
+            texts.append(f"MEDIA:{media_path}")
     item["status"] = "completed"
     item["result"] = {"content": [{"type": "text", "text": "\n".join(texts)}]}
+
+
+def _image_block_path(block: dict[str, Any]) -> str | None:
+    """Extract a file path from an image/media result block, if present."""
+    if block.get("type") not in ("image", "media"):
+        return None
+    for key in ("path", "url", "mediaUrl", "file"):
+        value = block.get(key)
+        if isinstance(value, str) and value.startswith("/"):
+            return value
+    source = block.get("source")
+    if isinstance(source, dict) and isinstance(source.get("path"), str):
+        return source["path"]
+    return None
 
 
 def _normalize_tool_call(block: dict[str, Any]) -> dict[str, Any]:
@@ -269,6 +288,10 @@ class OpenClawAgent(CLIAgent):
                 ),
                 metrics=AgentMetrics(end_to_end_ms=0, steps=0),
             )
+        finally:
+            # Every exit path must remove the provider apiKey from the
+            # per-task config so secrets never persist in task artifacts.
+            self._scrub_state_secrets(task_workspace)
         duration_ms = int((time.monotonic() - t_start) * 1000)
 
         return self._finalize_result(
@@ -384,13 +407,16 @@ class OpenClawAgent(CLIAgent):
         env_status, agent_done = self._map_exit_status(
             returncode, execution_error, has_result=bool(answer)
         )
+        error_message = execution_error
         if agent_done != "timeout" and not result_obj:
             env_status, agent_done = "failed", "error"
+            error_message = error_message or (
+                "No result JSON from OpenClaw: " + "".join(stdout_lines)[-500:].strip()
+            ).strip(": ")
         if env_status == "failed" and not answer:
-            answer = f"[Task Failed: {execution_error or 'No result JSON from OpenClaw'}]"
+            answer = f"[Task Failed: {error_message or 'No result JSON from OpenClaw'}]"
 
         items = self._session_items(result_obj, task_workspace)
-        self._scrub_state_secrets(task_workspace)
         saved_screenshots = _collect_media_screenshots(items, trajectory_dir)
         steps = sum(1 for item in items if item.get("type") in STEP_ITEM_TYPES)
         if items:
@@ -405,7 +431,7 @@ class OpenClawAgent(CLIAgent):
             env_status=env_status,  # type: ignore[arg-type]
             agent_done=agent_done,  # type: ignore[arg-type]
             answer=answer,
-            error=execution_error if env_status == "failed" else None,
+            error=error_message if env_status == "failed" else None,
             action_history=extract_actions(items),
             screenshots=saved_screenshots,
             model_id=model,

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -1,0 +1,464 @@
+"""
+OpenClawAgent - Browser automation using the OpenClaw CLI's built-in browser tool.
+
+This agent executes tasks by invoking `openclaw agent --local --json` (one
+embedded agent turn, no Gateway required) with a per-task isolated state
+directory. Browsing uses OpenClaw's own `browser` tool: either its managed
+local Chrome, or an external CDP endpoint (e.g. lexmount) attached via a
+browser profile with `cdpUrl` + `attachOnly`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from browseruse_bench.agents.cli_agent import CLIAgent
+from browseruse_bench.agents.playwright_mcp import (
+    SELF_LAUNCH_BROWSER_IDS,
+    STEP_ITEM_TYPES,
+    extract_actions,
+    write_api_logs,
+)
+from browseruse_bench.agents.registry import register_agent
+from browseruse_bench.browsers import open_browser_session
+from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
+from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
+from browseruse_bench.utils import IS_WINDOWS
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RULES = (
+    "You are a browser automation agent. "
+    "You MUST use ONLY the 'browser' tool for ALL browser interactions (and 'read' "
+    "for skill files). Do NOT run shell commands and do NOT write files."
+    "\n\nTask completion rules:\n"
+    "- If you can see enough information to answer the task from the current page (e.g., "
+    "ratings, names, prices visible in search results), provide your answer IMMEDIATELY "
+    "without clicking into individual items to get more detail.\n"
+    "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
+    "close that tab, return to the previous page, and use the data already collected to answer.\n"
+    "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+    "\n\nScreenshot rules:\n"
+    "- Take a screenshot with the browser screenshot action after navigating to the main "
+    "page and after finding the answer."
+)
+
+_MEDIA_PATH_RE = re.compile(r"MEDIA:(\S+)")
+
+
+def _stdout_json(stdout_lines: list[str]) -> dict[str, Any] | None:
+    """Parse the accumulated stdout as one JSON object, or None when incomplete."""
+    text = "".join(stdout_lines).strip()
+    if not text.startswith("{"):
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _normalize_session_items(session_file: Path) -> list[dict[str, Any]]:
+    """Read the session JSONL and normalize tool calls to the shared item shape."""
+    if not session_file.is_file():
+        return []
+    items: list[dict[str, Any]] = []
+    by_call_id: dict[str, dict[str, Any]] = {}
+    for raw_line in session_file.read_text(encoding="utf-8").splitlines():
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        message = obj.get("message")
+        if not isinstance(message, dict):
+            continue
+        _fold_message(message, items, by_call_id)
+    return items
+
+
+def _fold_message(
+    message: dict[str, Any],
+    items: list[dict[str, Any]],
+    by_call_id: dict[str, dict[str, Any]],
+) -> None:
+    role = message.get("role")
+    if role == "assistant":
+        for block in message.get("content", []):
+            if isinstance(block, dict) and block.get("type") == "toolCall":
+                item = _normalize_tool_call(block)
+                items.append(item)
+                by_call_id[str(block.get("id", ""))] = item
+        return
+    if role != "toolResult":
+        return
+    item = by_call_id.get(str(message.get("toolCallId", "")))
+    if item is None:
+        return
+    texts = [
+        block.get("text", "")
+        for block in message.get("content", [])
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    item["status"] = "completed"
+    item["result"] = {"content": [{"type": "text", "text": "\n".join(texts)}]}
+
+
+def _normalize_tool_call(block: dict[str, Any]) -> dict[str, Any]:
+    name = str(block.get("name", ""))
+    arguments = block.get("arguments")
+    if not isinstance(arguments, dict):
+        arguments = {}
+    if name == "browser":
+        action = str(arguments.get("action", ""))
+        return {
+            "type": "mcp_tool_call",
+            "tool": f"browser_{action}" if action else "browser",
+            "arguments": arguments,
+            "status": "in_progress",
+        }
+    if name == "exec":
+        return {
+            "type": "command_execution",
+            "command": str(arguments.get("command", ""))[:200],
+            "status": "in_progress",
+        }
+    return {"type": "mcp_tool_call", "tool": name, "arguments": arguments, "status": "in_progress"}
+
+
+def _collect_media_screenshots(items: list[dict[str, Any]], trajectory_dir: Path) -> list[str]:
+    """Copy MEDIA:<path> screenshot files referenced by tool results into trajectory/."""
+    saved: list[str] = []
+    for item in items:
+        result = item.get("result")
+        if not isinstance(result, dict):
+            continue
+        for block in result.get("content", []):
+            if isinstance(block, dict):
+                _copy_media_paths(str(block.get("text", "")), trajectory_dir, saved)
+    return saved
+
+
+def _copy_media_paths(text: str, trajectory_dir: Path, saved: list[str]) -> None:
+    for match in _MEDIA_PATH_RE.finditer(text):
+        source = Path(match.group(1))
+        if not source.is_file() or source.suffix.lower() not in (".png", ".jpeg", ".jpg"):
+            continue
+        fname = f"screenshot-{len(saved) + 1}{source.suffix.lower()}"
+        try:
+            trajectory_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, trajectory_dir / fname)
+            saved.append(fname)
+        except OSError as exc:
+            logger.warning("Failed to copy screenshot %s: %s", source, exc)
+
+
+@register_agent
+class OpenClawAgent(CLIAgent):
+    """
+    Browser automation agent using the OpenClaw CLI.
+
+    OpenClaw is invoked as an external process via `openclaw agent --local
+    --json` with OPENCLAW_STATE_DIR/OPENCLAW_CONFIG_PATH pointed at a per-task
+    directory (the operator's ~/.openclaw is never touched). The embedded
+    agent's `browser` tool drives either OpenClaw's managed Chrome or an
+    external CDP endpoint. The CLI process stays alive after the turn (its
+    browser service keeps running), so stdout is parsed incrementally and the
+    process is terminated as soon as the result JSON is complete.
+    Install first: npm install -g openclaw
+    """
+
+    name = "openclaw"
+
+    def run_task(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+    ) -> AgentResult | dict[str, Any]:
+        """Execute a browser automation task using OpenClaw CLI."""
+        browser_id = str(agent_config.get("browser_id") or "")
+        if browser_id in SELF_LAUNCH_BROWSER_IDS:
+            warn_if_local_proxy_unsupported(agent_config, self.name)
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=None)
+        with open_browser_session(
+            browser_id=browser_id,
+            agent_name=self.name,
+            agent_config=agent_config,
+        ) as session_context:
+            cdp_url = session_context.cdp_url if session_context.transport == "cdp" else None
+            if not cdp_url:
+                return self._unsupported_backend_result(
+                    task_info["task_id"], browser_id, session_context.transport
+                )
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=cdp_url)
+
+    def _unsupported_backend_result(
+        self, task_id: str, browser_id: str, transport: str
+    ) -> AgentResult:
+        """Fail fast instead of silently launching a managed local browser."""
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status="failed",  # type: ignore[arg-type]
+            agent_done="error",  # type: ignore[arg-type]
+            error=(
+                f"Browser backend '{browser_id}' (transport={transport}) provides no CDP "
+                "endpoint, so the openclaw agent cannot attach its browser tool to it. "
+                "Use a CDP-capable backend (e.g. lexmount, cdp) or browser_id=local."
+            ),
+            metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+        )
+
+    def _execute(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        cdp_url: str | None,
+    ) -> AgentResult:
+        task_id = task_info["task_id"]
+        prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
+        rules = agent_config.get("system_prompt") or _DEFAULT_RULES
+        model = agent_config.get("model_id") or agent_config.get("model", "gpt-5.4")
+        timeout = self._resolve_timeout(task_id, agent_config)
+
+        trajectory_dir = task_workspace / "trajectory"
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+        state_dir = task_workspace / ".openclaw-state"
+        self._write_state_config(agent_config, task_workspace, state_dir, model, cdp_url)
+        cmd = self._build_command(f"{rules}\n\n{prompt}", task_id, timeout)
+
+        env = {**os.environ}
+        env["OPENCLAW_STATE_DIR"] = str(state_dir)
+        env["OPENCLAW_CONFIG_PATH"] = str(state_dir / "openclaw.json")
+
+        logger.info(
+            "Executing OpenClaw for task %s (model=%s, timeout=%ds)", task_id, model, timeout
+        )
+        t_start = time.monotonic()
+        try:
+            returncode, stdout_lines, execution_error = self._run_subprocess(
+                cmd,
+                timeout=timeout,
+                task_workspace=task_workspace,
+                cwd=task_workspace,
+                env=env,
+                collect_stdout=True,
+                stderr_line_hook=_stderr_hook,
+                # The CLI keeps running after the turn (embedded browser
+                # service); terminate as soon as the result JSON is complete.
+                stop_predicate=lambda lines: _stdout_json(lines) is not None,
+            )
+        except FileNotFoundError:
+            return AgentResult(
+                task_id=task_id,
+                timestamp=datetime.now(UTC),
+                env_status="failed",  # type: ignore[arg-type]
+                agent_done="error",  # type: ignore[arg-type]
+                error=(
+                    "Executable 'openclaw' not found. "
+                    "Please install OpenClaw: npm install -g openclaw"
+                ),
+                metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+            )
+        duration_ms = int((time.monotonic() - t_start) * 1000)
+
+        return self._finalize_result(
+            task_id=task_id,
+            model=model,
+            rules=rules,
+            stdout_lines=stdout_lines,
+            returncode=returncode,
+            execution_error=execution_error,
+            duration_ms=duration_ms,
+            task_workspace=task_workspace,
+            trajectory_dir=trajectory_dir,
+        )
+
+    @staticmethod
+    def _resolve_timeout(task_id: str, agent_config: dict[str, Any]) -> int:
+        timeout_val = agent_config.get("timeout_seconds") or agent_config.get("timeout", 600)
+        try:
+            return int(timeout_val)
+        except (TypeError, ValueError) as exc:
+            logger.warning("Invalid timeout for task %s (%r): %s", task_id, timeout_val, exc)
+            return 600
+
+    @staticmethod
+    def _write_state_config(
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        state_dir: Path,
+        model: str,
+        cdp_url: str | None,
+    ) -> None:
+        """Write the per-task openclaw.json (provider, workspace, tools, browser)."""
+        state_dir.mkdir(parents=True, exist_ok=True)
+        config: dict[str, Any] = {
+            "models": {
+                "mode": "merge",
+                "providers": {
+                    "bench": {
+                        "baseUrl": agent_config.get("base_url", ""),
+                        "apiKey": agent_config.get("api_key", ""),
+                        "api": "openai-completions",
+                        "timeoutSeconds": int(agent_config.get("llm_timeout", 300)),
+                        "models": [{
+                            "id": model,
+                            "name": model,
+                            "input": ["text"],
+                            "contextWindow": int(agent_config.get("context_window", 195000)),
+                            "maxTokens": int(agent_config.get("max_tokens", 16000)),
+                            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                        }],
+                    }
+                },
+            },
+            "agents": {
+                "defaults": {
+                    "model": {"primary": f"bench/{model}"},
+                    # Subdirectory, not the task workspace itself: OpenClaw
+                    # bootstraps template files (SOUL.md, AGENTS.md, ...) into
+                    # its workspace, which must not pollute task artifacts.
+                    "workspace": str(task_workspace / ".openclaw-workspace"),
+                },
+                # Tool whitelist: browsing plus reading bundled skill files.
+                "list": [{"id": "main", "tools": {"allow": ["browser", "read"]}}],
+            },
+            "browser": {"enabled": True},
+        }
+        if cdp_url:
+            config["browser"] = {
+                "enabled": True,
+                "defaultProfile": "bench",
+                "profiles": {
+                    "bench": {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"},
+                },
+            }
+        (state_dir / "openclaw.json").write_text(
+            json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    @staticmethod
+    def _build_command(full_prompt: str, task_id: str, timeout: int) -> list[str]:
+        exe = "openclaw.cmd" if IS_WINDOWS else "openclaw"
+        return [
+            exe, "agent",
+            "--local",   # embedded agent turn, no Gateway service required
+            "--json",
+            "--session-key", f"agent:main:bench-{task_id}",
+            "-m", full_prompt,
+            "--timeout", str(timeout),
+        ]
+
+    def _finalize_result(
+        self,
+        task_id: str,
+        model: str,
+        rules: str,
+        stdout_lines: list[str],
+        returncode: int,
+        execution_error: str | None,
+        duration_ms: int,
+        task_workspace: Path,
+        trajectory_dir: Path,
+    ) -> AgentResult:
+        result_obj = _stdout_json(stdout_lines) or {}
+        payloads = result_obj.get("payloads")
+        answer = ""
+        if isinstance(payloads, list):
+            answer = "\n".join(
+                str(p.get("text", "")) for p in payloads if isinstance(p, dict) and p.get("text")
+            ).strip()
+
+        if execution_error and "Timeout" in execution_error:
+            logger.error("OpenClaw task %s timed out", task_id)
+        env_status, agent_done = self._map_exit_status(
+            returncode, execution_error, has_result=bool(answer)
+        )
+        if agent_done != "timeout" and not result_obj:
+            env_status, agent_done = "failed", "error"
+        if env_status == "failed" and not answer:
+            answer = f"[Task Failed: {execution_error or 'No result JSON from OpenClaw'}]"
+
+        items = self._session_items(result_obj, task_workspace)
+        self._scrub_state_secrets(task_workspace)
+        saved_screenshots = _collect_media_screenshots(items, trajectory_dir)
+        steps = sum(1 for item in items if item.get("type") in STEP_ITEM_TYPES)
+        if items:
+            try:
+                write_api_logs(task_id, model, rules, items, task_workspace / "api_logs")
+            except (OSError, TypeError, ValueError) as exc:
+                logger.warning("Failed to generate api_logs for task %s: %s", task_id, exc)
+
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status=env_status,  # type: ignore[arg-type]
+            agent_done=agent_done,  # type: ignore[arg-type]
+            answer=answer,
+            error=execution_error if env_status == "failed" else None,
+            action_history=extract_actions(items),
+            screenshots=saved_screenshots,
+            model_id=model,
+            metrics=AgentMetrics(
+                end_to_end_ms=duration_ms, steps=steps, usage=self._usage_from(result_obj)
+            ),
+        )
+
+    @staticmethod
+    def _scrub_state_secrets(task_workspace: Path) -> None:
+        """Redact the provider apiKey from the per-task config left in artifacts."""
+        config_path = task_workspace / ".openclaw-state" / "openclaw.json"
+        if not config_path.is_file():
+            return
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+            for provider in config.get("models", {}).get("providers", {}).values():
+                if isinstance(provider, dict) and provider.get("apiKey"):
+                    provider["apiKey"] = "***"
+            config_path.write_text(
+                json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to scrub state config secrets: %s", exc)
+
+    @staticmethod
+    def _session_items(result_obj: dict[str, Any], task_workspace: Path) -> list[dict[str, Any]]:
+        meta = result_obj.get("meta")
+        agent_meta = meta.get("agentMeta") if isinstance(meta, dict) else None
+        session_file = agent_meta.get("sessionFile") if isinstance(agent_meta, dict) else None
+        if not session_file:
+            return []
+        return _normalize_session_items(Path(str(session_file)))
+
+    @staticmethod
+    def _usage_from(result_obj: dict[str, Any]) -> AgentUsage | None:
+        meta = result_obj.get("meta")
+        agent_meta = meta.get("agentMeta") if isinstance(meta, dict) else None
+        usage = agent_meta.get("lastCallUsage") if isinstance(agent_meta, dict) else None
+        if not isinstance(usage, dict):
+            return None
+        total = int(usage.get("total") or 0)
+        if not total:
+            return None
+        return AgentUsage(
+            total_prompt_tokens=int(usage.get("input") or 0),
+            total_prompt_cached_tokens=int(usage.get("cacheRead") or 0),
+            total_completion_tokens=int(usage.get("output") or 0),
+            total_tokens=total,
+        )
+
+
+def _stderr_hook(line: str) -> None:
+    clean = line.strip()
+    if clean and ("error" in clean.lower() or "FailoverError" in clean):
+        logger.warning("[OpenClaw] %s", clean)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -167,6 +167,14 @@ models:
     model_type: OPENAI
     model_id: gpt-5.2
     api_key: $CURSOR_API_KEY
+  # OpenClaw CLI model. Only supported by the openclaw agent; the agent writes
+  # a per-task OpenClaw provider config from these values (OpenAI-compatible
+  # endpoints work, e.g. a LiteLLM proxy).
+  openclaw:
+    model_type: OPENAI
+    model_id: gpt-5.4
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
 browsers:
   lexmount:
     browser_id: lexmount
@@ -243,6 +251,9 @@ agents:
     sandbox_mode: read-only
   cursor:
     active_model: cursor
+    timeout: 600
+  openclaw:
+    active_model: openclaw
     timeout: 600
   deepbrowse:
     use_vision: auto

--- a/configs/agent_registry.yaml
+++ b/configs/agent_registry.yaml
@@ -64,6 +64,17 @@ cursor:
     - WebVoyager
     - Odysseys
 
+openclaw:
+  path: browseruse_bench/agents
+  entrypoint: browseruse_bench/runner/agent_runner.py
+  venv: .venv
+  supported_benchmarks:
+    - Online-Mind2Web
+    - BrowseComp
+    - LexBench-Browser
+    - WebVoyager
+    - Odysseys
+
 deepbrowse:
   path: browseruse_bench/agents
   entrypoint: browseruse_bench/runner/agent_runner.py

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -1,0 +1,275 @@
+"""Tests for OpenClawAgent: stdout JSON parsing, session normalization, run_task."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from browseruse_bench.agents.openclaw import (
+    OpenClawAgent,
+    _collect_media_screenshots,
+    _normalize_session_items,
+    _stdout_json,
+)
+from browseruse_bench.schemas import AgentResult
+
+TASK_INFO: dict[str, Any] = {
+    "task_id": "t1",
+    "task_text": "Go to example.com",
+    "url": "https://example.com",
+}
+
+AGENT_CONFIG: dict[str, Any] = {
+    "model_id": "gpt-test",
+    "api_key": "sk-test",
+    "base_url": "https://llm.example/v1",
+    "timeout": 10,
+}
+
+
+def _result_stdout(session_file: Path | None = None, answer: str = "The price is $42") -> list[str]:
+    obj = {
+        "payloads": [{"text": answer, "mediaUrl": None}],
+        "meta": {
+            "durationMs": 2000,
+            "agentMeta": {
+                "sessionId": "s1",
+                "sessionFile": str(session_file) if session_file else None,
+                "provider": "bench",
+                "model": "gpt-test",
+                "lastCallUsage": {"input": 100, "output": 20, "cacheRead": 40, "cacheWrite": 0, "total": 120},
+            },
+        },
+    }
+    text = json.dumps(obj, indent=2)
+    return [line + "\n" for line in text.split("\n")]
+
+
+def _write_session(path: Path) -> None:
+    lines = [
+        {"type": "message", "message": {"role": "user", "content": [{"type": "text", "text": "go"}]}},
+        {"type": "message", "message": {"role": "assistant", "content": [
+            {"type": "toolCall", "id": "c1", "name": "browser",
+             "arguments": {"action": "open", "url": "https://example.com"}},
+        ]}},
+        {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1", "toolName": "browser",
+            "content": [{"type": "text", "text": "opened"}]}},
+        {"type": "message", "message": {"role": "assistant", "content": [
+            {"type": "toolCall", "id": "c2", "name": "browser", "arguments": {"action": "screenshot"}},
+        ]}},
+        {"type": "message", "message": {"role": "toolResult", "toolCallId": "c2", "toolName": "browser",
+            "content": [{"type": "text", "text": "MEDIA:" + str(path.parent / "shot.png")}]}},
+        {"type": "message", "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}]}},
+    ]
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+
+class TestStdoutJson:
+    def test_incomplete_json_returns_none(self) -> None:
+        assert _stdout_json(["{\n", '  "payloads": [\n']) is None
+
+    def test_complete_json_parsed(self) -> None:
+        assert _stdout_json(_result_stdout())["payloads"][0]["text"] == "The price is $42"
+
+    def test_non_json_returns_none(self) -> None:
+        assert _stdout_json(["warning: something\n"]) is None
+        assert _stdout_json([]) is None
+
+
+class TestNormalizeSessionItems:
+    def test_tool_calls_and_results_joined(self, tmp_path: Path) -> None:
+        session = tmp_path / "session.jsonl"
+        _write_session(session)
+        items = _normalize_session_items(session)
+        assert len(items) == 2
+        assert items[0]["type"] == "mcp_tool_call"
+        assert items[0]["tool"] == "browser_open"
+        assert items[0]["arguments"]["url"] == "https://example.com"
+        assert items[0]["status"] == "completed"
+        assert items[0]["result"]["content"][0]["text"] == "opened"
+        assert items[1]["tool"] == "browser_screenshot"
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert _normalize_session_items(tmp_path / "absent.jsonl") == []
+
+
+class TestCollectMediaScreenshots:
+    def test_media_paths_copied(self, tmp_path: Path) -> None:
+        (tmp_path / "shot.png").write_bytes(b"png")
+        items = [{
+            "type": "mcp_tool_call", "tool": "browser_screenshot", "status": "completed",
+            "result": {"content": [{"type": "text", "text": f"MEDIA:{tmp_path / 'shot.png'}"}]},
+        }]
+        trajectory = tmp_path / "trajectory"
+        saved = _collect_media_screenshots(items, trajectory)
+        assert saved == ["screenshot-1.png"]
+        assert (trajectory / "screenshot-1.png").read_bytes() == b"png"
+
+    def test_missing_media_file_skipped(self, tmp_path: Path) -> None:
+        items = [{
+            "type": "mcp_tool_call", "tool": "browser_screenshot", "status": "completed",
+            "result": {"content": [{"type": "text", "text": "MEDIA:/nonexistent/x.png"}]},
+        }]
+        assert _collect_media_screenshots(items, tmp_path / "trajectory") == []
+
+
+class TestOpenClawAgentRunTask:
+    def test_successful_run_returns_answer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        session = tmp_path / "session.jsonl"
+        _write_session(session)
+        (tmp_path / "shot.png").write_bytes(b"png")
+        agent = OpenClawAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(session), None)
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert isinstance(result, AgentResult)
+        assert result.answer == "The price is $42"
+        assert result.env_status == "success"
+        assert result.agent_done == "done"
+        assert result.metrics.steps == 2
+        assert result.metrics.usage is not None
+        assert result.metrics.usage.total_prompt_tokens == 100
+        assert result.screenshots == ["screenshot-1.png"]
+        assert result.action_history[0] == "browser_open"
+
+    def test_state_config_written(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+        captured_env: dict[str, str] = {}
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            captured_env.update(kw.get("env") or {})
+            return 0, _result_stdout(), None
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+
+        state_dir = tmp_path / ".openclaw-state"
+        assert captured_env["OPENCLAW_STATE_DIR"] == str(state_dir)
+        cfg = json.loads((state_dir / "openclaw.json").read_text())
+        provider = cfg["models"]["providers"]["bench"]
+        assert provider["baseUrl"] == "https://llm.example/v1"
+        assert provider["models"][0]["id"] == "gpt-test"
+        assert cfg["agents"]["defaults"]["model"]["primary"] == "bench/gpt-test"
+        assert cfg["agents"]["defaults"]["workspace"] == str(tmp_path / ".openclaw-workspace")
+        assert cfg["agents"]["list"][0]["tools"]["allow"] == ["browser", "read"]
+        assert cfg["models"]["providers"]["bench"]["timeoutSeconds"] == 300
+        # The api key written for the run must be scrubbed from the artifact.
+        assert provider["apiKey"] == "***"
+
+    def test_cdp_url_written_as_attach_profile(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import openclaw as openclaw_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            yield BrowserSessionContext(
+                backend_id=browser_id, transport="cdp", cdp_url="wss://cdp.example/1"
+            )
+
+        monkeypatch.setattr(openclaw_module, "open_browser_session", fake_session)
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(), None))
+        config = {**AGENT_CONFIG, "browser_id": "lexmount"}
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+
+        cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
+        profile = cfg["browser"]["profiles"]["bench"]
+        assert profile["cdpUrl"] == "wss://cdp.example/1"
+        assert profile["attachOnly"] is True
+        assert cfg["browser"]["defaultProfile"] == "bench"
+        assert result.env_status == "success"
+
+    def test_non_cdp_backend_fails_fast(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import openclaw as openclaw_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            yield BrowserSessionContext(backend_id=browser_id, transport="cloud_native")
+
+        monkeypatch.setattr(openclaw_module, "open_browser_session", fake_session)
+        agent = OpenClawAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            lambda *a, **kw: pytest.fail("subprocess must not be launched"),
+        )
+        config = {**AGENT_CONFIG, "browser_id": "browser-use-cloud"}
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+        assert result.env_status == "failed"
+        assert "browser-use-cloud" in (result.error or "")
+
+    def test_no_result_json_is_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (0, ["FailoverError: 401\n"], None)
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+
+    def test_timeout_maps_to_timeout_status(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (-1, [], "Timeout after 10 seconds")
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "success"
+        assert result.agent_done == "timeout"
+
+    def test_executable_not_found_returns_error_result(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+
+        def _raise(*a: Any, **kw: Any) -> None:
+            raise FileNotFoundError("openclaw not found")
+
+        monkeypatch.setattr(agent, "_run_subprocess", _raise)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert "not found" in (result.error or "").lower()
+
+
+class TestStopPredicate:
+    def test_run_subprocess_stops_early_on_predicate(self, tmp_path: Path) -> None:
+        # A process that prints JSON then sleeps forever must be terminated as
+        # soon as the predicate matches, with a zero exit status.
+        import time as time_module
+
+        agent = OpenClawAgent()
+        cmd = [
+            "python3", "-u", "-c",
+            "import time, sys; print('{\"done\": true}'); sys.stdout.flush(); time.sleep(60)",
+        ]
+        t0 = time_module.monotonic()
+        returncode, lines, error = agent._run_subprocess(
+            cmd,
+            timeout=30,
+            task_workspace=tmp_path,
+            stop_predicate=lambda ls: _stdout_json(ls) is not None,
+        )
+        elapsed = time_module.monotonic() - t0
+        assert returncode == 0
+        assert error is None
+        assert _stdout_json(lines) == {"done": True}
+        assert elapsed < 15

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -224,6 +224,36 @@ class TestOpenClawAgentRunTask:
         result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
         assert result.env_status == "failed"
         assert result.agent_done == "error"
+        assert "FailoverError: 401" in (result.error or "")
+
+    def test_api_key_scrubbed_even_when_executable_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+
+        def _raise(*a: Any, **kw: Any) -> None:
+            raise FileNotFoundError("openclaw not found")
+
+        monkeypatch.setattr(agent, "_run_subprocess", _raise)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
+        assert cfg["models"]["providers"]["bench"]["apiKey"] == "***"
+
+    def test_image_block_screenshot_preserved(self, tmp_path: Path) -> None:
+        (tmp_path / "img.png").write_bytes(b"png")
+        session = tmp_path / "session.jsonl"
+        lines = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "c1", "name": "browser", "arguments": {"action": "screenshot"}},
+            ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1", "toolName": "browser",
+                "content": [{"type": "image", "path": str(tmp_path / "img.png")}]}},
+        ]
+        session.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+        items = _normalize_session_items(session)
+        saved = _collect_media_screenshots(items, tmp_path / "trajectory")
+        assert saved == ["screenshot-1.png"]
 
     def test_timeout_maps_to_timeout_status(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Summary

Adds `openclaw` as a new browser agent: invokes `openclaw agent --local --json` (one embedded agent turn, no Gateway service required) with a fully isolated per-task state directory. Unlike the codex/cursor agents, browsing uses **OpenClaw's own `browser` tool** rather than an injected Playwright MCP server — that is the product's native browsing path, which is what the benchmark should measure.

## Implementation notes

- **Isolation**: `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` point at `task_workspace/.openclaw-state`; the operator's `~/.openclaw` is never read. The per-task `openclaw.json` carries the model provider (OpenAI-compatible `base_url`/`api_key` from the bench model config, LiteLLM proxies work), a workspace **subdirectory** (OpenClaw bootstraps `SOUL.md`/`AGENTS.md` templates into its workspace — verified they pollute task artifacts otherwise), and a tool whitelist `allow: [browser, read]`.
- **Managed browsers**: CDP backends (lexmount, cdp) are attached via a browser profile with `cdpUrl` + `attachOnly: true` (verified against an external Chrome: OpenClaw drove it instead of self-launching); `browser_id=local` uses OpenClaw's managed Chrome; non-CDP cloud-native backends fail fast.
- **Early exit**: the CLI process does not exit after the turn — its embedded browser service keeps it alive (verified: result JSON flushes at turn end, process lives on). `CLIAgent._run_subprocess` gains an opt-in `stop_predicate` that terminates the process with a zero exit as soon as the accumulated stdout parses as complete JSON. Existing callers are unaffected (all 70 CLI-agent tests pass unchanged).
- **Secret hygiene**: the provider `apiKey` written into the per-task config is scrubbed to `***` after the run, so keys never persist under `experiments/`.
- **Parsing**: final answer from the result JSON `payloads`; steps/actions/api_logs from the session JSONL (`toolCall`/`toolResult` joined by id, normalized to the shared `playwright_mcp` step-item shape); screenshots collected from `MEDIA:<path>` references in tool results; missing result JSON (non-timeout) → `failed/error`.

## Prerequisites

```bash
npm install -g openclaw
```
No login needed — the agent supplies its own provider config per task.

## Testing

- `uv run pytest tests/` → 462 passed (15 new tests: stdout-JSON completion detection, session normalization, MEDIA screenshot collection, state-config content incl. scrubbed key, CDP attach profile, fail-fast on non-CDP backends, timeout/no-result/not-found mapping, and a live `stop_predicate` early-termination test against a real subprocess).
- Real smokes per AGENTS.md: `bubench run --agent openclaw --data LexBench-Browser --mode single` → 1/1 success through a lexmount session (`Lexmount session created: wss://...`), repeated after the scrub change → 1/1 success, artifact `apiKey: "***"` confirmed. One earlier failed run was a transient machine-wide DNS outage (LLM proxy and lexmount both unreachable), not agent behavior — the run was correctly recorded as failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)