### PR TITLE
Add INSTALL_CLI_AGENTS build arg for server deployment of CLI agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,38 @@ RUN chown -R 1000:1000 /app /root/.cache/uv
 ENV PATH="/app/.venv/bin:$PATH"
 ENV UV_PROJECT_ENVIRONMENT="/app/.venv"
 
+# Optional: CLI coding agents (codex / cursor / openclaw, plus the claude-code
+# CLI). Off by default to keep the CI image small. Enable with:
+#   docker build --build-arg INSTALL_CLI_AGENTS=true .
+# Notes (see docs/cli-agents-deployment.md):
+#   - Node 22.x via NodeSource: openclaw declares engines node>=22.19.0.
+#   - npm cache lives at a world-writable path so the uid-1000 runtime user
+#     reuses the pre-warmed Playwright MCP download (npx caches per-user via
+#     this env, not under /root).
+#   - cursor-agent installs under /root; relocate it and symlink the real
+#     binary so uid 1000 can execute it (/root is not traversable).
+#   - No Chrome in the image: server runs use the lexmount browser backend.
+#     claude-code (local-browser only) still needs Chrome added separately.
+ARG INSTALL_CLI_AGENTS=false
+ENV NPM_CONFIG_CACHE=/opt/npm-cache
+RUN if [ "$INSTALL_CLI_AGENTS" = "true" ]; then \
+        curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+        && apt-get install -y --no-install-recommends nodejs \
+        && rm -rf /var/lib/apt/lists/* \
+        && if [ "$USE_CN_MIRROR" = "true" ]; then npm config set registry https://registry.npmmirror.com -g; fi \
+        && npm install -g @anthropic-ai/claude-code @openai/codex openclaw \
+        && curl https://cursor.com/install -fsS | bash \
+        && mv /root/.local/share/cursor-agent /opt/cursor-agent \
+        && ln -s /opt/cursor-agent/versions/*/cursor-agent /usr/local/bin/cursor-agent \
+        && npx -y @playwright/mcp@latest --version \
+        && chmod -R a+rwX /opt/npm-cache \
+        && chmod -R a+rX /opt/cursor-agent \
+        # Real passwd entry + home for the uid-1000 runtime user: codex
+        # refuses a codex_home under temporary dirs, so HOME must not fall
+        # back to /tmp. docker run --user 1000 resolves HOME from passwd.
+        && useradd -u 1000 -m -s /bin/bash bench; \
+    fi
+
 # Setup entrypoint script (already copied from builder)
 RUN chmod +x /app/scripts/docker-entrypoint.sh
 

--- a/docs/cli-agents-deployment.md
+++ b/docs/cli-agents-deployment.md
@@ -105,40 +105,47 @@ npm install -g openclaw
 | `CURSOR_API_KEY` | cursor | Cursor key, not OpenAI |
 | `LEXMOUNT_API_KEY` / `LEXMOUNT_PROJECT_ID` | lexmount browser backend | recommended on servers |
 
-## Docker image status
+## Docker image
 
-The repo `Dockerfile` (used by self-hosted CI and server deploys) is based on
-`python:3.11-slim` and currently ships **neither Node.js nor any of these
-CLIs nor Chrome** — CLI agents cannot run in that image as-is. To support them
-in a container, the image needs at minimum:
+The repo `Dockerfile` supports the CLI agents behind a build arg (off by
+default, so the CI image is unchanged):
 
-```dockerfile
-# Node.js 22+ (openclaw requires >= 22.19; distro nodejs is usually too old)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g @anthropic-ai/claude-code @openai/codex openclaw
-# Pre-warm the Playwright MCP download AS THE RUNTIME USER (uid 1000 in this
-# image) — npx caches per-user, so warming root's cache does not help:
-USER 1000
-RUN npx -y @playwright/mcp@latest --version
-USER root
-# cursor-agent installs outside npm, into the installing user's home.
-# The repo image runs as uid 1000, and /root is not traversable by non-root
-# users — install as the runtime user (after USER 1000), or relocate the
-# install out of /root and point agents.cursor.cursor_agent_command at it:
-RUN curl https://cursor.com/install -fsS | bash \
-    && mv /root/.local/share/cursor-agent /opt/cursor-agent \
-    && chmod -R a+rX /opt/cursor-agent
-# then set agents.cursor.cursor_agent_command: /opt/cursor-agent/versions/<version>/cursor-agent
+```bash
+docker build --build-arg INSTALL_CLI_AGENTS=true -t bubench-cli .
 ```
 
-plus auth material at runtime (env vars above; `~/.codex/auth.json` for
-ChatGPT-login codex). With the lexmount browser path no Chrome is needed in
-the image for codex/cursor/openclaw; **include Chrome/Chromium (and headless
-deps) if claude-code or `browser_id=local` runs are planned**. This
-Dockerfile change is intentionally **not** applied yet — it grows the image
-and affects CI; apply it when server-side runs of these agents are actually
-scheduled.
+This installs Node.js 22.x (openclaw requires >= 22.19), the
+claude-code/codex/openclaw CLIs, cursor-agent (relocated to
+`/opt/cursor-agent` and symlinked into `/usr/local/bin` so the uid-1000
+runtime user can execute it), and pre-warms the Playwright MCP download into
+a world-readable npm cache (`NPM_CONFIG_CACHE=/opt/npm-cache`).
+
+At runtime, provide auth material via env (`OPENAI_API_KEY`/`OPENAI_BASE_URL`,
+`CURSOR_API_KEY`, `LEXMOUNT_API_KEY`, ...) — typically by mounting `.env` —
+plus a `config.yaml`. Verified container invocations (image runs as uid 1000,
+whose home is `/home/bench`):
+
+```bash
+# openclaw / cursor — env-only auth:
+docker run --rm --user 1000 -v "$PWD/.env:/app/.env:ro" bubench-cli \
+  uv run scripts/run.py --agent openclaw --data LexBench-Browser --mode single
+
+# codex with ChatGPT login — do NOT bind-mount auth.json directly into
+# ~/.codex (docker creates the parent dir root-owned and codex cannot write
+# its session files); stage it and copy:
+docker run --rm --user 1000 -v "$PWD/.env:/app/.env:ro" \
+  -v "$HOME/.codex/auth.json:/auth/auth.json:ro" --entrypoint bash bubench-cli \
+  -c 'mkdir -p ~/.codex && cp /auth/auth.json ~/.codex/ \
+      && exec /app/scripts/docker-entrypoint.sh uv run scripts/run.py \
+         --agent codex --data LexBench-Browser --mode single'
+```
+
+With API-key codex auth instead, set `models.codex.base_url` when using a
+proxy endpoint (the key alone routes to api.openai.com).
+
+With the lexmount browser path no Chrome is needed in the image for
+codex/cursor/openclaw; **include Chrome/Chromium (and headless deps)
+separately if claude-code or `browser_id=local` runs are planned**.
 
 ## Smoke verification (per agent, after deploy)
 


### PR DESCRIPTION
## Summary

Enables running the new CLI agents (codex / cursor / openclaw, plus the claude-code CLI) inside the repo Docker image, behind a build arg that is **off by default** — the CI image is unchanged (verified: default build contains no Node/CLIs, same 9.89GB).

```bash
docker build --build-arg INSTALL_CLI_AGENTS=true -t bubench-cli .   # +2.2GB
```

## What the flag installs

- **Node.js 22.x** via NodeSource — openclaw declares `engines: node>=22.19.0`, distro nodejs is too old
- **claude-code / codex / openclaw** via `npm -g` (npmmirror registry honored under `USE_CN_MIRROR=true`)
- **cursor-agent** relocated to `/opt/cursor-agent` with the real binary symlinked into `/usr/local/bin` — uid 1000 cannot traverse `/root` where the installer puts it
- **Playwright MCP pre-warm** into `NPM_CONFIG_CACHE=/opt/npm-cache` (world-writable, so the uid-1000 runtime user reuses the cache instead of redownloading on the first task)
- **passwd entry + `/home/bench` for uid 1000** — codex 0.139 refuses a `codex_home` under temporary dirs, so HOME must resolve to a real directory

No Chrome in the image: server runs use the lexmount backend. claude-code (local-browser only) still needs Chrome added separately.

## Verification (all in the built image, `--user 1000`, lexmount backend, `.env` mounted)

| Check | Result |
|---|---|
| CLI self-checks as uid 1000 | node v22.22.3, codex-cli 0.139.0, cursor-agent 2026.06.12, openclaw 2026.6.5, claude 2.1.174, MCP `npx` cache hit |
| `bubench run --agent openclaw --mode single` in container | 1/1 success |
| `bubench run --agent cursor --mode single` in container | 1/1 success |
| `bubench run --agent codex --mode single` in container (auth.json staged) | 1/1 success |
| Default build (`INSTALL_CLI_AGENTS` unset) | no Node/CLIs present, image size unchanged |

The codex run surfaced a real deployment gotcha now documented: bind-mounting `auth.json` directly into `~/.codex` leaves a root-owned parent directory codex cannot write session files into — stage the file and copy instead (exact command in [docs/cli-agents-deployment.md](docs/cli-agents-deployment.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)