### PR TITLE
Distinguish 'not enabled in config' from 'unknown agent' in resolve_agent_entry

### DIFF
--- a/browseruse_bench/utils/config_loader.py
+++ b/browseruse_bench/utils/config_loader.py
@@ -322,6 +322,12 @@ def resolve_agent_entry(agent: str, root_config: dict[str, Any]) -> dict[str, An
     agents = root_config.get("agents", {})
     agent = _resolve_agent_key(agent, agents)
     if agent not in agents:
+        if load_agent_registry(agent):
+            raise SystemExit(
+                f"Agent '{agent}' is supported by this version but not enabled in the "
+                f"runtime config: add an 'agents.{agent}' entry to config.yaml "
+                f"(see config.example.yaml). Enabled agents: {', '.join(sorted(agents))}"
+            )
         raise SystemExit(f"Unknown Agent: {agent}. Options: {', '.join(sorted(agents))}")
     registry = load_agent_registry(agent)
     # Registry fields take precedence for structural info; root config may override

--- a/tests/browseruse_bench/test_config_loader.py
+++ b/tests/browseruse_bench/test_config_loader.py
@@ -398,6 +398,21 @@ def test_resolve_agent_entry_uses_registry_venvs_for_builtin_agents(tmp_path: Pa
     assert resolve_agent_entry("deepbrowse", config).get("venv") == ".venvs/deepbrowse"
 
 
+def test_resolve_agent_entry_supported_but_not_enabled_hint() -> None:
+    # codex is in the checked-in agent registry but absent from this runtime
+    # config's agents section (the stale-server-config case): the error must
+    # point at the missing config entry, not claim the agent is unknown.
+    config = {"agents": {"browser-use": {}}}
+    with pytest.raises(SystemExit, match="not enabled in the runtime config"):
+        resolve_agent_entry("codex", config)
+
+
+def test_resolve_agent_entry_unknown_agent_lists_options() -> None:
+    config = {"agents": {"browser-use": {}}}
+    with pytest.raises(SystemExit, match="Unknown Agent: no-such-agent"):
+        resolve_agent_entry("no-such-agent", config)
+
+
 class TestSkyvernConfigCanonicalization:
     """Tests for canonicalize_skyvern_model_name + apply_skyvern_env legacy-key handling.
 


### PR DESCRIPTION
## Summary

A server deployment running the new code with a stale `config.yaml` (its `agents:` section predates codex/cursor/openclaw) failed with `Unknown Agent: codex. Options: Agent-TARS, browser-use, claude-code, seeact, skyvern` — misleadingly suggesting the agent is not registered in code, when the code registry has it and only the runtime config lacks an entry.

`resolve_agent_entry` now checks the checked-in agent registry before declaring an agent unknown:

```
Agent 'codex' is supported by this version but not enabled in the runtime config:
add an 'agents.codex' entry to config.yaml (see config.example.yaml).
Enabled agents: browser-use, seeact
```

Genuinely unknown names keep the original message.

## Testing

- 2 new tests (`test_resolve_agent_entry_supported_but_not_enabled_hint`, `test_resolve_agent_entry_unknown_agent_lists_options`); 61 config_loader tests pass.
- Success path unchanged; real smoke per AGENTS.md: `bubench run --agent openclaw --data LexBench-Browser --mode single` → 1/1 success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)