### PR TITLE
Publish GHCR images with CLI agents installed

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -53,6 +53,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            INSTALL_CLI_AGENTS=true
 
       - name: Trigger Kestra image warmup webhook (best-effort)
         # NOTE: Kestra runs on an internal network and is not reachable from GitHub Actions.


### PR DESCRIPTION
## Summary

Passes `INSTALL_CLI_AGENTS=true` (added in #45) to the GHCR publish build, so the published images ship with Node 22 + the codex/cursor/openclaw/claude-code CLIs and the pre-warmed Playwright MCP cache — servers can pull and run the new agents directly instead of building the image themselves.

## Impact

- Applies to **all published tags** (`latest`, `dev-latest`, semver): single-image strategy, no `-cli` variant tag.
- Image size grows ~2.2GB (9.89 → 12.1GB, measured in #45).
- Functionally inert for existing users: the CLIs are only exercised when the runtime `config.yaml` enables the agents (`agents.codex` etc.); the self-hosted CI workflow is unaffected beyond pull size.
- The in-image installs and all three agents were verified end-to-end in #45 (uid 1000, lexmount backend, 1/1 each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)