### PR TITLE
Never print the warmup webhook response body in public logs

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -84,9 +84,17 @@ jobs:
           fi
           echo "Warmup target tag: ${docker_image_tag}"
 
-          curl -fsS --max-time 10 --retry 1 --retry-delay 2 -X POST \
+          # -o /dev/null: never print the response body - the platform echoes
+          # execution trigger details that can contain internal credentials,
+          # and these logs are public.
+          http_code=$(curl -sS -o /dev/null -w "%{http_code}" \
+            --max-time 10 --retry 1 --retry-delay 2 -X POST \
             "https://bench.lexmount.com/api/webhooks/image-warmup" \
             -H "Authorization: Bearer ${IMAGE_WARMUP_WEBHOOK_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"docker_image_tag\": \"${docker_image_tag}\"}"
-          echo "Warmup webhook triggered successfully."
+            -d "{\"docker_image_tag\": \"${docker_image_tag}\"}")
+          if [ "${http_code}" != "200" ]; then
+            echo "Warmup webhook failed: HTTP ${http_code}"
+            exit 1
+          fi
+          echo "Warmup webhook triggered successfully (HTTP ${http_code})."


### PR DESCRIPTION
## Summary

The first live warmup call (run 27410287740) revealed that the bench platform's webhook response echoes the full Kestra execution trigger details — including the forwarded Basic auth header (base64 plaintext) and registry account info. These Actions logs are **public**.

This PR makes the workflow defensive regardless of platform behavior: the curl response body is discarded (`-o /dev/null`), only the HTTP status code is logged, and a non-200 fails the step (still `continue-on-error` at the step level).

## Required follow-ups outside this repo

1. **Rotate the exposed Kestra Basic auth credentials** (visible in the public log of run 27410287740 until that log is deleted).
2. bench platform: return only `{"success": true, "execution_id": ...}` from the webhook — do not echo `execution.trigger.variables`.
3. Consider deleting the exposed run log: `gh run delete 27410287740`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)