### PR TITLE
claude-code: attach managed CDP backends, run as root, fix tool wildcard

### DIFF
--- a/browseruse_bench/agents/claude_code.py
+++ b/browseruse_bench/agents/claude_code.py
@@ -18,7 +18,12 @@ from pathlib import Path
 from typing import Any
 
 from browseruse_bench.agents.cli_agent import CLIAgent
+from browseruse_bench.agents.playwright_mcp import (
+    SELF_LAUNCH_BROWSER_IDS,
+    build_playwright_mcp_args,
+)
 from browseruse_bench.agents.registry import register_agent
+from browseruse_bench.browsers import open_browser_session
 from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
 from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
 from browseruse_bench.utils import IS_WINDOWS
@@ -413,8 +418,52 @@ class ClaudeCodeAgent(CLIAgent):
         agent_config: dict[str, Any],
         task_workspace: Path,
     ) -> AgentResult | dict[str, Any]:
-        """Execute a browser automation task using Claude Code CLI."""
-        warn_if_local_proxy_unsupported(agent_config, self.name)
+        """Execute a browser automation task using Claude Code CLI.
+
+        With a managed browser backend (lexmount, cdp), the backend session is
+        opened first and its CDP endpoint is handed to Playwright MCP; with
+        local/unset browser_id, MCP launches its own browser.
+        """
+        browser_id = str(agent_config.get("browser_id") or "")
+        if browser_id in SELF_LAUNCH_BROWSER_IDS:
+            warn_if_local_proxy_unsupported(agent_config, self.name)
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=None)
+        with open_browser_session(
+            browser_id=browser_id,
+            agent_name=self.name,
+            agent_config=agent_config,
+        ) as session_context:
+            cdp_url = session_context.cdp_url if session_context.transport == "cdp" else None
+            if not cdp_url:
+                return self._unsupported_backend_result(
+                    task_info["task_id"], browser_id, session_context.transport
+                )
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=cdp_url)
+
+    def _unsupported_backend_result(
+        self, task_id: str, browser_id: str, transport: str
+    ) -> AgentResult:
+        """Fail fast instead of silently self-launching a local browser."""
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status="failed",  # type: ignore[arg-type]
+            agent_done="error",  # type: ignore[arg-type]
+            error=(
+                f"Browser backend '{browser_id}' (transport={transport}) provides no CDP "
+                "endpoint, so claude-code cannot attach Playwright MCP to it. "
+                "Use a CDP-capable backend (e.g. lexmount, cdp) or browser_id=local."
+            ),
+            metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+        )
+
+    def _execute(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        cdp_url: str | None,
+    ) -> AgentResult | dict[str, Any]:
         task_id = task_info["task_id"]
         # Reuse the prompt already formatted by cli/run.py (it carries the
         # single-site constraint, the same-site region allowance, and the
@@ -432,7 +481,9 @@ class ClaudeCodeAgent(CLIAgent):
             logger.warning("Invalid timeout for task %s (%r): %s", task_id, timeout_val, exc)
             timeout = 300
 
-        allowed_tools = agent_config.get("allowed_tools", "mcp__playwright*")
+        # Current claude CLI rejects a trailing wildcard ("mcp__playwright*") in
+        # allow rules; the segment wildcard "mcp__playwright__*" is accepted.
+        allowed_tools = agent_config.get("allowed_tools", "mcp__playwright__*")
         system_prompt = agent_config.get("system_prompt") or _DEFAULT_SYSTEM_PROMPT
 
         api_key = agent_config.get("api_key")
@@ -440,16 +491,11 @@ class ClaudeCodeAgent(CLIAgent):
 
         # Build a Playwright-only MCP config so the subprocess ignores all other
         # user-scope MCP servers (e.g. chrome-devtools-mcp) that would otherwise
-        # be loaded and cause spurious socket errors.
+        # be loaded and cause spurious socket errors. With a managed backend,
+        # build_playwright_mcp_args appends --cdp-endpoint <cdp_url> so MCP
+        # attaches to the cloud browser instead of launching a local one.
         playwright_mcp_cmd = agent_config.get("playwright_mcp_command", "npx")
-        playwright_mcp_base_args = agent_config.get("playwright_mcp_args", ["@playwright/mcp@latest"])
-        # --timeout-action 30000: increase from the 5000ms default (screenshots
-        #   timeout on pages with slow external font CDNs).
-        # No --output-dir: MCP creates a .playwright-mcp/ subdirectory inside
-        #   its cwd (task_workspace) automatically, keeping the workspace root clean.
-        playwright_mcp_args = playwright_mcp_base_args + [
-            "--timeout-action", "30000",
-        ]
+        playwright_mcp_args = build_playwright_mcp_args(agent_config, cdp_url)
         mcp_config_json = json.dumps({
             "mcpServers": {
                 "playwright": {
@@ -484,6 +530,9 @@ class ClaudeCodeAgent(CLIAgent):
         )
 
         env = {**os.environ}
+        # claude refuses --dangerously-skip-permissions under root/sudo unless
+        # IS_SANDBOX=1 is set; server/container deployments commonly run as root.
+        env["IS_SANDBOX"] = "1"
         if api_key:
             env["ANTHROPIC_API_KEY"] = api_key
         if base_url:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -258,9 +258,14 @@ agents:
     # Set database_string only when you want a managed/persistent Skyvern database.
     # database_string: postgresql+psycopg://skyvern@localhost/skyvern
   claude-code:
+    # claude-code needs an Anthropic model (api_key=$ANTHROPIC_API_KEY); without
+    # active_model it would inherit default.model (an OpenAI entry) and fail auth.
+    active_model: sonnet
+    active_browser: lexmount
     max_turns: 50
     timeout: 300
-    allowed_tools: mcp__playwright*
+    # Segment wildcard (mcp__playwright__*); a trailing wildcard is rejected.
+    allowed_tools: mcp__playwright__*
   codex:
     active_model: codex
     timeout: 600

--- a/docs/cli-agents-deployment.md
+++ b/docs/cli-agents-deployment.md
@@ -23,19 +23,16 @@ upgrading.
 
 - **Recommended on servers: `lexmount`** (default via `agents.<agent>.active_browser`).
   The browser runs in the cloud; the server only needs outbound network. No
-  local Chrome required for the CDP-capable agents (codex/cursor/openclaw) in
-  this mode. **claude-code is the exception**: it has no managed-backend
-  support and always launches a local browser via Playwright MCP, so a
-  deployment that includes claude-code still needs Chrome/Chromium.
+  local Chrome required for the CDP-capable agents (claude-code/codex/cursor/openclaw)
+  in this mode — claude-code now opens the managed backend session and attaches
+  Playwright MCP to its CDP endpoint (`--cdp-endpoint`), like the others.
 - **`browser_id=local`**: requires a local Chrome/Chromium plus headless-Linux
-  dependencies. For codex/cursor, Playwright MCP downloads its own browser on
-  first run — pre-warm with `npx -y @playwright/mcp@latest --version` during
-  image build to avoid first-task latency.
+  dependencies. For claude-code/codex/cursor, Playwright MCP downloads its own
+  browser on first run — pre-warm with `npx -y @playwright/mcp@latest --version`
+  during image build to avoid first-task latency.
 - Cloud-native backends (`browser-use-cloud`, `skyvern-cloud`) are **not
-  supported** by CLI agents (no CDP endpoint). codex/cursor/openclaw fail fast
-  with a clear error; **claude-code does not inspect `browser_id` at all** and
-  silently uses its local Playwright MCP browser regardless of the selected
-  backend — do not point claude-code at a managed backend and expect an error.
+  supported** by CLI agents (no CDP endpoint). All four (claude-code/codex/cursor/openclaw)
+  fail fast with a clear error rather than silently self-launching a local browser.
 
 ## Per-agent install and auth
 
@@ -46,9 +43,21 @@ npm install -g @anthropic-ai/claude-code
 ```
 
 - Auth: `ANTHROPIC_API_KEY` (+ optional `ANTHROPIC_BASE_URL`) via the model
-  entry (`models.<name>.api_key/base_url`).
-- Browser: Playwright MCP via `npx @playwright/mcp@latest` (local browser only;
-  no managed-backend support yet).
+  entry (`models.<name>.api_key/base_url`). Select an Anthropic model with
+  `agents.claude-code.active_model` (e.g. `sonnet`); without it the agent
+  inherits `default.model` (an OpenAI entry) and auth fails.
+- `base_url` must be the Anthropic API **root** — the claude CLI appends
+  `/v1/messages` itself, so a value ending in `/v1` becomes `/v1/v1/messages`
+  and 404s. (`api.anthropic.com` needs no override; for a LiteLLM proxy use the
+  bare host, not the OpenAI-style `.../v1` URL.) The endpoint must serve the
+  Anthropic Messages API natively, including `thinking`/`context_management` —
+  a proxy that routes Claude through an OpenAI adapter rejects those params with
+  a 400.
+- Browser: Playwright MCP via `npx @playwright/mcp@latest`; managed CDP backends
+  (lexmount, cdp) attach automatically with `--cdp-endpoint`, so no local Chrome
+  is needed in that mode.
+- Runs as root (server/container): claude refuses `--dangerously-skip-permissions`
+  under root unless `IS_SANDBOX=1` — the agent sets it in the subprocess env.
 
 ### codex (verified: codex-cli 0.130.0)
 
@@ -152,9 +161,9 @@ docker run --rm --user 1000 -v "$PWD/.env:/app/.env:ro" \
 With API-key codex auth instead, set `models.codex.base_url` when using a
 proxy endpoint (the key alone routes to api.openai.com).
 
-With the lexmount browser path no Chrome is needed in the image for
-codex/cursor/openclaw; **include Chrome/Chromium (and headless deps)
-separately if claude-code or `browser_id=local` runs are planned**.
+With the lexmount browser path no Chrome is needed in the image for any of the
+CLI agents (claude-code/codex/cursor/openclaw); **include Chrome/Chromium (and
+headless deps) separately only if `browser_id=local` runs are planned**.
 
 ## Smoke verification (per agent, after deploy)
 
@@ -166,17 +175,15 @@ claude --version; codex --version; cursor-agent --version; openclaw --version
 bubench run --agent codex   --data LexBench-Browser --mode single
 bubench run --agent cursor  --data LexBench-Browser --mode single
 bubench run --agent openclaw --data LexBench-Browser --mode single
-# claude-code needs local Chrome + headless deps even when others use lexmount,
-# and an Anthropic model selected (config.example.yaml has no
-# agents.claude-code.active_model, so without an override it inherits
-# default.model and the wrong api key):
-bubench run --agent claude-code --data LexBench-Browser --mode single --model sonnet
+# claude-code on lexmount needs no local Chrome; config.example.yaml pins
+# agents.claude-code.active_model: sonnet (an Anthropic model):
+bubench run --agent claude-code --data LexBench-Browser --mode single
 ```
 
 Verify by log, not exit code:
 
-- codex/cursor/openclaw on a managed backend: `run.log` shows
+- All four CLI agents on a managed backend: `run.log` shows
   `Lexmount session created: wss://...` plus the agent's model-call lines.
-- claude-code (and any `browser_id=local` run): no Lexmount line is expected —
-  look for the Playwright MCP browser starting and the agent's tool calls.
+- Any `browser_id=local` run: no Lexmount line is expected — look for the
+  Playwright MCP browser starting and the agent's tool calls.
 - In all cases `result.json` should record steps > 0 for browsing tasks.

--- a/tests/browseruse_bench/test_claude_code_agent.py
+++ b/tests/browseruse_bench/test_claude_code_agent.py
@@ -373,6 +373,105 @@ class TestClaudeCodeAgentCmd:
         idx = args.index("--timeout-action")
         assert int(args[idx + 1]) > 5000  # must exceed the 5000ms default
 
+    def test_allowed_tools_default_is_segment_wildcard(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # The claude CLI rejects a trailing wildcard ("mcp__playwright*");
+        # the default must be the accepted segment form.
+        cmd = self._capture_cmd(monkeypatch, tmp_path)
+        assert cmd[cmd.index("--allowedTools") + 1] == "mcp__playwright__*"
+
+    def test_self_launch_has_no_cdp_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Default config sets no browser_id -> self-launch, no --cdp-endpoint.
+        cmd = self._capture_cmd(monkeypatch, tmp_path)
+        mcp_cfg = json.loads(cmd[cmd.index("--mcp-config") + 1])
+        assert "--cdp-endpoint" not in mcp_cfg["mcpServers"]["playwright"]["args"]
+
+
+# ---------------------------------------------------------------------------
+# Browser backend wiring (open_browser_session) and root sandbox env
+# ---------------------------------------------------------------------------
+
+class TestClaudeCodeAgentBackend:
+    def _stream(self) -> list[str]:
+        return [_line({"type": "result", "result": "ok", "num_turns": 1, "duration_ms": 100})]
+
+    def test_managed_backend_attaches_cdp_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import claude_code as cc_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        opened: dict[str, str] = {}
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            opened["browser_id"] = browser_id
+            yield BrowserSessionContext(
+                backend_id=browser_id, transport="cdp", cdp_url="ws://cdp.example/1"
+            )
+
+        monkeypatch.setattr(cc_module, "open_browser_session", fake_session)
+        captured: list[list[str]] = []
+        agent = ClaudeCodeAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            lambda cmd, **kw: (captured.append(cmd), (0, self._stream(), None))[1],
+        )
+        result = agent.run_task(TASK_INFO, {**AGENT_CONFIG, "browser_id": "lexmount"}, tmp_path)
+        mcp_cfg = json.loads(captured[0][captured[0].index("--mcp-config") + 1])
+        args = mcp_cfg["mcpServers"]["playwright"]["args"]
+        assert opened["browser_id"] == "lexmount"
+        assert "--cdp-endpoint" in args
+        assert args[args.index("--cdp-endpoint") + 1] == "ws://cdp.example/1"
+        assert result.env_status == "success"
+
+    def test_non_cdp_backend_fails_fast(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import claude_code as cc_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            yield BrowserSessionContext(backend_id=browser_id, transport="cloud_native")
+
+        monkeypatch.setattr(cc_module, "open_browser_session", fake_session)
+        agent = ClaudeCodeAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            lambda *a, **kw: pytest.fail("subprocess must not be launched"),
+        )
+        result = agent.run_task(
+            TASK_INFO, {**AGENT_CONFIG, "browser_id": "browser-use-cloud"}, tmp_path
+        )
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "browser-use-cloud" in (result.error or "")
+        assert "cloud_native" in (result.error or "")
+
+    def test_is_sandbox_env_set_for_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # claude refuses --dangerously-skip-permissions under root without
+        # IS_SANDBOX=1; the agent must inject it into the subprocess env.
+        captured_env: dict[str, str] = {}
+        agent = ClaudeCodeAgent()
+
+        def _fake(cmd: list[str], **kw: Any) -> tuple:
+            captured_env.update(kw.get("env") or {})
+            return 0, self._stream(), None
+
+        monkeypatch.setattr(agent, "_run_subprocess", _fake)
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert captured_env.get("IS_SANDBOX") == "1"
+
 
 # ---------------------------------------------------------------------------
 # Integration smoke test — requires claude CLI + ANTHROPIC_API_KEY


### PR DESCRIPTION
## Summary

Brings the `claude-code` agent in line with the other CLI agents (codex/cursor/openclaw). Previously it ignored `browser_id`, always self-launched a local Playwright MCP browser, and could not run under root in a container. Fixes three issues reported from a bench run on a server:

1. **Runs as root** — claude refuses `--dangerously-skip-permissions` under root/sudo. The agent now sets `IS_SANDBOX=1` in the subprocess env so it is accepted in server/container deployments.
2. **Managed-backend (lexmount/CDP) support** — `run_task` now opens the backend session via `open_browser_session` and threads its CDP endpoint into Playwright MCP via `build_playwright_mcp_args(agent_config, cdp_url)` (`--cdp-endpoint`), exactly like codex/cursor. Cloud-native backends (no CDP endpoint) fail fast instead of silently self-launching. Local/unset `browser_id` keeps the self-launch path.
3. **Tool wildcard** — default `allowed_tools` changed from the trailing-wildcard `mcp__playwright*` (rejected by the current claude CLI) to the segment form `mcp__playwright__*`.

Also:
- `config.example.yaml`: pin `agents.claude-code.active_model: sonnet` (an Anthropic model) and `active_browser: lexmount` so the default fleet works without local Chrome.
- Docs: claude-code no longer needs local Chrome on lexmount; documents two deployment gotchas discovered while smoke-testing — `base_url` must be the Anthropic **root** (the CLI appends `/v1/messages`, so a `.../v1` value 404s as `/v1/v1/messages`), and the endpoint must serve the Anthropic Messages API natively (`thinking`/`context_management`), which an OpenAI-adapter proxy rejects with a 400.

## Smoke test (real `bubench run`, lexmount, model `dmx-claude-sonnet-4-6`)

```
bubench run --agent claude-code --data LexBench-Browser --mode single --model sonnet --browser-id lexmount
```

`run.log` shows `Lexmount session created: wss://...` (claude-code never opened a managed session before this change), and the claude `init` event reports:
- `permissionMode: bypassPermissions` — `--dangerously-skip-permissions` accepted under the runtime user (Issue 1)
- `mcp_servers: [{playwright, connected}]` + 23 `mcp__playwright__*` tools registered — wildcard accepted, MCP connected (Issue 3 + wiring)
- the live model call is reached (Issue 2 path runs end to end)

The only failure in this environment is the local LiteLLM proxy returning `400 UnsupportedParamsError` on the CLI's native `thinking` param — a proxy-config limitation, not the agent code (real `api.anthropic.com` / a native Anthropic passthrough accepts it).

## Tests

`tests/browseruse_bench/test_claude_code_agent.py` — added `TestClaudeCodeAgentBackend` (managed backend attaches `--cdp-endpoint`; non-CDP backend fails fast; `IS_SANDBOX=1` set) and command tests for the segment-wildcard default and no-`--cdp-endpoint` self-launch. 27 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)