### PR TITLE
[codex] Add configurable Lexmount official proxy

### DIFF
--- a/browseruse_bench/browsers/providers/lexmount.py
+++ b/browseruse_bench/browsers/providers/lexmount.py
@@ -35,6 +35,7 @@ _PROFILE_FIELDS = (
     "base_url",
     "verify_ssl",
     "browser_mode",
+    "official_proxy",
     "proxy_server",
     "proxy_type",
     "proxy_username",
@@ -79,6 +80,14 @@ def _resolve_lexmount_creds(agent_config: dict[str, Any]) -> dict[str, Any]:
     return resolved
 
 
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if value in (None, ""):
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in ("false", "0", "no", "off")
+
+
 _ANSI_GREEN = "\033[32m"
 _ANSI_RESET = "\033[0m"
 
@@ -120,8 +129,8 @@ class LexmountBackend(BrowserBackend):
         base_url = creds.get("base_url") or None
         if base_url and "://" not in base_url:
             base_url = "https://" + base_url
-        verify_ssl_raw = creds.get("verify_ssl")
-        verify_ssl = False if str(verify_ssl_raw).lower() in ("false", "0", "no") else True
+        verify_ssl = _coerce_bool(creds.get("verify_ssl"), default=True)
+        official_proxy = _coerce_bool(creds.get("official_proxy"), default=False)
         lexmount_client = Lexmount(
             **({} if not api_key else {"api_key": api_key}),
             **({} if not project_id else {"project_id": project_id}),
@@ -181,6 +190,7 @@ class LexmountBackend(BrowserBackend):
         try:
             session = lexmount_client.sessions.create(
                 browser_mode=mode,
+                official_proxy=official_proxy,
                 proxy=proxy,
                 **({"context": session_context_arg} if session_context_arg else {}),
             )

--- a/browseruse_bench/cli/login.py
+++ b/browseruse_bench/cli/login.py
@@ -57,9 +57,22 @@ def _resolve_credential(cli_value: str | None, *env_keys: str) -> str | None:
 def _as_bool(flag: bool | None, env_val: str | None, default: bool = True) -> bool:
     if flag is not None:
         return flag
-    if env_val is None:
+    return _coerce_bool(env_val, default=default)
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if value in (None, ""):
         return default
-    return env_val.strip().lower() not in ("false", "0", "no", "off")
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in ("false", "0", "no", "off")
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return None
 
 
 def configure_login_parser(parser: argparse.ArgumentParser, _config: dict[str, Any]) -> None:
@@ -218,13 +231,7 @@ def _profile_keys_for_run(args: argparse.Namespace, _config: dict[str, Any]) -> 
         return [str(args.profile).strip().lower()]
     keys: list[str] = []
     seen: set[str] = set()
-    agents_cfg = (_config or {}).get("agents") or {}
-    if not isinstance(agents_cfg, dict):
-        return keys
-    for agent_cfg in agents_cfg.values():
-        if not isinstance(agent_cfg, dict):
-            continue
-        browser = agent_cfg.get("browser") if isinstance(agent_cfg, dict) else None
+    for browser in _iter_lexmount_browser_configs(_config):
         profiles = normalize_profile_keys(
             browser.get("lexmount_profiles") if isinstance(browser, dict) else None
         )
@@ -235,18 +242,41 @@ def _profile_keys_for_run(args: argparse.Namespace, _config: dict[str, Any]) -> 
     return keys
 
 
+def _iter_lexmount_browser_configs(_config: dict[str, Any]) -> list[dict[str, Any]]:
+    configs: list[dict[str, Any]] = []
+    browsers_cfg = (_config or {}).get("browsers") or {}
+    if isinstance(browsers_cfg, dict):
+        preferred = browsers_cfg.get("lexmount")
+        if isinstance(preferred, dict):
+            configs.append(preferred)
+        for key, browser in browsers_cfg.items():
+            if key == "lexmount" or not isinstance(browser, dict):
+                continue
+            if str(browser.get("browser_id") or "").lower() == "lexmount":
+                configs.append(browser)
+
+    agents_cfg = (_config or {}).get("agents") or {}
+    if isinstance(agents_cfg, dict):
+        for agent_cfg in agents_cfg.values():
+            if not isinstance(agent_cfg, dict):
+                continue
+            browser = agent_cfg.get("browser")
+            if isinstance(browser, dict):
+                configs.append(browser)
+    return configs
+
+
+def _lexmount_browser_config(_config: dict[str, Any]) -> dict[str, Any]:
+    configs = _iter_lexmount_browser_configs(_config)
+    return configs[0] if configs else {}
+
+
 def _profile_cfg_from_config(_config: dict[str, Any], profile_key: str) -> dict[str, Any]:
     """Find the per-profile dict in any agent's `lexmount_profiles`, case-insensitive."""
     if not profile_key:
         return {}
     norm_key = profile_key.strip().lower()
-    agents_cfg = (_config or {}).get("agents") or {}
-    if not isinstance(agents_cfg, dict):
-        return {}
-    for agent_cfg in agents_cfg.values():
-        if not isinstance(agent_cfg, dict):
-            continue
-        browser = agent_cfg.get("browser")
+    for browser in _iter_lexmount_browser_configs(_config):
         profiles = normalize_profile_keys(
             browser.get("lexmount_profiles") if isinstance(browser, dict) else None
         )
@@ -262,6 +292,7 @@ def _resolve_creds_for_profile(
 ) -> dict[str, Any] | None:
     """Resolve creds for one profile. Returns None when api_key or project_id missing."""
     cfg_profile = _profile_cfg_from_config(_config, profile_key) if profile_key else {}
+    browser_cfg = _lexmount_browser_config(_config)
     upper = (profile_key or "").upper().replace("-", "_")
     api_env = (f"LEXMOUNT_API_KEY_{upper}", f"LEXMOUNT_API_{upper}") if upper else ()
     project_env = (f"LEXMOUNT_PROJECT_ID_{upper}",) if upper else ()
@@ -270,28 +301,40 @@ def _resolve_creds_for_profile(
         args.api_key
         or _resolve_credential(None, *api_env)
         or cfg_profile.get("api_key")
+        or browser_cfg.get("lexmount_api_key")
         or _resolve_credential(None, "LEXMOUNT_API_KEY", "LEXMOUNT_API")
     )
     project_id = (
         args.project_id
         or _resolve_credential(None, *project_env)
         or cfg_profile.get("project_id")
+        or browser_cfg.get("lexmount_project_id")
         or _resolve_credential(None, "LEXMOUNT_PROJECT_ID")
     )
     base_url = (
         args.base_url
         or _resolve_credential(None, *base_env)
         or cfg_profile.get("base_url")
+        or browser_cfg.get("lexmount_base_url")
         or _resolve_credential(None, "LEXMOUNT_BASE_URL")
     )
     if not api_key or not project_id:
         return None
     verify_ssl = _as_bool(args.verify_ssl, os.getenv("LEXMOUNT_VERIFY_SSL"), default=True)
+    official_proxy = _coerce_bool(
+        _first_present(
+            cfg_profile.get("official_proxy"),
+            browser_cfg.get("lexmount_official_proxy"),
+            os.getenv("LEXMOUNT_OFFICIAL_PROXY"),
+        ),
+        default=False,
+    )
     return {
         "api_key": api_key,
         "project_id": project_id,
         "base_url": base_url,
         "verify_ssl": verify_ssl,
+        "official_proxy": official_proxy,
     }
 
 
@@ -401,6 +444,7 @@ def _login_one_profile(
         session = client.sessions.create(
             context={"id": base_ctx_id, "mode": "read_write"},
             browser_mode=args.browser_mode,
+            official_proxy=creds["official_proxy"],
         )
         target = _get_page_target(client, session)
         page_ws_url = (

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -159,6 +159,7 @@ browsers:
   lexmount:
     browser_id: lexmount
     lexmount_browser_mode: normal
+    lexmount_official_proxy: false
     lexmount_api_key: $LEXMOUNT_API_KEY
     lexmount_project_id: $LEXMOUNT_PROJECT_ID
     # lexmount_base_url: $LEXMOUNT_BASE_URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "psycopg2-binary>=2.9.9",
-    "lexmount>=0.4.8",
+    "lexmount==0.5.12",
     "lexbench-sdk>=0.1.0",
     "python-socks",
     "pandas>=2.1.3",

--- a/tests/browseruse_bench/test_lexmount_backend.py
+++ b/tests/browseruse_bench/test_lexmount_backend.py
@@ -35,10 +35,15 @@ def _install_fake_lexmount_sdk(
         def create(
             self,
             browser_mode: str,
+            official_proxy: bool = False,
             proxy: str | None = None,
             context: dict | None = None,
         ) -> FakeSession:
-            state["create_calls"].append({"browser_mode": browser_mode, "context": context})
+            state["create_calls"].append({
+                "browser_mode": browser_mode,
+                "official_proxy": official_proxy,
+                "context": context,
+            })
             return FakeSession()
 
         def delete(self, session_id: str) -> None:
@@ -133,6 +138,7 @@ def test_lexmount_backend_forks_login_context_when_env_set(
     assert state["create_calls"] == [
         {
             "browser_mode": "normal",
+            "official_proxy": False,
             "context": {"id": "forked_ctx_9876", "mode": "read_write"},
         }
     ]
@@ -158,7 +164,9 @@ def test_lexmount_backend_skips_fork_when_env_unset(monkeypatch: pytest.MonkeyPa
     session_context = backend.open(agent_name="browser-use", agent_config={})
 
     assert state["fork_calls"] == []
-    assert state["create_calls"] == [{"browser_mode": "normal", "context": None}]
+    assert state["create_calls"] == [
+        {"browser_mode": "normal", "official_proxy": False, "context": None}
+    ]
     assert "forked_context_id" not in session_context.metadata
     backend.close(session_context)
     assert state["ctx_delete_calls"] == []
@@ -270,3 +278,55 @@ def test_lexmount_profile_partial_override(monkeypatch: pytest.MonkeyPatch) -> N
         "project_id": "P-default",
         "base_url": "https://en.example",
     }
+
+
+def test_lexmount_official_proxy_defaults_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lexmount sessions default to official_proxy=False unless config opts in."""
+    state = _install_fake_lexmount_sdk(monkeypatch)
+    backend = LexmountBackend("lexmount")
+
+    backend.open(agent_name="browser-use", agent_config={})
+
+    assert state["create_calls"] == [
+        {"browser_mode": "normal", "official_proxy": False, "context": None}
+    ]
+
+
+def test_lexmount_official_proxy_from_top_level_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """lexmount_official_proxy controls the SDK sessions.create official_proxy kwarg."""
+    state = _install_fake_lexmount_sdk(monkeypatch)
+    backend = LexmountBackend("lexmount")
+
+    backend.open(
+        agent_name="browser-use",
+        agent_config={"lexmount_official_proxy": True},
+    )
+
+    assert state["create_calls"] == [
+        {"browser_mode": "normal", "official_proxy": True, "context": None}
+    ]
+
+
+def test_lexmount_official_proxy_profile_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-profile official_proxy can override the top-level lexmount_official_proxy."""
+    state = _install_fake_lexmount_sdk(monkeypatch)
+    monkeypatch.setenv(lexmount_module.LEXMOUNT_PROFILE_ENV_KEY, "zh")
+    backend = LexmountBackend("lexmount")
+
+    backend.open(
+        agent_name="browser-use",
+        agent_config={
+            "lexmount_official_proxy": False,
+            "lexmount_profiles": {
+                "zh": {"official_proxy": True},
+            },
+        },
+    )
+
+    assert state["create_calls"] == [
+        {"browser_mode": "normal", "official_proxy": True, "context": None}
+    ]

--- a/tests/browseruse_bench/test_login_cli.py
+++ b/tests/browseruse_bench/test_login_cli.py
@@ -55,6 +55,145 @@ def _make_args(**overrides) -> object:
     )
 
 
+def test_profile_keys_for_run_reads_flat_lexmount_profiles() -> None:
+    """bubench login add should discover profiles from new-style browsers.lexmount config."""
+    args = _make_args(profile=None)
+    cfg = {
+        "browsers": {
+            "lexmount": {
+                "browser_id": "lexmount",
+                "lexmount_profiles": {
+                    "zh": {"api_key": "K-zh"},
+                    "en": {"api_key": "K-en"},
+                },
+            }
+        }
+    }
+
+    assert login_cli._profile_keys_for_run(args, cfg) == ["zh", "en"]
+
+
+def test_resolve_creds_uses_flat_lexmount_official_proxy_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """lexmount_official_proxy in browsers.lexmount flows into login session creation config."""
+    monkeypatch.delenv("LEXMOUNT_API_KEY", raising=False)
+    monkeypatch.delenv("LEXMOUNT_API", raising=False)
+    monkeypatch.delenv("LEXMOUNT_PROJECT_ID", raising=False)
+    monkeypatch.delenv("LEXMOUNT_BASE_URL", raising=False)
+    monkeypatch.delenv("LEXMOUNT_OFFICIAL_PROXY", raising=False)
+    args = _make_args()
+    cfg = {
+        "browsers": {
+            "lexmount": {
+                "browser_id": "lexmount",
+                "lexmount_api_key": "K-flat",
+                "lexmount_project_id": "P-flat",
+                "lexmount_base_url": "https://flat.example",
+                "lexmount_official_proxy": True,
+            }
+        }
+    }
+
+    creds = login_cli._resolve_creds_for_profile(args, cfg, profile_key=None)
+
+    assert creds == {
+        "api_key": "K-flat",
+        "project_id": "P-flat",
+        "base_url": "https://flat.example",
+        "verify_ssl": True,
+        "official_proxy": True,
+    }
+
+
+def test_resolve_creds_official_proxy_defaults_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """official_proxy defaults to false when config and env do not opt in."""
+    monkeypatch.delenv("LEXMOUNT_OFFICIAL_PROXY", raising=False)
+    args = _make_args()
+    cfg = {
+        "browsers": {
+            "lexmount": {
+                "browser_id": "lexmount",
+                "lexmount_api_key": "K-flat",
+                "lexmount_project_id": "P-flat",
+            }
+        }
+    }
+
+    creds = login_cli._resolve_creds_for_profile(args, cfg, profile_key=None)
+
+    assert creds is not None
+    assert creds["official_proxy"] is False
+
+
+def test_login_one_profile_passes_official_proxy_to_session_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The login flow passes the resolved official_proxy value into Lexmount sessions.create."""
+    captured: dict = {}
+
+    class _Context:
+        id = "ctx_login"
+
+    class _Session:
+        session_id = "session_login"
+        id = session_id
+        inspect_url = "https://inspect.example"
+
+        def close(self) -> None:
+            captured["closed"] = True
+
+    class _Contexts:
+        def create(self, metadata):
+            captured["metadata"] = metadata
+            return _Context()
+
+    class _Sessions:
+        def create(self, **kwargs):
+            captured["session_create"] = kwargs
+            return _Session()
+
+        def delete(self, session_id):
+            captured["deleted_session"] = session_id
+
+    class _Client:
+        contexts = _Contexts()
+        sessions = _Sessions()
+
+    monkeypatch.setattr(login_cli, "_build_client", lambda *args: _Client())
+    monkeypatch.setattr(login_cli, "_get_page_target", lambda client, session: None)
+    monkeypatch.setattr(login_cli, "_wait_for_user_login", lambda *args: None)
+    monkeypatch.setattr(login_cli, "_persist_login_entry", lambda *args: None)
+    args = _make_args(browser_mode="normal")
+    cfg = {
+        "browsers": {
+            "lexmount": {
+                "browser_id": "lexmount",
+                "lexmount_api_key": "K-flat",
+                "lexmount_project_id": "P-flat",
+                "lexmount_official_proxy": True,
+            }
+        }
+    }
+
+    rc = login_cli._login_one_profile(
+        args,
+        cfg,
+        site="example",
+        website="https://example.com",
+        profile_key=None,
+    )
+
+    assert rc == 0
+    assert captured["session_create"] == {
+        "context": {"id": "ctx_login", "mode": "read_write"},
+        "browser_mode": "normal",
+        "official_proxy": True,
+    }
+
+
 def test_delete_remote_entry_uses_per_profile_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Add `lexmount_official_proxy` as a YAML-configurable Lexmount browser parameter, defaulting to `false` in `config.example.yaml`.
- Pass the resolved value into `lexmount_client.sessions.create(..., official_proxy=...)` for benchmark sessions.
- Pass the same resolved value into login session creation, including support for flat `browsers.lexmount` config and per-profile overrides.
- Pin `lexmount==0.5.12` so the SDK parameter is available consistently.

## Validation

- YAML parse check: `lexmount_official_proxy` defaults to `false`; 14 models remain configured.
- Runtime config loader check with the browser-use Lexmount environment: `lexmount_official_proxy False`, `browser_id lexmount`.
- `/tmp/lexmount-pr-venv/bin/python -m pytest tests/browseruse_bench/test_lexmount_backend.py tests/browseruse_bench/test_login_cli.py` (19 passed).
- `git diff --check`
