### PR TITLE
docs(ci): fix warmup webhook comment to match actual Kestra flow

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -58,12 +58,14 @@ jobs:
 
       - name: Trigger Kestra image warmup via bench webhook (best-effort)
         # The bench platform (bench.lexmount.com) forwards this to Kestra's
-        # lex-browser-image-warmup flow. Auth is a shared Bearer secret
+        # lex/lex-browser-image-warmup flow. Auth is a shared Bearer secret
         # (IMAGE_WARMUP_WEBHOOK_SECRET) configured both in this repo's Actions
         # secrets and in the platform's deployment env; the platform returns
         # 401 until both sides share the same value. Best-effort
-        # (continue-on-error): Kestra's 10-minute schedule trigger remains the
-        # fallback warmup mechanism, so a failed webhook never blocks CI.
+        # (continue-on-error) so a failed webhook never blocks CI. Note: the
+        # warmup flow currently has ONLY a webhook trigger (no schedule
+        # fallback), so a skipped or failed webhook leaves the image un-warmed
+        # until the next successful build webhook.
         continue-on-error: true
         shell: bash
         env:
@@ -72,8 +74,9 @@ jobs:
           set -euo pipefail
 
           if [ -z "${IMAGE_WARMUP_WEBHOOK_SECRET:-}" ]; then
-            echo "IMAGE_WARMUP_WEBHOOK_SECRET not configured."
-            echo "Warmup will be handled by Kestra's 10-minute schedule trigger."
+            echo "IMAGE_WARMUP_WEBHOOK_SECRET not configured; skipping warmup."
+            echo "The warmup flow has no schedule fallback, so the image will be"
+            echo "warmed only on the next build that sends this webhook."
             exit 0
           fi
 


### PR DESCRIPTION
## What

Corrects an inaccurate comment in the GHCR publish workflow's image-warmup step.

The comment claimed *"Kestra's 10-minute schedule trigger remains the fallback warmup mechanism"*, but the actual `lex/lex-browser-image-warmup` flow (revision 3) has **only a Webhook trigger** — there is no schedule trigger, so there is no fallback.

## Evidence

Verified directly against the Kestra instance and GitHub Actions history:

- Flow `lex/lex-browser-image-warmup` is enabled and its `triggers:` block contains a single `io.kestra.plugin.core.trigger.Webhook` (key `lexbench-image-warmup`); no `Schedule` trigger exists.
- Every recent warmup execution is `trigger=Webhook` and maps 1:1 to a build's webhook POST (each GitHub build's warmup step returns `HTTP 200` and produces exactly one execution). There are no schedule-triggered executions.

## Change

- Step comment: drop the nonexistent "10-minute schedule" fallback claim; state that the flow has only a webhook trigger, so a skipped/failed webhook leaves the image un-warmed until the next successful build webhook. Also qualify the flow name with its namespace.
- Secret-missing `echo`: replace the "handled by the schedule trigger" message with an accurate one.

Comment/log-text only — no change to the webhook logic or any agent runtime path, so no bench smoke test applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)