### PR TITLE
fix(eval): route Online-Mind2Web WebJudge through list-returning engine

### DIFF
--- a/browseruse_bench/eval/online_mind2web/evaluator.py
+++ b/browseruse_bench/eval/online_mind2web/evaluator.py
@@ -228,6 +228,33 @@ class OnlineMind2WebEvaluator(BaseEvaluator):
     name: ClassVar[str] = "Online-Mind2Web"
     default_mode: ClassVar[str] = "WebJudge_Online_Mind2Web_eval"
 
+    def __init__(self, args, model):
+        super().__init__(args, model)
+        self._engine: Optional[OpenaiEngine] = None
+
+    def _engine_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "model": self.args.model,
+            "api_key": self.args.api_key,
+            "base_url": self.args.base_url,
+        }
+        if self.args.temperature is not None:
+            kwargs["temperature"] = self.args.temperature
+        return kwargs
+
+    @property
+    def engine(self) -> OpenaiEngine:
+        """List-returning engine required by the WebJudge pipeline.
+
+        WebJudge indexes ``model.generate(...)[0]`` expecting ``list[str]`` (the
+        OpenaiEngine contract). The shared ``EvaluationModel.generate`` returns a
+        ``str`` for LexBench, so reusing it here would slice the first character
+        of every judge response. Build a dedicated OpenaiEngine for both paths.
+        """
+        if self._engine is None:
+            self._engine = OpenaiEngine(**self._engine_kwargs())
+        return self._engine
+
     def results_filename(self) -> str:
         threshold = self.args.score_threshold
         return (
@@ -248,7 +275,7 @@ class OnlineMind2WebEvaluator(BaseEvaluator):
 
     def evaluate_one(self, task_id, task, agent_result, trajectory_dir):
         return _judge_one(
-            task_id, trajectory_dir, agent_result, self.model,
+            task_id, trajectory_dir, agent_result, self.engine,
             self.args.score_threshold or 3, self.args.mode,
         )
 
@@ -267,13 +294,7 @@ class OnlineMind2WebEvaluator(BaseEvaluator):
             self.results_path(), len(pending), max(1, progress_interval),
         )
 
-        engine_kwargs = {
-            "model": self.args.model,
-            "api_key": self.args.api_key,
-            "base_url": self.args.base_url,
-        }
-        if self.args.temperature is not None:
-            engine_kwargs["temperature"] = self.args.temperature
+        engine_kwargs = self._engine_kwargs()
 
         chunk_size = max(1, len(pending) // num_workers)
         subsets = [pending[i:i + chunk_size] for i in range(0, len(pending), chunk_size)]

--- a/tests/browseruse_bench/test_eval_online_mind2web.py
+++ b/tests/browseruse_bench/test_eval_online_mind2web.py
@@ -1,0 +1,93 @@
+"""Regression tests for the Online-Mind2Web evaluator model wiring.
+
+WebJudge indexes ``model.generate(...)[0]`` expecting ``list[str]`` (the
+OpenaiEngine contract). A prior bug wired the shared ``EvaluationModel`` (whose
+``generate`` returns a ``str``) into the single-worker path, so ``[0]`` sliced
+the first character of every judge response ("Thoughts..." -> "T"), forcing all
+tasks to a parser-default failure regardless of the agent's real answer.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from browseruse_bench.eval.base import EvaluatorArgs
+from browseruse_bench.eval.online_mind2web.evaluator import OnlineMind2WebEvaluator
+from browseruse_bench.eval.online_mind2web.utils import OpenaiEngine
+
+
+def _args(tmp_path: Path) -> EvaluatorArgs:
+    traj = tmp_path / "tasks"
+    traj.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    return EvaluatorArgs(
+        benchmark="Online-Mind2Web",
+        model="gpt-5.4",
+        api_key="test-key",
+        base_url=None,
+        trajectories_dir=traj,
+        output_path=out,
+        score_threshold=3,
+        num_worker=1,
+        temperature=1.0,
+        split="All",
+        data_source="local",
+        mode="WebJudge_Online_Mind2Web_eval",
+    )
+
+
+class _StrModel:
+    """Mimics EvaluationModel: ``generate`` returns a ``str`` (not a list)."""
+
+    def __init__(self) -> None:
+        self.last_usage = None
+
+    def generate(self, messages, *args, **kwargs) -> str:
+        return 'Thoughts: looks complete.\nStatus: "success"'
+
+
+class _FakeListEngine:
+    """Mimics OpenaiEngine: ``generate`` returns ``list[str]``."""
+
+    def __init__(self) -> None:
+        self.last_usage = None
+
+    def generate(self, messages, *args, **kwargs):
+        system = messages[0]["content"] if messages else ""
+        if "web navigation agent" in system:
+            return ['Thoughts: All key points are satisfied.\nStatus: "success"']
+        return ["**Key Points**:\n1. Complete the task"]
+
+
+def test_webjudge_engine_is_list_returning_openai_engine(tmp_path):
+    # The judge must run through a dedicated OpenaiEngine (list-returning),
+    # never the shared str-returning model handed to BaseEvaluator.
+    ev = OnlineMind2WebEvaluator(_args(tmp_path), model=_StrModel())
+    assert isinstance(ev.engine, OpenaiEngine)
+    assert ev.engine is not ev.model
+
+
+def test_evaluate_one_preserves_full_verdict(tmp_path):
+    # Shared model returns a str; if evaluate_one used it, generate(...)[0] would
+    # slice "T" and the task would be force-failed. With the dedicated engine the
+    # full 'Status: "success"' verdict must survive.
+    ev = OnlineMind2WebEvaluator(_args(tmp_path), model=_StrModel())
+    ev._engine = _FakeListEngine()  # avoid any network in the engine property
+
+    tdir = ev.args.trajectories_dir / "task1"
+    tdir.mkdir()
+    agent_result = {
+        "task": "Find the lowest-priced farm in Wilkes County, NC.",
+        "action_history": ["Searched Wilkes County", "Found $38,888 as lowest"],
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    (tdir / "result.json").write_text(json.dumps(agent_result), encoding="utf-8")
+
+    result = ev.evaluate_one("task1", {}, agent_result, tdir)
+
+    assert result.predicted_label == 1
+    assert 'Status: "success"' in result.evaluation_details.response
+    # The response must be the full verdict, not a single sliced character.
+    assert len(result.evaluation_details.response) > 1


### PR DESCRIPTION
## Problem

Online-Mind2Web (WebJudge) evaluations were silently failing **every** task (0% success) regardless of the agent's actual answer. The judge responses were being truncated to a single character (`"T"`, `"K"`, `"1"`), which broke all downstream parsing and forced a parser-default `failure`.

## Root cause

WebJudge indexes `model.generate(...)[0]` expecting `list[str]` — the upstream `OpenaiEngine` contract (`return [choice.message.content for ...]`). The **single-worker** path passed the shared `EvaluationModel`, whose `generate()` returns a `str` (LexBench consumes it directly). Indexing `[0]` on a string slices the **first character** of every judge response:

- `identify_key_points` → `"K"` / `"1"`
- `judge_image` → `"1"` (then `split("Score")[1]` raises `list index out of range`, score defaults to 0 → no screenshots pass the threshold)
- final verdict → `"T"` (no `Status:` found → `extract_predication` defaults to `failure`)

The multi-worker path was unaffected because it builds its own `OpenaiEngine`.

## Fix

Route **both** worker paths through a dedicated list-returning `OpenaiEngine` via an `engine` property (sharing `_engine_kwargs`). The str-returning `EvaluationModel` used by LexBench is left untouched. This matches the upstream Online-Mind2Web implementation, which always uses `OpenaiEngine`.

## Testing

- New regression tests in `tests/browseruse_bench/test_eval_online_mind2web.py`: assert the judge runs through a list-returning `OpenaiEngine` (not the shared str model), and that a full verdict survives instead of being sliced to one character. Verified the behavioral test fails when the bug is reintroduced.
- Full unit suite: 499 passed (pre-existing unrelated failures: optional-SDK collection errors + one agent-passthrough config test).
- Verified end-to-end: the previously-broken single-worker eval now returns full verdicts with no parse errors.

Eval-only change, so the agent `bubench run` smoke test does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)