### PR TITLE
Add machine identity and JS action log classification

### DIFF
--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -57,6 +57,12 @@ from browseruse_bench.utils import (
     resolve_split,
     setup_logger,
 )
+from browseruse_bench.utils.run_identity import (
+    INCLUDE_RAW_MACHINE_IDENTIFIERS_ENV_KEY,
+    MACHINE_ID_ENV_KEY,
+    MACHINE_IDENTITY_ENV_KEY,
+    collect_machine_identity,
+)
 
 CONFIG_PATH = REPO_ROOT / "config.yaml"
 
@@ -314,12 +320,14 @@ def _write_run_manifest(
     agent_config: dict[str, Any] | None = None,
     resolved_agent_config: dict[str, Any] | None = None,
     run_context: dict[str, Any] | None = None,
+    machine_identity: dict[str, Any] | None = None,
 ) -> None:
     """Write a redacted config snapshot for reproducibility."""
     try:
         runtime_config = resolved_agent_config or agent_config or config or {}
         snapshot = {
             "run": _redact_config_secrets(run_context or {}),
+            "machine": machine_identity or collect_machine_identity(),
             "runtime_config": _redact_config_secrets(runtime_config),
         }
         config_snapshot_path = output_dir / "config_snapshot.json"
@@ -552,6 +560,23 @@ def configure_run_parser(parser: argparse.ArgumentParser, config: dict[str, Any]
         help="Number of tasks to run in parallel (default: 1 = sequential).",
     )
     parser.add_argument(
+        "--machine-id",
+        default=None,
+        help=(
+            "Optional stable label for the machine running this experiment. "
+            f"Defaults to ${MACHINE_ID_ENV_KEY} or hostname."
+        ),
+    )
+    parser.add_argument(
+        "--include-raw-machine-identifiers",
+        action="store_true",
+        help=(
+            "Include raw hardware identifiers such as MAC address in run outputs. "
+            f"By default only hashed identifiers are recorded; can also be enabled "
+            f"with ${INCLUDE_RAW_MACHINE_IDENTIFIERS_ENV_KEY}=1."
+        ),
+    )
+    parser.add_argument(
         "--write-output-dir",
         dest="write_output_dir",
         default=None,
@@ -652,6 +677,20 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
 
     logger.info("Running %s on %s", agent_name, benchmark_name)
     logger.info("   Output: %s", output_dir)
+    include_raw_machine_identifiers = bool(
+        getattr(args, "include_raw_machine_identifiers", False)
+        or str(os.getenv(INCLUDE_RAW_MACHINE_IDENTIFIERS_ENV_KEY) or "").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+    machine_identity = collect_machine_identity(
+        getattr(args, "machine_id", None),
+        include_raw_identifiers=include_raw_machine_identifiers,
+    )
+    logger.info(
+        "   Machine: %s (host=%s)",
+        machine_identity.get("machine_id"),
+        machine_identity.get("hostname"),
+    )
 
     # Load tasks
     default_task_url = config.get("default", {}).get("task_start_url")
@@ -729,6 +768,7 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
     env["BROWSERUSE_BENCH_LOG_FORMAT"] = "plain"
+    env[MACHINE_IDENTITY_ENV_KEY] = json.dumps(machine_identity, ensure_ascii=False)
     repo_root_str = str(REPO_ROOT)
     old_pythonpath = env.get("PYTHONPATH", "")
     if old_pythonpath:
@@ -961,6 +1001,7 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
                     "benchmark": benchmark_name,
                     "split": args.split,
                     "model_id": model_id,
+                    "machine_id": machine_identity.get("machine_id"),
                     "timestamp": timestamp,
                     "model_name_override": getattr(args, "model_name", None),
                     "browser_id_override": getattr(args, "browser_id", None),
@@ -972,6 +1013,7 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
                     "concurrency": getattr(args, "concurrency", None),
                     "agent_config_path": str(getattr(args, "agent_config", None) or ""),
                 },
+                machine_identity=machine_identity,
             )
         except (OSError, KeyError, AttributeError, TypeError) as exc:
             logger.warning("Failed to finalize run manifest: %s", exc)

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -265,6 +265,55 @@ _RE_STATUS = re.compile(r"^\[(RUNNING|SUCCESS|FAILED|TIMING)\]")
 _RE_FINAL = re.compile(r"Final Result:")
 
 
+def _classify_js_code_for_log(code: str) -> str:
+    lowered = code.lower()
+    if any(token in lowered for token in ("localstorage", "sessionstorage", "document.cookie", "indexeddb")):
+        return "storage"
+    if any(token in lowered for token in ("fetch(", "xmlhttprequest", "performance.getentries")):
+        return "network"
+    if any(token in lowered for token in (
+        ".click(",
+        "dispatchevent",
+        "setattribute",
+        "appendchild",
+        "removechild",
+        "createelement",
+    )):
+        return "modify_page"
+    if any(token in lowered for token in ("location.", "document.title", "document.readystate", "window.inner")):
+        return "page_state"
+    if (
+        re.search(r"queryselectorall\(\s*['\"]a(?:[\\.\\[#:'\"]|$)", lowered)
+        or (".href" in lowered and "location.href" not in lowered)
+    ):
+        return "extract_links"
+    if (
+        re.search(r"queryselector(?:all)?\(\s*['\"][^'\"]*(?:input|textarea|select)", lowered)
+        or any(token in lowered for token in (".value", ".checked"))
+    ):
+        return "form_state"
+    if any(token in lowered for token in (
+        "queryselector",
+        "getelement",
+        "innertext",
+        "textcontent",
+        "innerhtml",
+        "document.body",
+    )):
+        return "read_dom"
+    return "custom"
+
+
+def _clarify_agent_stdout_line(line: str) -> str:
+    """Make third-party agent tool names clearer in run logs."""
+    marker = "evaluate: code:"
+    if marker not in line:
+        return line
+    prefix, _, code = line.partition(marker)
+    category = _classify_js_code_for_log(code)
+    return f"{prefix}execute_js({category}): code:{code}"
+
+
 class _TaskBriefWriter:
     """Extract key event lines from subprocess output into task_brief.log."""
 
@@ -892,11 +941,12 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
             if proc.stdout:
                 for line in iter(proc.stdout.readline, ""):
                     if line:
+                        display_line = _clarify_agent_stdout_line(line.rstrip("\n"))
                         # Prefix each output line with task id when concurrent.
                         if concurrency > 1:
-                            logger.info("[%s] %s", current_task_id, line.rstrip("\n"))
+                            logger.info("[%s] %s", current_task_id, display_line)
                         else:
-                            logger.info(line.rstrip("\n"))
+                            logger.info(display_line)
 
             returncode = proc.wait()
 

--- a/browseruse_bench/runner/agent_runner.py
+++ b/browseruse_bench/runner/agent_runner.py
@@ -48,6 +48,7 @@ from browseruse_bench.utils import (
     setup_logger,
 )
 from browseruse_bench.utils.llm_cost import enrich_result_usage_cost_if_needed
+from browseruse_bench.utils.run_identity import load_machine_identity_from_env
 
 # Load environment variables from root .env
 load_env_file(REPO_ROOT / ".env")
@@ -123,6 +124,14 @@ def _save_result(workspace: Path, result_data: dict[str, Any]) -> None:
         logger.error("Failed to write result.json at %s: %s", result_path, exc)
 
 
+def _attach_run_metadata(result_data: dict[str, Any], run_metadata: dict[str, Any]) -> dict[str, Any]:
+    existing = result_data.get("run_metadata")
+    merged = dict(existing) if isinstance(existing, dict) else {}
+    merged.update(run_metadata)
+    result_data["run_metadata"] = merged
+    return result_data
+
+
 def main() -> int:
     signal.signal(signal.SIGTERM, _signal_handler)
     signal.signal(signal.SIGINT, _signal_handler)
@@ -147,6 +156,7 @@ def main() -> int:
     # Resolve timeout
     timeout = resolve_timeout_value(args.timeout, agent_config)
     agent_config["timeout_seconds"] = timeout
+    run_metadata = {"machine": load_machine_identity_from_env()}
 
     # Ensure workspace exists
     workspace = args.workspace
@@ -198,6 +208,7 @@ def main() -> int:
             result_data,
             model_name=result_data.get("model_id"),
         )
+        result_data = _attach_run_metadata(result_data, run_metadata)
 
         _save_result(workspace, result_data)
 
@@ -217,12 +228,14 @@ def main() -> int:
             env_status="interrupted",
             agent_done="interrupted",
         )
+        error_result = _attach_run_metadata(error_result, run_metadata)
         _save_result(workspace, error_result)
         return ExitCode.INTERRUPTED
 
     except (ImportError, OSError, RuntimeError, ValueError, TypeError, KeyError) as exc:
         logger.exception("[FAILED] Task execution error: %s", exc)
         error_result = _build_error_result(task_info, str(exc), traceback.format_exc())
+        error_result = _attach_run_metadata(error_result, run_metadata)
         _save_result(workspace, error_result)
         return ExitCode.FAILURE
 

--- a/browseruse_bench/schemas/agent_result.py
+++ b/browseruse_bench/schemas/agent_result.py
@@ -99,6 +99,9 @@ class AgentResult(BaseModel):
     # Agent-specific opaque data (eval scripts must not read this)
     agent_metadata: dict[str, Any] = Field(default_factory=dict)
 
+    # Run-level metadata injected by the runner (machine id, orchestration info)
+    run_metadata: dict[str, Any] = Field(default_factory=dict)
+
     # Prompt snapshot
     system_prompt: PromptSnapshot | None = None
 

--- a/browseruse_bench/utils/run_identity.py
+++ b/browseruse_bench/utils/run_identity.py
@@ -1,0 +1,108 @@
+"""Run identity helpers for experiment traceability."""
+from __future__ import annotations
+
+import getpass
+import hashlib
+import json
+import os
+import platform
+import socket
+import uuid
+from typing import Any
+
+MACHINE_ID_ENV_KEY = "BUBENCH_MACHINE_ID"
+LEGACY_MACHINE_ID_ENV_KEY = "BROWSERUSE_BENCH_MACHINE_ID"
+MACHINE_IDENTITY_ENV_KEY = "BUBENCH_MACHINE_IDENTITY"
+INCLUDE_RAW_MACHINE_IDENTIFIERS_ENV_KEY = "BUBENCH_INCLUDE_RAW_MACHINE_IDENTIFIERS"
+
+
+def _safe_user() -> str:
+    try:
+        return getpass.getuser()
+    except OSError:
+        return ""
+
+
+def _clean_identity_value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _truthy_env(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _format_mac_address(node: int) -> str:
+    return ":".join(f"{(node >> shift) & 0xFF:02x}" for shift in range(40, -1, -8))
+
+
+def _machine_hardware_identity(include_raw_identifiers: bool) -> dict[str, Any]:
+    node = uuid.getnode()
+    mac_address = _format_mac_address(node)
+    # uuid.getnode() may synthesize a random multicast address when it cannot
+    # find a hardware address. The multicast bit in the first octet flags that.
+    is_random = bool((node >> 40) & 0x01)
+    source = "uuid.getnode_random" if is_random else "uuid.getnode"
+    mac_hash = hashlib.sha256(mac_address.encode("utf-8")).hexdigest()
+    hardware: dict[str, Any] = {
+        "mac_address_sha256": mac_hash,
+        "mac_address_source": source,
+        "hardware_fingerprint": mac_hash[:16],
+    }
+    if include_raw_identifiers:
+        hardware["mac_address"] = mac_address
+    return hardware
+
+
+def collect_machine_identity(
+    machine_id: str | None = None,
+    *,
+    include_raw_identifiers: bool = False,
+) -> dict[str, Any]:
+    """Return non-secret machine metadata for run/result attribution.
+
+    ``machine_id`` is intentionally overrideable so distributed workers can use
+    stable labels such as ``gpu-a100-01`` instead of OS hostnames.
+    """
+    hostname = socket.gethostname()
+    fqdn = socket.getfqdn()
+    resolved_id = _clean_identity_value(machine_id)
+    source = "cli"
+    if not resolved_id:
+        for env_key in (MACHINE_ID_ENV_KEY, LEGACY_MACHINE_ID_ENV_KEY):
+            resolved_id = _clean_identity_value(os.getenv(env_key))
+            if resolved_id:
+                source = f"env:{env_key}"
+                break
+    if not resolved_id:
+        resolved_id = hostname or "unknown"
+        source = "hostname"
+
+    return {
+        "machine_id": resolved_id,
+        "machine_id_source": source,
+        "hostname": hostname,
+        "fqdn": fqdn,
+        "user": _safe_user(),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+        **_machine_hardware_identity(include_raw_identifiers),
+    }
+
+
+def load_machine_identity_from_env() -> dict[str, Any]:
+    """Load parent-provided machine identity, falling back to local detection."""
+    raw = os.getenv(MACHINE_IDENTITY_ENV_KEY)
+    if raw:
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            decoded = None
+        if isinstance(decoded, dict) and _clean_identity_value(decoded.get("machine_id")):
+            return {
+                str(key): value
+                for key, value in decoded.items()
+                if isinstance(key, str)
+            }
+    return collect_machine_identity(
+        include_raw_identifiers=_truthy_env(os.getenv(INCLUDE_RAW_MACHINE_IDENTIFIERS_ENV_KEY)),
+    )

--- a/browseruse_bench/visualization/generate_index.py
+++ b/browseruse_bench/visualization/generate_index.py
@@ -391,6 +391,7 @@ def scan_task(task_dir: Path, run_path_rel: str) -> Optional[Dict]:
         "action_history": result.get("action_history", []),
         "metrics": result.get("metrics") or {},
         "config": result.get("config", {}),
+        "run_metadata": result.get("run_metadata", {}),
         "screenshots": screenshots,
         "api_logs": api_logs,
         "has_gif": has_gif,
@@ -527,6 +528,13 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
     first = next(iter(tasks.values()))
     model_id = first.get("model_id", "unknown")
     config = first.get("config", {})
+    config_snapshot = _read_json(timestamp_dir / "config_snapshot.json") or {}
+    machine = config_snapshot.get("machine")
+    if not isinstance(machine, dict):
+        run_metadata = first.get("run_metadata", {})
+        machine = run_metadata.get("machine") if isinstance(run_metadata, dict) else {}
+    if not isinstance(machine, dict):
+        machine = {}
 
     # Aggregate browser_id across all tasks. Picking the dominant value
     # (rather than only first task) is robust to synthetic / reconstructed
@@ -585,6 +593,8 @@ def scan_run(benchmark: str, split: str, agent: str, timestamp_dir: Path, model:
         "agent": agent,
         "model": model,
         "model_id": model_id,
+        "machine_id": machine.get("machine_id", ""),
+        "machine": machine,
         "config": config,
         "browser": browser_kind,
         "browser_label": browser_label,

--- a/tests/browseruse_bench/test_run_identity.py
+++ b/tests/browseruse_bench/test_run_identity.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import hashlib
+
+from browseruse_bench.utils import run_identity
+
+
+def test_collect_machine_identity_records_hashed_mac_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(run_identity.uuid, "getnode", lambda: 0x001122334455)
+    monkeypatch.delenv(run_identity.MACHINE_ID_ENV_KEY, raising=False)
+    monkeypatch.delenv(run_identity.LEGACY_MACHINE_ID_ENV_KEY, raising=False)
+
+    identity = run_identity.collect_machine_identity(machine_id="worker-a")
+
+    expected_mac = "00:11:22:33:44:55"
+    expected_hash = hashlib.sha256(expected_mac.encode("utf-8")).hexdigest()
+    assert identity["machine_id"] == "worker-a"
+    assert identity["mac_address_sha256"] == expected_hash
+    assert identity["hardware_fingerprint"] == expected_hash[:16]
+    assert identity["mac_address_source"] == "uuid.getnode"
+    assert "mac_address" not in identity
+
+
+def test_collect_machine_identity_can_include_raw_mac(monkeypatch) -> None:
+    monkeypatch.setattr(run_identity.uuid, "getnode", lambda: 0x001122334455)
+
+    identity = run_identity.collect_machine_identity(
+        machine_id="worker-a",
+        include_raw_identifiers=True,
+    )
+
+    assert identity["mac_address"] == "00:11:22:33:44:55"

--- a/tests/browseruse_bench/test_run_manifest.py
+++ b/tests/browseruse_bench/test_run_manifest.py
@@ -30,16 +30,23 @@ def test_write_run_manifest_redacts_secrets(tmp_path: Path) -> None:
             "benchmark": "LexBench-Browser",
             "model_id": "gpt-5.4",
         },
+        machine_identity={
+            "machine_id": "worker-a",
+            "hostname": "host-a",
+            "machine_id_source": "test",
+        },
     )
 
     snapshot = json.loads((tmp_path / "config_snapshot.json").read_text(encoding="utf-8"))
 
-    assert sorted(snapshot.keys()) == ["run", "runtime_config"]
+    assert sorted(snapshot.keys()) == ["machine", "run", "runtime_config"]
     assert "models" not in snapshot
     assert "browsers" not in snapshot
     assert "agents" not in snapshot
     assert snapshot["run"]["agent"] == "browser-use"
     assert snapshot["run"]["benchmark"] == "LexBench-Browser"
+    assert snapshot["machine"]["machine_id"] == "worker-a"
+    assert snapshot["machine"]["hostname"] == "host-a"
     assert snapshot["runtime_config"]["use_vision"] is False
     assert snapshot["runtime_config"]["max_steps"] == 3
     assert snapshot["runtime_config"]["model_id"] == "gpt-5.4"

--- a/tests/browseruse_bench/test_run_routing.py
+++ b/tests/browseruse_bench/test_run_routing.py
@@ -10,7 +10,9 @@ import pytest
 from browseruse_bench.browsers import login_contexts as lc
 from browseruse_bench.cli.run import (
     _canonicalize_cli_browser_id,
+    _classify_js_code_for_log,
     _claim_unique_run_dir,
+    _clarify_agent_stdout_line,
     resolve_lexmount_routing_for_task,
 )
 
@@ -168,3 +170,34 @@ def test_claim_unique_run_dir_exhaustion_raises(tmp_path: Path) -> None:
     base = tmp_path / "model"
     with pytest.raises(SystemExit, match="unique run output directory"):
         _claim_unique_run_dir(base, max_seconds=0)
+
+
+def test_clarify_agent_stdout_line_renames_browser_evaluate_code() -> None:
+    line = "INFO     [Agent]   ▶️   evaluate: code: document.querySelectorAll('h2')"
+
+    assert _clarify_agent_stdout_line(line) == (
+        "INFO     [Agent]   ▶️   execute_js(read_dom): code: document.querySelectorAll('h2')"
+    )
+
+
+def test_clarify_agent_stdout_line_keeps_other_tools_unchanged() -> None:
+    line = "INFO     [Agent]   ▶️   click: index: 8695"
+
+    assert _clarify_agent_stdout_line(line) == line
+
+
+@pytest.mark.parametrize(
+    ("code", "category"),
+    [
+        ("[...document.querySelectorAll('a')].map(a=>a.href)", "extract_links"),
+        ("document.querySelectorAll('h1,h2').length", "read_dom"),
+        ("Array.from(document.querySelectorAll('input')).map(i=>i.value)", "form_state"),
+        ("localStorage.getItem('city')", "storage"),
+        ("document.title + location.href + document.readyState", "page_state"),
+        ("performance.getEntries().map(e=>e.name)", "network"),
+        ("document.querySelector('#x').click()", "modify_page"),
+        ("(() => 42)()", "custom"),
+    ],
+)
+def test_classify_js_code_for_log(code: str, category: str) -> None:
+    assert _classify_js_code_for_log(code) == category

--- a/tests/browseruse_bench/test_visualization_generate_index.py
+++ b/tests/browseruse_bench/test_visualization_generate_index.py
@@ -141,6 +141,24 @@ class TestScanRunModelField:
             },
         ]
 
+    def test_scan_run_includes_machine_identity(self, tmp_path, patch_repo_root):
+        run_dir = make_run_dir(tmp_path)
+        (run_dir / "config_snapshot.json").write_text(
+            json.dumps({
+                "machine": {
+                    "machine_id": "worker-a",
+                    "hostname": "host-a",
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        result = gi.scan_run("bench", "split", "agent", run_dir)
+
+        assert result is not None
+        assert result["machine_id"] == "worker-a"
+        assert result["machine"]["hostname"] == "host-a"
+
 
 class TestRepoRootMissing:
     """Regression: import must succeed and generate_index() must fail cleanly when REPO_ROOT is unresolved."""

--- a/tests/scripts/test_agent_runner.py
+++ b/tests/scripts/test_agent_runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from browseruse_bench.utils import llm_cost
+from browseruse_bench.utils.run_identity import MACHINE_IDENTITY_ENV_KEY
 from browseruse_bench.runner import agent_runner
 
 TEST_PRICE_TABLE = {
@@ -69,6 +70,10 @@ def test_agent_runner_enriches_usage_cost_before_result_write(
     monkeypatch.setattr(agent_runner, "resolve_timeout_value", lambda _timeout, _config: 300)
     monkeypatch.setattr(agent_runner.signal, "signal", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(llm_cost, "load_litellm_price_table", lambda: TEST_PRICE_TABLE)
+    monkeypatch.setenv(
+        MACHINE_IDENTITY_ENV_KEY,
+        json.dumps({"machine_id": "worker-a", "hostname": "host-a"}),
+    )
 
     exit_code = agent_runner.main()
     assert exit_code == 0
@@ -80,6 +85,8 @@ def test_agent_runner_enriches_usage_cost_before_result_write(
     assert usage["total_completion_tokens"] == 100
     assert usage["total_tokens"] == 1100
     assert usage["total_cost"] == pytest.approx(0.0028)
+    assert saved_result["run_metadata"]["machine"]["machine_id"] == "worker-a"
+    assert saved_result["run_metadata"]["machine"]["hostname"] == "host-a"
 
 
 def test_agent_runner_marks_interrupts_as_interrupted(
@@ -103,6 +110,10 @@ def test_agent_runner_marks_interrupts_as_interrupted(
     monkeypatch.setattr(agent_runner, "load_agent_config_from_path", lambda _path: {})
     monkeypatch.setattr(agent_runner, "resolve_timeout_value", lambda _timeout, _config: 300)
     monkeypatch.setattr(agent_runner.signal, "signal", lambda *_args, **_kwargs: None)
+    monkeypatch.setenv(
+        MACHINE_IDENTITY_ENV_KEY,
+        json.dumps({"machine_id": "worker-b", "hostname": "host-b"}),
+    )
 
     exit_code = agent_runner.main()
     assert exit_code == 130
@@ -111,3 +122,4 @@ def test_agent_runner_marks_interrupts_as_interrupted(
     saved_result = json.loads(result_path.read_text(encoding="utf-8"))
     assert saved_result["env_status"] == "interrupted"
     assert saved_result["agent_done"] == "interrupted"
+    assert saved_result["run_metadata"]["machine"]["machine_id"] == "worker-b"


### PR DESCRIPTION
## Summary
- record machine identity in run manifests and per-task result metadata
- include hashed MAC-based hardware fingerprint by default, with opt-in raw MAC recording
- expose machine identity in visualization index
- classify browser evaluate-code actions in run logs as execute_js(<category>)

## Test
- uv run pytest tests/browseruse_bench/test_run_identity.py tests/browseruse_bench/test_run_manifest.py tests/scripts/test_agent_runner.py tests/browseruse_bench/test_visualization_generate_index.py
- uv run pytest tests/browseruse_bench/test_run_routing.py