### PR TITLE
fix(cost): correct token accounting across agents and judge pricing

### DIFF
--- a/browseruse_bench/agents/claude_code.py
+++ b/browseruse_bench/agents/claude_code.py
@@ -147,6 +147,66 @@ def _parse_stream(
     return result_obj, assistant_messages, saved_screenshots, turns
 
 
+def _fold_anthropic_usage(raw: Any, totals: dict[str, int]) -> bool:
+    """Accumulate one Anthropic-style usage block into *totals*.
+
+    Anthropic ``input_tokens`` EXCLUDES cache reads/writes; fold the cache
+    counters into the prompt count to match the AgentUsage convention
+    (prompt includes cached). Returns True when the block carried any tokens.
+    """
+    if not isinstance(raw, dict):
+        return False
+    input_tokens = int(raw.get("input_tokens") or 0)
+    cache_read = int(raw.get("cache_read_input_tokens") or 0)
+    cache_creation = int(raw.get("cache_creation_input_tokens") or 0)
+    output_tokens = int(raw.get("output_tokens") or 0)
+    if input_tokens + cache_read + cache_creation + output_tokens == 0:
+        return False
+    totals["prompt"] += input_tokens + cache_read + cache_creation
+    totals["cached"] += cache_read
+    totals["cache_creation"] += cache_creation
+    totals["completion"] += output_tokens
+    return True
+
+
+def _usage_totals_from_stream(
+    result_obj: dict[str, Any],
+    assistant_messages: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Extract token totals from the result event, or sum assistant messages.
+
+    The result event's ``usage`` is the run-wide aggregate; when it never
+    arrived (timeout / early exit), fall back to summing the per-message
+    ``usage`` blocks so token counts are not lost.
+    """
+    totals = {"prompt": 0, "cached": 0, "cache_creation": 0, "completion": 0, "entries": 0}
+    if _fold_anthropic_usage(result_obj.get("usage"), totals):
+        totals["entries"] = int(result_obj.get("num_turns") or 0)
+        return totals
+    for message in assistant_messages:
+        if _fold_anthropic_usage(message.get("usage"), totals):
+            totals["entries"] += 1
+    return totals
+
+
+def _build_agent_usage(
+    result_obj: dict[str, Any],
+    assistant_messages: list[dict[str, Any]],
+    total_cost_usd: float | None,
+) -> AgentUsage | None:
+    totals = _usage_totals_from_stream(result_obj, assistant_messages)
+    if totals["prompt"] + totals["completion"] == 0 and total_cost_usd is None:
+        return None
+    return AgentUsage(
+        total_prompt_tokens=totals["prompt"],
+        total_prompt_cached_tokens=totals["cached"],
+        total_prompt_cache_creation_tokens=totals["cache_creation"],
+        total_completion_tokens=totals["completion"],
+        total_cost=total_cost_usd or 0.0,
+        entry_count=totals["entries"],
+    )
+
+
 def _save_screenshot(
     b64_data: str,
     index: int,
@@ -669,7 +729,7 @@ class ClaudeCodeAgent(CLIAgent):
             metrics=AgentMetrics(
                 end_to_end_ms=duration_ms,
                 steps=num_turns,
-                usage=AgentUsage(total_cost=total_cost_usd) if total_cost_usd is not None else None,
+                usage=_build_agent_usage(result_obj, assistant_messages, total_cost_usd),
             ),
             agent_metadata=agent_metadata,
         )

--- a/browseruse_bench/agents/claude_code.py
+++ b/browseruse_bench/agents/claude_code.py
@@ -27,6 +27,7 @@ from browseruse_bench.browsers import open_browser_session
 from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
 from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
 from browseruse_bench.utils import IS_WINDOWS
+from browseruse_bench.utils.parse_utils import safe_int
 
 logger = logging.getLogger(__name__)
 
@@ -156,10 +157,10 @@ def _fold_anthropic_usage(raw: Any, totals: dict[str, int]) -> bool:
     """
     if not isinstance(raw, dict):
         return False
-    input_tokens = int(raw.get("input_tokens") or 0)
-    cache_read = int(raw.get("cache_read_input_tokens") or 0)
-    cache_creation = int(raw.get("cache_creation_input_tokens") or 0)
-    output_tokens = int(raw.get("output_tokens") or 0)
+    input_tokens = safe_int(raw.get("input_tokens"))
+    cache_read = safe_int(raw.get("cache_read_input_tokens"))
+    cache_creation = safe_int(raw.get("cache_creation_input_tokens"))
+    output_tokens = safe_int(raw.get("output_tokens"))
     if input_tokens + cache_read + cache_creation + output_tokens == 0:
         return False
     totals["prompt"] += input_tokens + cache_read + cache_creation
@@ -177,14 +178,29 @@ def _usage_totals_from_stream(
 
     The result event's ``usage`` is the run-wide aggregate; when it never
     arrived (timeout / early exit), fall back to summing the per-message
-    ``usage`` blocks so token counts are not lost.
+    ``usage`` blocks so token counts are not lost. The stream emits one
+    assistant event per content block of the same API message, each repeating
+    the identical usage — dedup by message id (last event wins) so a turn is
+    counted once.
     """
     totals = {"prompt": 0, "cached": 0, "cache_creation": 0, "completion": 0, "entries": 0}
     if _fold_anthropic_usage(result_obj.get("usage"), totals):
-        totals["entries"] = int(result_obj.get("num_turns") or 0)
+        totals["entries"] = safe_int(result_obj.get("num_turns"))
         return totals
+
+    usage_by_message: dict[str, Any] = {}
+    unidentified_usages: list[Any] = []
     for message in assistant_messages:
-        if _fold_anthropic_usage(message.get("usage"), totals):
+        raw_usage = message.get("usage")
+        if not isinstance(raw_usage, dict):
+            continue
+        message_id = message.get("id")
+        if message_id:
+            usage_by_message[message_id] = raw_usage
+        else:
+            unidentified_usages.append(raw_usage)
+    for raw_usage in [*usage_by_message.values(), *unidentified_usages]:
+        if _fold_anthropic_usage(raw_usage, totals):
             totals["entries"] += 1
     return totals
 

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -84,6 +84,46 @@ def _normalize_session_items(session_file: Path) -> list[dict[str, Any]]:
     return items
 
 
+def _fold_openclaw_usage(raw: Any, totals: dict[str, int]) -> bool:
+    """Accumulate one OpenClaw (pi-ai) usage block into *totals*.
+
+    OpenClaw reports Anthropic-style disjoint components: ``input`` EXCLUDES
+    ``cacheRead``/``cacheWrite``. Fold them into the prompt count to match the
+    AgentUsage convention (prompt includes cached). Returns True when the
+    block carried any tokens.
+    """
+    if not isinstance(raw, dict):
+        return False
+    input_tokens = int(raw.get("input") or 0)
+    cache_read = int(raw.get("cacheRead") or 0)
+    cache_write = int(raw.get("cacheWrite") or 0)
+    output_tokens = int(raw.get("output") or 0)
+    if input_tokens + cache_read + cache_write + output_tokens == 0:
+        return False
+    totals["prompt"] += input_tokens + cache_read + cache_write
+    totals["cached"] += cache_read
+    totals["cache_creation"] += cache_write
+    totals["completion"] += output_tokens
+    totals["entries"] += 1
+    return True
+
+
+def _collect_session_usage(session_file: Path | None) -> dict[str, int]:
+    """Sum per-call usage blocks across all assistant messages in the session log."""
+    totals = {"prompt": 0, "cached": 0, "cache_creation": 0, "completion": 0, "entries": 0}
+    if session_file is None or not session_file.is_file():
+        return totals
+    for raw_line in session_file.read_text(encoding="utf-8").splitlines():
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        message = obj.get("message")
+        if isinstance(message, dict) and message.get("role") == "assistant":
+            _fold_openclaw_usage(message.get("usage"), totals)
+    return totals
+
+
 def _fold_message(
     message: dict[str, Any],
     items: list[dict[str, Any]],
@@ -458,29 +498,41 @@ class OpenClawAgent(CLIAgent):
             logger.warning("Failed to scrub state config secrets: %s", exc)
 
     @staticmethod
-    def _session_items(result_obj: dict[str, Any], task_workspace: Path) -> list[dict[str, Any]]:
+    def _agent_meta(result_obj: dict[str, Any]) -> dict[str, Any] | None:
         meta = result_obj.get("meta")
         agent_meta = meta.get("agentMeta") if isinstance(meta, dict) else None
-        session_file = agent_meta.get("sessionFile") if isinstance(agent_meta, dict) else None
-        if not session_file:
+        return agent_meta if isinstance(agent_meta, dict) else None
+
+    @staticmethod
+    def _session_file_from(result_obj: dict[str, Any]) -> Path | None:
+        agent_meta = OpenClawAgent._agent_meta(result_obj)
+        session_file = agent_meta.get("sessionFile") if agent_meta else None
+        return Path(str(session_file)) if session_file else None
+
+    @staticmethod
+    def _session_items(result_obj: dict[str, Any], task_workspace: Path) -> list[dict[str, Any]]:
+        session_file = OpenClawAgent._session_file_from(result_obj)
+        if session_file is None:
             return []
-        return _normalize_session_items(Path(str(session_file)))
+        return _normalize_session_items(session_file)
 
     @staticmethod
     def _usage_from(result_obj: dict[str, Any]) -> AgentUsage | None:
-        meta = result_obj.get("meta")
-        agent_meta = meta.get("agentMeta") if isinstance(meta, dict) else None
-        usage = agent_meta.get("lastCallUsage") if isinstance(agent_meta, dict) else None
-        if not isinstance(usage, dict):
-            return None
-        total = int(usage.get("total") or 0)
-        if not total:
+        totals = _collect_session_usage(OpenClawAgent._session_file_from(result_obj))
+        if not totals["entries"]:
+            # lastCallUsage covers only the final LLM call; use it only when
+            # the session log carries no per-message usage at all.
+            agent_meta = OpenClawAgent._agent_meta(result_obj)
+            last_call = agent_meta.get("lastCallUsage") if agent_meta else None
+            _fold_openclaw_usage(last_call, totals)
+        if not totals["entries"]:
             return None
         return AgentUsage(
-            total_prompt_tokens=int(usage.get("input") or 0),
-            total_prompt_cached_tokens=int(usage.get("cacheRead") or 0),
-            total_completion_tokens=int(usage.get("output") or 0),
-            total_tokens=total,
+            total_prompt_tokens=totals["prompt"],
+            total_prompt_cached_tokens=totals["cached"],
+            total_prompt_cache_creation_tokens=totals["cache_creation"],
+            total_completion_tokens=totals["completion"],
+            entry_count=totals["entries"],
         )
 
 

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -32,6 +32,7 @@ from browseruse_bench.browsers import open_browser_session
 from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
 from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
 from browseruse_bench.utils import IS_WINDOWS
+from browseruse_bench.utils.parse_utils import safe_int
 
 logger = logging.getLogger(__name__)
 
@@ -94,10 +95,10 @@ def _fold_openclaw_usage(raw: Any, totals: dict[str, int]) -> bool:
     """
     if not isinstance(raw, dict):
         return False
-    input_tokens = int(raw.get("input") or 0)
-    cache_read = int(raw.get("cacheRead") or 0)
-    cache_write = int(raw.get("cacheWrite") or 0)
-    output_tokens = int(raw.get("output") or 0)
+    input_tokens = safe_int(raw.get("input"))
+    cache_read = safe_int(raw.get("cacheRead"))
+    cache_write = safe_int(raw.get("cacheWrite"))
+    output_tokens = safe_int(raw.get("output"))
     if input_tokens + cache_read + cache_write + output_tokens == 0:
         return False
     totals["prompt"] += input_tokens + cache_read + cache_write
@@ -116,7 +117,8 @@ def _collect_session_usage(session_file: Path | None) -> dict[str, int]:
     for raw_line in session_file.read_text(encoding="utf-8").splitlines():
         try:
             obj = json.loads(raw_line)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
+            logger.debug("OpenClaw usage: skipping unparsable session line: %s", exc)
             continue
         message = obj.get("message")
         if isinstance(message, dict) and message.get("role") == "assistant":
@@ -519,6 +521,7 @@ class OpenClawAgent(CLIAgent):
     @staticmethod
     def _usage_from(result_obj: dict[str, Any]) -> AgentUsage | None:
         totals = _collect_session_usage(OpenClawAgent._session_file_from(result_obj))
+        last_call: Any = None
         if not totals["entries"]:
             # lastCallUsage covers only the final LLM call; use it only when
             # the session log carries no per-message usage at all.
@@ -526,7 +529,12 @@ class OpenClawAgent(CLIAgent):
             last_call = agent_meta.get("lastCallUsage") if agent_meta else None
             _fold_openclaw_usage(last_call, totals)
         if not totals["entries"]:
-            return None
+            # Degenerate lastCallUsage with only an aggregate total: keep the
+            # total token count rather than dropping usage entirely.
+            total_tokens = safe_int(last_call.get("total")) if isinstance(last_call, dict) else 0
+            if not total_tokens:
+                return None
+            return AgentUsage(total_tokens=total_tokens, entry_count=1)
         return AgentUsage(
             total_prompt_tokens=totals["prompt"],
             total_prompt_cached_tokens=totals["cached"],

--- a/browseruse_bench/agents/skyvern.py
+++ b/browseruse_bench/agents/skyvern.py
@@ -398,23 +398,44 @@ def _extract_usage_from_response_blob(blob: Any) -> dict[str, int] | None:
         except (TypeError, ValueError):
             return 0
 
+    def _details_cached(node: dict[str, Any]) -> int:
+        for details_key in ("prompt_tokens_details", "input_tokens_details"):
+            details = node.get(details_key)
+            if isinstance(details, dict) and details.get("cached_tokens") is not None:
+                return _safe_int(details["cached_tokens"])
+        fallback = node.get("cache_read_input_tokens")
+        if fallback is None:
+            fallback = node.get("cached_tokens")
+        return _safe_int(fallback) if fallback is not None else 0
+
     def _candidate_usage(node: Any) -> dict[str, int] | None:
         if not isinstance(node, dict):
             return None
-        pt = node.get("prompt_tokens") or node.get("input_tokens")
-        ct = node.get("completion_tokens") or node.get("output_tokens")
+        pt = node.get("prompt_tokens")
+        it = node.get("input_tokens")
+        ct = node.get("completion_tokens")
+        if ct is None:
+            ct = node.get("output_tokens")
         tt = node.get("total_tokens")
-        if pt is None and ct is None and tt is None:
+        if pt is None and it is None and ct is None and tt is None:
             return None
-        cached = 0
-        details = node.get("prompt_tokens_details")
-        if isinstance(details, dict):
-            cached = _safe_int(details.get("cached_tokens", 0))
-        cached_input = node.get("cache_read_input_tokens") or node.get("cached_tokens")
-        if cached == 0 and cached_input is not None:
-            cached = _safe_int(cached_input)
 
-        prompt = _safe_int(pt) if pt is not None else 0
+        cached = _details_cached(node)
+        creation = _safe_int(node.get("cache_creation_input_tokens", 0))
+        prompt = _safe_int(pt if pt is not None else it)
+        # Anthropic-style usage: input_tokens EXCLUDES cache reads/writes,
+        # which arrive as separate cache_*_input_tokens counters. Fold them
+        # into the prompt count so it matches the OpenAI convention used by
+        # downstream cost math (prompt includes cached). OpenAI's Responses
+        # API also uses input_tokens but reports cached via
+        # input_tokens_details, so the cache_* keys are a safe discriminator.
+        anthropic_style = pt is None and (
+            "cache_read_input_tokens" in node or "cache_creation_input_tokens" in node
+        )
+        if anthropic_style:
+            cached = _safe_int(node.get("cache_read_input_tokens", 0))
+            prompt += cached + creation
+
         completion = _safe_int(ct) if ct is not None else 0
         total = _safe_int(tt) if tt is not None else prompt + completion
         if prompt == 0 and completion == 0 and total == 0:
@@ -423,6 +444,7 @@ def _extract_usage_from_response_blob(blob: Any) -> dict[str, int] | None:
             "prompt_tokens": prompt,
             "completion_tokens": completion,
             "cached_tokens": min(cached, max(prompt, 0)),
+            "cache_creation_tokens": min(creation, max(prompt, 0)),
             "total_tokens": total if total > 0 else prompt + completion,
         }
 
@@ -485,6 +507,7 @@ def collect_usage_from_skyvern_artifacts(task_dirs: list[Path]) -> dict[str, Any
     total_prompt = 0
     total_completion = 0
     total_cached = 0
+    total_cache_creation = 0
     entry_count = 0
 
     for task_dir in task_dirs:
@@ -525,6 +548,7 @@ def collect_usage_from_skyvern_artifacts(task_dirs: list[Path]) -> dict[str, Any
                 total_prompt += usage["prompt_tokens"]
                 total_completion += usage["completion_tokens"]
                 total_cached += usage["cached_tokens"]
+                total_cache_creation += usage["cache_creation_tokens"]
                 entry_count += 1
                 # One usage block per step is enough; avoid double-counting a
                 # retry payload in the same step dir.
@@ -537,6 +561,7 @@ def collect_usage_from_skyvern_artifacts(task_dirs: list[Path]) -> dict[str, Any
         "total_prompt_tokens": total_prompt,
         "total_completion_tokens": total_completion,
         "total_prompt_cached_tokens": total_cached,
+        "total_prompt_cache_creation_tokens": total_cache_creation,
         "total_tokens": total_prompt + total_completion,
         "entry_count": entry_count,
     }
@@ -1229,6 +1254,7 @@ class SkyvernAgent(BaseAgent):
                         "total_prompt_tokens": cloud_usage["prompt_tokens"],
                         "total_completion_tokens": cloud_usage["completion_tokens"],
                         "total_prompt_cached_tokens": cloud_usage["cached_tokens"],
+                        "total_prompt_cache_creation_tokens": cloud_usage["cache_creation_tokens"],
                         "total_tokens": cloud_usage["total_tokens"],
                         "entry_count": 1,
                     }

--- a/browseruse_bench/agents/skyvern.py
+++ b/browseruse_bench/agents/skyvern.py
@@ -399,10 +399,14 @@ def _extract_usage_from_response_blob(blob: Any) -> dict[str, int] | None:
             return 0
 
     def _details_cached(node: dict[str, Any]) -> int:
+        # Trust a nonzero details counter first; a zero-filled details object
+        # must not mask a real top-level cache counter.
         for details_key in ("prompt_tokens_details", "input_tokens_details"):
             details = node.get(details_key)
-            if isinstance(details, dict) and details.get("cached_tokens") is not None:
-                return _safe_int(details["cached_tokens"])
+            if isinstance(details, dict):
+                cached = _safe_int(details.get("cached_tokens", 0))
+                if cached:
+                    return cached
         fallback = node.get("cache_read_input_tokens")
         if fallback is None:
             fallback = node.get("cached_tokens")
@@ -411,7 +415,9 @@ def _extract_usage_from_response_blob(blob: Any) -> dict[str, int] | None:
     def _candidate_usage(node: Any) -> dict[str, int] | None:
         if not isinstance(node, dict):
             return None
-        pt = node.get("prompt_tokens")
+        # A zero-filled prompt_tokens falls through to input_tokens, matching
+        # the pre-existing `or` chain semantics.
+        pt = node.get("prompt_tokens") or None
         it = node.get("input_tokens")
         ct = node.get("completion_tokens")
         if ct is None:

--- a/browseruse_bench/eval/base.py
+++ b/browseruse_bench/eval/base.py
@@ -208,7 +208,7 @@ class BaseEvaluator(ABC):
             usage = details.get("eval_usage")
             if usage:
                 usages.append(usage)
-        cost_summary = aggregate_evaluation_costs(usages)
+        cost_summary = aggregate_evaluation_costs(usages, model_name=self.args.model)
         if cost_summary:
             summary["evaluation_cost"] = cost_summary
         summary["evaluation_config"] = {

--- a/browseruse_bench/eval/lexbench_browser/evaluator.py
+++ b/browseruse_bench/eval/lexbench_browser/evaluator.py
@@ -666,7 +666,7 @@ class LexBenchBrowserEvaluator(BaseEvaluator):
             usage = (r.get("evaluation_details") or {}).get("eval_usage")
             if usage is not None:
                 usage_list.append(usage)
-        cost_summary = aggregate_evaluation_costs(usage_list)
+        cost_summary = aggregate_evaluation_costs(usage_list, model_name=self.args.model)
         if cost_summary:
             summary["evaluation_cost"] = cost_summary
 

--- a/browseruse_bench/eval/odysseys/evaluator.py
+++ b/browseruse_bench/eval/odysseys/evaluator.py
@@ -200,7 +200,7 @@ class OdysseysEvaluator(BaseEvaluator):
             for record in records
             if (record.get("evaluation_details") or {}).get("eval_usage")
         ]
-        cost_summary = aggregate_evaluation_costs(usages)
+        cost_summary = aggregate_evaluation_costs(usages, model_name=self.args.model)
         if cost_summary:
             summary["evaluation_cost"] = cost_summary
         summary["evaluation_config"] = {

--- a/browseruse_bench/eval/summary.py
+++ b/browseruse_bench/eval/summary.py
@@ -44,22 +44,38 @@ def calculate_evaluation_cost(
         price_table=price_table,
         force=True,
     )
-    if "total_cost" not in enriched:
+    # A zero-token usage dict comes back unchanged from enrichment (nothing to
+    # price); require the full enriched shape before indexing it.
+    required_keys = (
+        "total_prompt_tokens",
+        "total_prompt_cost",
+        "total_prompt_cached_tokens",
+        "total_prompt_cached_cost",
+        "total_prompt_cache_creation_tokens",
+        "total_prompt_cache_creation_cost",
+        "total_completion_tokens",
+        "total_completion_cost",
+        "total_cost",
+    )
+    if not all(key in enriched for key in required_keys):
         return None
 
     prompt_tokens = enriched["total_prompt_tokens"]
     cached_tokens = enriched["total_prompt_cached_tokens"]
     creation_tokens = enriched["total_prompt_cache_creation_tokens"]
-    cached_cost = enriched["total_prompt_cached_cost"] + enriched["total_prompt_cache_creation_cost"]
+    cached_cost = enriched["total_prompt_cached_cost"]
+    creation_cost = enriched["total_prompt_cache_creation_cost"]
     return {
         "prompt_tokens": prompt_tokens,
         "completion_tokens": enriched["total_completion_tokens"],
         "cached_tokens": cached_tokens,
+        "cache_creation_tokens": creation_tokens,
         "non_cached_prompt": max(0, prompt_tokens - cached_tokens - creation_tokens),
         "costs": {
-            "input": enriched["total_prompt_cost"] - cached_cost,
+            "input": enriched["total_prompt_cost"] - cached_cost - creation_cost,
             "output": enriched["total_completion_cost"],
             "cached": cached_cost,
+            "cache_creation": creation_cost,
             "total": enriched["total_cost"],
         },
     }
@@ -78,6 +94,8 @@ def aggregate_evaluation_costs(
     total_output_cost = 0.0
     total_cached_cost = 0.0
 
+    total_cache_creation = 0
+    total_cache_creation_cost = 0.0
     for usage in usage_list:
         if usage is None:
             continue
@@ -86,21 +104,25 @@ def aggregate_evaluation_costs(
             total_prompt += cost_info["prompt_tokens"]
             total_completion += cost_info["completion_tokens"]
             total_cached += cost_info["cached_tokens"]
+            total_cache_creation += cost_info["cache_creation_tokens"]
             total_input_cost += cost_info["costs"]["input"]
             total_output_cost += cost_info["costs"]["output"]
             total_cached_cost += cost_info["costs"]["cached"]
+            total_cache_creation_cost += cost_info["costs"]["cache_creation"]
 
-    total_cost = total_input_cost + total_output_cost + total_cached_cost
+    total_cost = total_input_cost + total_output_cost + total_cached_cost + total_cache_creation_cost
 
     return {
         "total_prompt_tokens": total_prompt,
         "total_completion_tokens": total_completion,
         "total_cached_tokens": total_cached,
-        "total_non_cached_prompt": max(0, total_prompt - total_cached),
+        "total_cache_creation_tokens": total_cache_creation,
+        "total_non_cached_prompt": max(0, total_prompt - total_cached - total_cache_creation),
         "costs": {
             "input": total_input_cost,
             "output": total_output_cost,
             "cached": total_cached_cost,
+            "cache_creation": total_cache_creation_cost,
             "total": total_cost,
         },
     }

--- a/browseruse_bench/eval/summary.py
+++ b/browseruse_bench/eval/summary.py
@@ -10,13 +10,18 @@ from typing import Any, Dict, Iterator, List, Optional
 logger = logging.getLogger(__name__)
 
 
-def calculate_evaluation_cost(usage_dict: Any) -> Optional[Dict[str, Any]]:
-    """Calculate total cost based on usage and pricing.
+def calculate_evaluation_cost(
+    usage_dict: Any,
+    model_name: Optional[str] = None,
+    price_table: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Calculate the evaluation-LLM cost (USD) from usage and shared pricing.
 
-    Pricing (per million tokens):
-    - Input: ￥10 / M tokens
-    - Output: ￥40 / M tokens
-    - Cached: ￥2.5 / M tokens
+    Rates resolve through the same tables as agent-side costs (custom
+    ``configs/pricing/model_pricing.yaml`` first, then the LiteLLM table);
+    an unknown ``model_name`` yields cost 0 with a warning, matching the
+    agent-side convention. ``price_table`` overrides the LiteLLM table
+    (mainly for tests).
     """
     if not usage_dict:
         return None
@@ -29,42 +34,43 @@ def calculate_evaluation_cost(usage_dict: Any) -> Optional[Dict[str, Any]]:
         else:
             return None
 
-    prompt_tokens = usage_dict.get("prompt_tokens", 0)
-    completion_tokens = usage_dict.get("completion_tokens", 0)
+    # Lazy import: llm_cost pulls in browseruse_bench.utils, whose __init__
+    # re-exports from this module (same cycle as generate_evaluation_summary).
+    from browseruse_bench.utils.llm_cost import enrich_usage_with_litellm_pricing
 
-    cached_tokens = 0
-    prompt_details = usage_dict.get("prompt_tokens_details", {})
-    if isinstance(prompt_details, dict):
-        cached_tokens = prompt_details.get("cached_tokens", 0)
+    enriched = enrich_usage_with_litellm_pricing(
+        usage=usage_dict,
+        model_name=model_name,
+        price_table=price_table,
+        force=True,
+    )
+    if "total_cost" not in enriched:
+        return None
 
-    PRICE_INPUT = 10
-    PRICE_OUTPUT = 40
-    PRICE_CACHED = 2.5
-
-    non_cached_prompt = max(0, prompt_tokens - cached_tokens)
-
-    input_cost = (non_cached_prompt / 1_000_000) * PRICE_INPUT
-    output_cost = (completion_tokens / 1_000_000) * PRICE_OUTPUT
-    cached_cost = (cached_tokens / 1_000_000) * PRICE_CACHED
-
-    total_cost = input_cost + output_cost + cached_cost
-
+    prompt_tokens = enriched["total_prompt_tokens"]
+    cached_tokens = enriched["total_prompt_cached_tokens"]
+    creation_tokens = enriched["total_prompt_cache_creation_tokens"]
+    cached_cost = enriched["total_prompt_cached_cost"] + enriched["total_prompt_cache_creation_cost"]
     return {
         "prompt_tokens": prompt_tokens,
-        "completion_tokens": completion_tokens,
+        "completion_tokens": enriched["total_completion_tokens"],
         "cached_tokens": cached_tokens,
-        "non_cached_prompt": non_cached_prompt,
+        "non_cached_prompt": max(0, prompt_tokens - cached_tokens - creation_tokens),
         "costs": {
-            "input": input_cost,
-            "output": output_cost,
+            "input": enriched["total_prompt_cost"] - cached_cost,
+            "output": enriched["total_completion_cost"],
             "cached": cached_cost,
-            "total": total_cost,
+            "total": enriched["total_cost"],
         },
     }
 
 
-def aggregate_evaluation_costs(usage_list: List[Any]) -> Dict[str, Any]:
-    """Aggregate costs from multiple usage dictionaries."""
+def aggregate_evaluation_costs(
+    usage_list: List[Any],
+    model_name: Optional[str] = None,
+    price_table: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Aggregate USD costs from multiple usage dictionaries."""
     total_prompt = 0
     total_completion = 0
     total_cached = 0
@@ -75,7 +81,7 @@ def aggregate_evaluation_costs(usage_list: List[Any]) -> Dict[str, Any]:
     for usage in usage_list:
         if usage is None:
             continue
-        cost_info = calculate_evaluation_cost(usage)
+        cost_info = calculate_evaluation_cost(usage, model_name=model_name, price_table=price_table)
         if cost_info:
             total_prompt += cost_info["prompt_tokens"]
             total_completion += cost_info["completion_tokens"]

--- a/browseruse_bench/eval/webvoyager/evaluator.py
+++ b/browseruse_bench/eval/webvoyager/evaluator.py
@@ -221,7 +221,7 @@ class WebVoyagerEvaluator(BaseEvaluator):
             for r in all_records
             if (r.get("evaluation_details") or {}).get("eval_usage") is not None
         ]
-        cost_summary = aggregate_evaluation_costs(usage_list)
+        cost_summary = aggregate_evaluation_costs(usage_list, model_name=self.args.model)
         if cost_summary:
             summary["evaluation_cost"] = cost_summary
 

--- a/browseruse_bench/schemas/agent_result.py
+++ b/browseruse_bench/schemas/agent_result.py
@@ -15,7 +15,14 @@ from browseruse_bench.schemas.prompt import PromptSnapshot
 
 
 class AgentUsage(BaseModel):
-    """Token usage statistics from the agent's LLM calls."""
+    """Token usage statistics from the agent's LLM calls.
+
+    Convention (OpenAI-style): ``total_prompt_tokens`` INCLUDES cache reads and
+    cache-creation tokens; ``total_prompt_cached_tokens`` and
+    ``total_prompt_cache_creation_tokens`` are disjoint subsets of it.
+    Anthropic-style sources (where input_tokens excludes cache reads/writes)
+    must fold the cache counters into the prompt count before building this.
+    """
 
     model_config = ConfigDict(extra="allow")
 
@@ -23,11 +30,13 @@ class AgentUsage(BaseModel):
     total_prompt_tokens: int = 0
     total_completion_tokens: int = 0
     total_prompt_cached_tokens: int = 0
+    total_prompt_cache_creation_tokens: int = 0
     total_tokens: int = 0
 
     # Cost breakdown
     total_prompt_cost: float = 0.0
     total_prompt_cached_cost: float = 0.0
+    total_prompt_cache_creation_cost: float = 0.0
     total_completion_cost: float = 0.0
     total_cost: float = 0.0
 

--- a/browseruse_bench/utils/llm_cost.py
+++ b/browseruse_bench/utils/llm_cost.py
@@ -72,6 +72,10 @@ def _extract_usage_totals(usage: Mapping[str, Any]) -> dict[str, int] | None:
         if isinstance(details, dict):
             cached_tokens = safe_int(details.get("cached_tokens", 0))
 
+    cache_creation_tokens = safe_int(
+        usage.get("total_prompt_cache_creation_tokens", usage.get("cache_creation_input_tokens", 0))
+    )
+
     if prompt_tokens == 0 and completion_tokens == 0 and total_tokens > 0:
         prompt_tokens = total_tokens
     if prompt_tokens == 0 and completion_tokens == 0 and total_tokens == 0:
@@ -82,6 +86,7 @@ def _extract_usage_totals(usage: Mapping[str, Any]) -> dict[str, int] | None:
         "completion_tokens": max(0, completion_tokens),
         "total_tokens": max(0, total_tokens),
         "cached_tokens": max(0, cached_tokens),
+        "cache_creation_tokens": max(0, cache_creation_tokens),
         "entry_count": max(1, safe_int(usage.get("entry_count", 1), 1)),
     }
 
@@ -102,18 +107,20 @@ def _extract_rates(
     entry: Mapping[str, Any],
     *,
     allow_per_million: bool,
-) -> tuple[float | None, float | None, float | None]:
+) -> tuple[float | None, float | None, float | None, float | None]:
     if allow_per_million:
         return (
             _read_rate(entry, "input_cost_per_token", "input_cost_per_million_tokens"),
             _read_rate(entry, "output_cost_per_token", "output_cost_per_million_tokens"),
             _read_rate(entry, "cache_read_input_token_cost", "cache_read_input_cost_per_million_tokens"),
+            _read_rate(entry, "cache_creation_input_token_cost", "cache_creation_input_cost_per_million_tokens"),
         )
 
     return (
         _read_rate(entry, "input_cost_per_token"),
         _read_rate(entry, "output_cost_per_token"),
         _read_rate(entry, "cache_read_input_token_cost"),
+        _read_rate(entry, "cache_creation_input_token_cost"),
     )
 
 
@@ -191,11 +198,12 @@ def _load_custom_model_pricing_table() -> dict[str, dict[str, Any]]:
         if not isinstance(model_key, str) or not isinstance(raw_entry, dict):
             continue
 
-        input_rate, output_rate, cached_rate = _extract_rates(raw_entry, allow_per_million=True)
+        input_rate, output_rate, cached_rate, creation_rate = _extract_rates(raw_entry, allow_per_million=True)
         normalized_entry = {
             "input_cost_per_token": input_rate,
             "output_cost_per_token": output_rate,
             "cache_read_input_token_cost": cached_rate,
+            "cache_creation_input_token_cost": creation_rate,
         }
         normalized_entry = {key: value for key, value in normalized_entry.items() if value is not None}
         price_table[model_key] = normalized_entry
@@ -257,23 +265,32 @@ def _build_usage_summary(
     prompt_tokens = safe_int(usage_totals.get("prompt_tokens", 0))
     completion_tokens = safe_int(usage_totals.get("completion_tokens", 0))
     total_tokens = safe_int(usage_totals.get("total_tokens", 0), prompt_tokens + completion_tokens)
+    # Convention: prompt_tokens INCLUDES cache reads and cache-creation tokens
+    # (OpenAI-style); both are disjoint subsets billed at their own rates.
     cached_tokens = min(max(0, safe_int(usage_totals.get("cached_tokens", 0))), max(0, prompt_tokens))
+    cache_creation_tokens = min(
+        max(0, safe_int(usage_totals.get("cache_creation_tokens", 0))),
+        max(0, prompt_tokens - cached_tokens),
+    )
     entry_count = max(1, safe_int(usage_totals.get("entry_count", 1), 1))
 
     pricing = custom_table.get(model_key) or litellm_table.get(model_key) or {}
-    input_rate, output_rate, cached_rate = _extract_rates(pricing, allow_per_million=False)
+    input_rate, output_rate, cached_rate, creation_rate = _extract_rates(pricing, allow_per_million=False)
     input_rate = input_rate or 0.0
     output_rate = output_rate or 0.0
     if cached_rate is None:
         cached_rate = input_rate
+    if creation_rate is None:
+        creation_rate = input_rate
 
     if input_rate == 0.0 and output_rate == 0.0:
         logger.warning("Missing pricing for model '%s'. Cost set to 0.", model_label)
 
-    non_cached_prompt_tokens = max(0, prompt_tokens - cached_tokens)
+    non_cached_prompt_tokens = max(0, prompt_tokens - cached_tokens - cache_creation_tokens)
     prompt_non_cached_cost = non_cached_prompt_tokens * input_rate
     prompt_cached_cost = cached_tokens * cached_rate
-    prompt_cost = prompt_non_cached_cost + prompt_cached_cost
+    prompt_cache_creation_cost = cache_creation_tokens * creation_rate
+    prompt_cost = prompt_non_cached_cost + prompt_cached_cost + prompt_cache_creation_cost
     completion_cost = completion_tokens * output_rate
     total_cost = prompt_cost + completion_cost
     resolved_total_tokens = total_tokens if total_tokens > 0 else prompt_tokens + completion_tokens
@@ -283,6 +300,8 @@ def _build_usage_summary(
         "total_prompt_cost": prompt_cost,
         "total_prompt_cached_tokens": cached_tokens,
         "total_prompt_cached_cost": prompt_cached_cost,
+        "total_prompt_cache_creation_tokens": cache_creation_tokens,
+        "total_prompt_cache_creation_cost": prompt_cache_creation_cost,
         "total_completion_tokens": completion_tokens,
         "total_completion_cost": completion_cost,
         "total_tokens": resolved_total_tokens,

--- a/browseruse_bench/utils/llm_cost.py
+++ b/browseruse_bench/utils/llm_cost.py
@@ -27,6 +27,10 @@ DEFAULT_PRICE_CACHE_TTL_SECONDS = 86400
 DEFAULT_HTTP_TIMEOUT_SECONDS = 10
 
 _PRICE_CACHE: dict[str, tuple[float, dict[str, dict[str, Any]]]] = {}
+# Parsed custom pricing table keyed by file path, invalidated by mtime — the
+# eval summary path resolves cost per usage record and must not re-read the
+# YAML each time.
+_CUSTOM_PRICING_CACHE: dict[str, tuple[float, dict[str, dict[str, Any]]]] = {}
 
 
 def _as_mapping_dict(value: Any) -> dict[str, Any] | None:
@@ -183,6 +187,15 @@ def _load_custom_model_pricing_table() -> dict[str, dict[str, Any]]:
     if not DEFAULT_CUSTOM_MODEL_PRICING_FILE.exists():
         return {}
 
+    cache_key = str(DEFAULT_CUSTOM_MODEL_PRICING_FILE)
+    try:
+        mtime = DEFAULT_CUSTOM_MODEL_PRICING_FILE.stat().st_mtime
+    except OSError:
+        mtime = -1.0
+    cache_hit = _CUSTOM_PRICING_CACHE.get(cache_key)
+    if cache_hit and cache_hit[0] == mtime:
+        return cache_hit[1]
+
     try:
         payload = yaml.safe_load(DEFAULT_CUSTOM_MODEL_PRICING_FILE.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
@@ -208,7 +221,9 @@ def _load_custom_model_pricing_table() -> dict[str, dict[str, Any]]:
         normalized_entry = {key: value for key, value in normalized_entry.items() if value is not None}
         price_table[model_key] = normalized_entry
 
-    return _normalize_price_table(price_table)
+    normalized_table = _normalize_price_table(price_table)
+    _CUSTOM_PRICING_CACHE[cache_key] = (mtime, normalized_table)
+    return normalized_table
 
 
 def load_litellm_price_table() -> dict[str, dict[str, Any]]:

--- a/browseruse_bench/utils/stats.py
+++ b/browseruse_bench/utils/stats.py
@@ -5,6 +5,18 @@ from math import fsum
 from typing import Any, Dict, List, Optional
 
 
+# Cost fields carry per-task USD values well below 0.01; 6 decimal places keeps
+# them meaningful while still trimming float noise on ms/step metrics.
+_STATS_PRECISION = 6
+
+
+def _median(sorted_values: List[float]) -> float:
+    mid = len(sorted_values) // 2
+    if len(sorted_values) % 2:
+        return sorted_values[mid]
+    return (sorted_values[mid - 1] + sorted_values[mid]) / 2
+
+
 def _calc_stats(values: List[float]) -> Dict[str, float]:
     """Calculate statistics for a list of values.
 
@@ -19,10 +31,10 @@ def _calc_stats(values: List[float]) -> Dict[str, float]:
     s = sorted(values)
     return {
         "count": len(s),
-        "mean": round(sum(s) / len(s), 2),
+        "mean": round(sum(s) / len(s), _STATS_PRECISION),
         "min": min(s),
         "max": max(s),
-        "median": round(s[len(s) // 2], 2)
+        "median": round(_median(s), _STATS_PRECISION)
     }
 
 
@@ -81,6 +93,8 @@ def calculate_usage_stats(tasks: List[Dict[str, Any]], path: str = "evaluation_d
         "total_prompt_cost",
         "total_prompt_cached_tokens",
         "total_prompt_cached_cost",
+        "total_prompt_cache_creation_tokens",
+        "total_prompt_cache_creation_cost",
         "total_completion_tokens",
         "total_completion_cost",
         "total_tokens",

--- a/tests/browseruse_bench/test_claude_code_agent.py
+++ b/tests/browseruse_bench/test_claude_code_agent.py
@@ -383,6 +383,35 @@ class TestClaudeCodeAgentUsage:
         assert usage.total_completion_tokens == 12
         assert usage.entry_count == 2
 
+    def test_usage_fallback_dedups_events_of_same_message(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Claude Code emits one assistant event per content block of the same
+        # API message, each repeating the identical usage block. The fallback
+        # must count each message id once.
+        usage = {"input_tokens": 100, "cache_read_input_tokens": 400, "output_tokens": 20}
+        stream = [
+            _line({"type": "assistant", "message": {
+                "id": "msg_1",
+                "content": [{"type": "text", "text": "thinking"}],
+                "usage": usage,
+            }}),
+            _line({"type": "assistant", "message": {
+                "id": "msg_1",
+                "content": [{"type": "tool_use", "id": "tu_1", "name": "browser_click", "input": {}}],
+                "usage": usage,
+            }}),
+        ]
+        agent = self._agent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            lambda *a, **kw: (-1, stream, "Timeout after 10 seconds"),
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.metrics.usage is not None
+        assert result.metrics.usage.total_prompt_tokens == 500
+        assert result.metrics.usage.entry_count == 1
+
     def test_usage_without_cost_still_records_tokens(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/browseruse_bench/test_claude_code_agent.py
+++ b/tests/browseruse_bench/test_claude_code_agent.py
@@ -321,6 +321,87 @@ class TestClaudeCodeAgentRunTask:
         assert result.agent_done == "error"
 
 
+class TestClaudeCodeAgentUsage:
+    """Token counts must survive into AgentUsage, not just total_cost_usd."""
+
+    def _agent(self) -> ClaudeCodeAgent:
+        return ClaudeCodeAgent()
+
+    def test_usage_tokens_from_result_event(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Anthropic semantics: input_tokens EXCLUDES cache reads/writes.
+        stream = [
+            _line({"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}),
+            _line({
+                "type": "result", "result": "done", "num_turns": 2, "duration_ms": 100,
+                "total_cost_usd": 0.0123,
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_creation_input_tokens": 50,
+                    "cache_read_input_tokens": 400,
+                    "output_tokens": 20,
+                },
+            }),
+        ]
+        agent = self._agent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, stream, None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        usage = result.metrics.usage
+        assert usage is not None
+        assert usage.total_prompt_tokens == 550
+        assert usage.total_prompt_cached_tokens == 400
+        assert usage.total_prompt_cache_creation_tokens == 50
+        assert usage.total_completion_tokens == 20
+        assert usage.total_tokens == 570
+        assert usage.total_cost == pytest.approx(0.0123)
+        assert usage.entry_count == 2
+
+    def test_usage_fallback_sums_assistant_messages_on_timeout(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        stream = [
+            _line({"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "step 1"}],
+                "usage": {"input_tokens": 10, "cache_read_input_tokens": 100, "output_tokens": 5},
+            }}),
+            _line({"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "step 2"}],
+                "usage": {"input_tokens": 20, "cache_read_input_tokens": 200, "output_tokens": 7},
+            }}),
+        ]
+        agent = self._agent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            lambda *a, **kw: (-1, stream, "Timeout after 10 seconds"),
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        usage = result.metrics.usage
+        assert usage is not None
+        assert usage.total_prompt_tokens == 330
+        assert usage.total_prompt_cached_tokens == 300
+        assert usage.total_completion_tokens == 12
+        assert usage.entry_count == 2
+
+    def test_usage_without_cost_still_records_tokens(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        stream = [
+            _line({
+                "type": "result", "result": "done", "num_turns": 1, "duration_ms": 100,
+                "usage": {"input_tokens": 100, "output_tokens": 20},
+            }),
+        ]
+        agent = self._agent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, stream, None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        usage = result.metrics.usage
+        assert usage is not None
+        assert usage.total_prompt_tokens == 100
+        assert usage.total_completion_tokens == 20
+        assert usage.total_cost == 0.0
+
+
 # ---------------------------------------------------------------------------
 # Command-construction unit tests (no claude CLI needed)
 # ---------------------------------------------------------------------------

--- a/tests/browseruse_bench/test_eval.py
+++ b/tests/browseruse_bench/test_eval.py
@@ -97,3 +97,61 @@ class TestCalculateSuccess:
         """Test with custom threshold."""
         assert calculate_success(70, threshold=70) is True
         assert calculate_success(69, threshold=70) is False
+
+
+class TestEvaluationCostPricing:
+    """Judge-model cost must come from the shared pricing tables (USD), not hardcoded rates."""
+
+    PRICE_TABLE = {
+        "judge-model": {
+            "input_cost_per_token": 2e-06,
+            "output_cost_per_token": 8e-06,
+            "cache_read_input_token_cost": 5e-07,
+        }
+    }
+
+    def test_cost_resolved_from_pricing_table(self):
+        from browseruse_bench.eval.summary import calculate_evaluation_cost
+
+        usage = {
+            "prompt_tokens": 1000,
+            "completion_tokens": 100,
+            "prompt_tokens_details": {"cached_tokens": 400},
+        }
+        cost = calculate_evaluation_cost(
+            usage, model_name="judge-model", price_table=self.PRICE_TABLE
+        )
+        assert cost is not None
+        assert cost["prompt_tokens"] == 1000
+        assert cost["cached_tokens"] == 400
+        assert cost["non_cached_prompt"] == 600
+        # 600 * 2e-6 + 400 * 5e-7 + 100 * 8e-6
+        assert cost["costs"]["input"] == pytest.approx(0.0012)
+        assert cost["costs"]["cached"] == pytest.approx(0.0002)
+        assert cost["costs"]["output"] == pytest.approx(0.0008)
+        assert cost["costs"]["total"] == pytest.approx(0.0022)
+
+    def test_unknown_model_costs_zero(self):
+        from browseruse_bench.eval.summary import calculate_evaluation_cost
+
+        usage = {"prompt_tokens": 1000, "completion_tokens": 100}
+        cost = calculate_evaluation_cost(
+            usage, model_name="unknown-model", price_table={}
+        )
+        assert cost is not None
+        assert cost["costs"]["total"] == 0.0
+
+    def test_aggregate_threads_model_pricing(self):
+        from browseruse_bench.eval.summary import aggregate_evaluation_costs
+
+        usages = [
+            {"prompt_tokens": 1000, "completion_tokens": 100},
+            {"prompt_tokens": 500, "completion_tokens": 50},
+        ]
+        agg = aggregate_evaluation_costs(
+            usages, model_name="judge-model", price_table=self.PRICE_TABLE
+        )
+        assert agg["total_prompt_tokens"] == 1500
+        assert agg["total_completion_tokens"] == 150
+        # 1500 * 2e-6 + 150 * 8e-6
+        assert agg["costs"]["total"] == pytest.approx(0.0042)

--- a/tests/browseruse_bench/test_eval.py
+++ b/tests/browseruse_bench/test_eval.py
@@ -155,3 +155,46 @@ class TestEvaluationCostPricing:
         assert agg["total_completion_tokens"] == 150
         # 1500 * 2e-6 + 150 * 8e-6
         assert agg["costs"]["total"] == pytest.approx(0.0042)
+
+
+class TestEvaluationCostRobustness:
+    def test_zero_token_usage_with_total_cost_returns_none(self):
+        from browseruse_bench.eval.summary import calculate_evaluation_cost
+
+        # Already-enriched zero-token usage that carries a total_cost key must
+        # not crash on the enriched-only keys it lacks.
+        usage = {
+            "total_prompt_tokens": 0,
+            "total_completion_tokens": 0,
+            "total_tokens": 0,
+            "total_cost": 0.02,
+        }
+        assert calculate_evaluation_cost(usage, model_name="judge-model", price_table={}) is None
+
+    def test_aggregate_accounts_cache_creation_consistently(self):
+        from browseruse_bench.eval.summary import aggregate_evaluation_costs
+
+        price_table = {
+            "judge-model": {
+                "input_cost_per_token": 2e-06,
+                "output_cost_per_token": 8e-06,
+                "cache_read_input_token_cost": 5e-07,
+                "cache_creation_input_token_cost": 2.5e-06,
+            }
+        }
+        usages = [
+            {
+                "total_prompt_tokens": 1000,
+                "total_prompt_cached_tokens": 400,
+                "total_prompt_cache_creation_tokens": 200,
+                "total_completion_tokens": 0,
+            }
+        ] * 2
+        agg = aggregate_evaluation_costs(usages, model_name="judge-model", price_table=price_table)
+        assert agg["total_cache_creation_tokens"] == 400
+        # non-cached prompt excludes cached AND creation tokens
+        assert agg["total_non_cached_prompt"] == 800
+        # cached bucket is cache reads only; creation has its own bucket
+        assert agg["costs"]["cached"] == pytest.approx(2 * 400 * 5e-07)
+        assert agg["costs"]["cache_creation"] == pytest.approx(2 * 200 * 2.5e-06)
+        assert agg["costs"]["total"] == pytest.approx(2 * (400 * 2e-06 + 400 * 5e-07 + 200 * 2.5e-06))

--- a/tests/browseruse_bench/test_llm_cost.py
+++ b/tests/browseruse_bench/test_llm_cost.py
@@ -93,6 +93,88 @@ def test_enrich_usage_with_cached_tokens() -> None:
     assert enriched["total_cost"] == pytest.approx(0.0022)
 
 
+def test_enrich_usage_bills_cache_creation_tokens() -> None:
+    price_table = {
+        "claude-x": {
+            "input_cost_per_token": 2e-06,
+            "output_cost_per_token": 8e-06,
+            "cache_read_input_token_cost": 5e-07,
+            "cache_creation_input_token_cost": 2.5e-06,
+        }
+    }
+    # prompt_tokens includes cached reads and cache-creation tokens.
+    usage = {
+        "total_prompt_tokens": 1000,
+        "total_prompt_cached_tokens": 400,
+        "total_prompt_cache_creation_tokens": 200,
+        "total_completion_tokens": 100,
+        "total_tokens": 1100,
+    }
+
+    enriched = enrich_usage_with_litellm_pricing(
+        usage=usage,
+        model_name="claude-x",
+        price_table=price_table,
+    )
+
+    assert enriched["total_prompt_cache_creation_tokens"] == 200
+    # 400 non-cached * 2e-6 + 400 cached * 5e-7 + 200 creation * 2.5e-6
+    assert enriched["total_prompt_cost"] == pytest.approx(0.0015)
+    assert enriched["total_prompt_cache_creation_cost"] == pytest.approx(0.0005)
+    assert enriched["total_cost"] == pytest.approx(0.0023)
+
+
+def test_enrich_usage_cache_creation_rate_falls_back_to_input_rate() -> None:
+    usage = {
+        "total_prompt_tokens": 1000,
+        "total_prompt_cache_creation_tokens": 200,
+        "total_completion_tokens": 0,
+    }
+
+    enriched = enrich_usage_with_litellm_pricing(
+        usage=usage,
+        model_name="gpt-4.1",
+        price_table=TEST_PRICE_TABLE,
+    )
+
+    # No cache_creation rate configured: creation tokens bill at the input rate,
+    # so the prompt cost matches 1000 tokens at 2e-6.
+    assert enriched["total_prompt_cost"] == pytest.approx(0.002)
+    assert enriched["total_prompt_cache_creation_cost"] == pytest.approx(0.0004)
+
+
+def test_custom_pricing_reads_cache_creation_per_million(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_price_file = tmp_path / "model_pricing.yaml"
+    custom_price_file.write_text(
+        "my-model:\n"
+        "  input_cost_per_million_tokens: 2\n"
+        "  output_cost_per_million_tokens: 8\n"
+        "  cache_read_input_cost_per_million_tokens: 0.5\n"
+        "  cache_creation_input_cost_per_million_tokens: 2.5\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(llm_cost, "DEFAULT_CUSTOM_MODEL_PRICING_FILE", custom_price_file)
+
+    usage = {
+        "total_prompt_tokens": 1000,
+        "total_prompt_cached_tokens": 400,
+        "total_prompt_cache_creation_tokens": 200,
+        "total_completion_tokens": 0,
+    }
+
+    enriched = enrich_usage_with_litellm_pricing(
+        usage=usage,
+        model_name="my-model",
+        price_table={},
+    )
+
+    assert enriched["total_prompt_cost"] == pytest.approx(0.0015)
+    assert enriched["total_prompt_cache_creation_cost"] == pytest.approx(0.0005)
+
+
 def test_enrich_usage_keeps_complete_usage_without_force() -> None:
     usage = {
         "total_prompt_tokens": 50,

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -338,3 +338,15 @@ class TestStopPredicate:
         assert error is None
         assert _stdout_json(lines) == {"done": True}
         assert elapsed < 15
+
+
+class TestUsageFromTotalOnly:
+    def test_total_only_last_call_usage_preserved(self) -> None:
+        from browseruse_bench.agents.openclaw import OpenClawAgent
+
+        result_obj = {
+            "meta": {"agentMeta": {"lastCallUsage": {"total": 5000}}},
+        }
+        usage = OpenClawAgent._usage_from(result_obj)
+        assert usage is not None
+        assert usage.total_tokens == 5000

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -134,9 +134,44 @@ class TestOpenClawAgentRunTask:
         assert result.agent_done == "done"
         assert result.metrics.steps == 2
         assert result.metrics.usage is not None
-        assert result.metrics.usage.total_prompt_tokens == 100
+        # lastCallUsage fallback; pi-ai `input` excludes cacheRead/cacheWrite,
+        # so the normalized prompt count folds them back in (100 + 40 + 0).
+        assert result.metrics.usage.total_prompt_tokens == 140
+        assert result.metrics.usage.total_prompt_cached_tokens == 40
         assert result.screenshots == ["screenshot-1.png"]
         assert result.action_history[0] == "browser_open"
+
+    def test_usage_aggregates_across_session_messages(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Session log carries per-call usage: aggregate it instead of trusting
+        # lastCallUsage (which covers only the final LLM call).
+        session = tmp_path / "session.jsonl"
+        lines = [
+            {"type": "message", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "step 1"}],
+                "usage": {"input": 10, "output": 5, "cacheRead": 100, "cacheWrite": 30},
+            }},
+            {"type": "message", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "step 2"}],
+                "usage": {"input": 20, "output": 7, "cacheRead": 200, "cacheWrite": 0},
+            }},
+        ]
+        session.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+        agent = OpenClawAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(session), None)
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        usage = result.metrics.usage
+        assert usage is not None
+        assert usage.total_prompt_tokens == 360  # 10+100+30 + 20+200+0
+        assert usage.total_prompt_cached_tokens == 300
+        assert usage.total_prompt_cache_creation_tokens == 30
+        assert usage.total_completion_tokens == 12
+        assert usage.entry_count == 2
 
     def test_state_config_written(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/browseruse_bench/test_skyvern_agent.py
+++ b/tests/browseruse_bench/test_skyvern_agent.py
@@ -254,3 +254,35 @@ class TestExtractUsageFromResponseBlob:
         assert summary["total_prompt_cached_tokens"] == 200
         assert summary["total_prompt_cache_creation_tokens"] == 30
         assert summary["total_tokens"] == 340
+
+    def test_details_zero_falls_back_to_top_level_cache_keys(self) -> None:
+        from browseruse_bench.agents.skyvern import _extract_usage_from_response_blob
+
+        # Zero-filled details must not mask a real top-level cache counter.
+        blob = {
+            "usage": {
+                "prompt_tokens": 12000,
+                "completion_tokens": 300,
+                "prompt_tokens_details": {"cached_tokens": 0},
+                "cache_read_input_tokens": 9000,
+            }
+        }
+        usage = _extract_usage_from_response_blob(blob)
+        assert usage is not None
+        assert usage["cached_tokens"] == 9000
+
+    def test_zero_prompt_tokens_falls_back_to_input_tokens(self) -> None:
+        from browseruse_bench.agents.skyvern import _extract_usage_from_response_blob
+
+        blob = {
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": 500,
+                "input_tokens": 8000,
+                "cache_read_input_tokens": 6000,
+            }
+        }
+        usage = _extract_usage_from_response_blob(blob)
+        assert usage is not None
+        assert usage["prompt_tokens"] == 14000  # anthropic-style fold
+        assert usage["cached_tokens"] == 6000

--- a/tests/browseruse_bench/test_skyvern_agent.py
+++ b/tests/browseruse_bench/test_skyvern_agent.py
@@ -161,3 +161,96 @@ def test_build_local_chromium_args_username_only_no_password() -> None:
         },
     )
     assert args == ["--proxy-server=http://alice@proxy.corp:3128"]
+
+
+class TestExtractUsageFromResponseBlob:
+    """Usage extraction must not mix OpenAI and Anthropic token semantics."""
+
+    def test_openai_style_prompt_includes_cached(self) -> None:
+        from browseruse_bench.agents.skyvern import _extract_usage_from_response_blob
+
+        blob = {
+            "usage": {
+                "prompt_tokens": 500,
+                "completion_tokens": 20,
+                "prompt_tokens_details": {"cached_tokens": 300},
+            }
+        }
+        usage = _extract_usage_from_response_blob(blob)
+        assert usage == {
+            "prompt_tokens": 500,
+            "completion_tokens": 20,
+            "cached_tokens": 300,
+            "cache_creation_tokens": 0,
+            "total_tokens": 520,
+        }
+
+    def test_anthropic_style_adds_cache_components_to_prompt(self) -> None:
+        from browseruse_bench.agents.skyvern import _extract_usage_from_response_blob
+
+        # Anthropic input_tokens EXCLUDES cache reads/writes; the normalized
+        # prompt count must include them so downstream cost math (which
+        # subtracts cached from prompt) stays correct.
+        blob = {
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 400,
+                "cache_creation_input_tokens": 50,
+            }
+        }
+        usage = _extract_usage_from_response_blob(blob)
+        assert usage == {
+            "prompt_tokens": 550,
+            "completion_tokens": 20,
+            "cached_tokens": 400,
+            "cache_creation_tokens": 50,
+            "total_tokens": 570,
+        }
+
+    def test_responses_api_style_input_already_includes_cached(self) -> None:
+        from browseruse_bench.agents.skyvern import _extract_usage_from_response_blob
+
+        # OpenAI Responses API: input_tokens INCLUDES cached tokens.
+        blob = {
+            "usage": {
+                "input_tokens": 500,
+                "output_tokens": 20,
+                "input_tokens_details": {"cached_tokens": 300},
+            }
+        }
+        usage = _extract_usage_from_response_blob(blob)
+        assert usage == {
+            "prompt_tokens": 500,
+            "completion_tokens": 20,
+            "cached_tokens": 300,
+            "cache_creation_tokens": 0,
+            "total_tokens": 520,
+        }
+
+    def test_collect_usage_sums_cache_creation(self, tmp_path) -> None:
+        import json
+
+        from browseruse_bench.agents.skyvern import collect_usage_from_skyvern_artifacts
+
+        step_dir = tmp_path / "tsk_1" / "a_stp_001"
+        step_dir.mkdir(parents=True)
+        (step_dir / "raw_llm_response.json").write_text(
+            json.dumps(
+                {
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 10,
+                        "cache_read_input_tokens": 200,
+                        "cache_creation_input_tokens": 30,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        summary = collect_usage_from_skyvern_artifacts([tmp_path / "tsk_1"])
+        assert summary["total_prompt_tokens"] == 330
+        assert summary["total_prompt_cached_tokens"] == 200
+        assert summary["total_prompt_cache_creation_tokens"] == 30
+        assert summary["total_tokens"] == 340

--- a/tests/browseruse_bench/test_stats.py
+++ b/tests/browseruse_bench/test_stats.py
@@ -3,6 +3,44 @@
 import pytest
 
 from browseruse_bench.utils import filter_tasks_by_label, generate_evaluation_summary
+from browseruse_bench.utils.stats import calculate_metric_stats, calculate_usage_stats
+
+
+def _task_with_usage(task_id: str, usage: dict) -> dict:
+    return {
+        "task_id": task_id,
+        "predicted_label": 1,
+        "evaluation_details": {"agent_metrics": {"usage": usage}},
+    }
+
+
+class TestCalcStatsPrecision:
+    """Per-task USD costs are small; 2dp rounding used to flatten them to 0.0."""
+
+    def test_mean_preserves_small_cost_values(self):
+        tasks = [
+            _task_with_usage("1", {"total_cost": 0.003}),
+            _task_with_usage("2", {"total_cost": 0.004}),
+        ]
+        stats = calculate_usage_stats(tasks)
+        assert stats["total_cost"]["mean"] == 0.0035
+
+    def test_median_preserves_small_cost_values(self):
+        tasks = [
+            _task_with_usage("1", {"total_cost": 0.001}),
+            _task_with_usage("2", {"total_cost": 0.002}),
+            _task_with_usage("3", {"total_cost": 0.003}),
+        ]
+        stats = calculate_usage_stats(tasks)
+        assert stats["total_cost"]["median"] == 0.002
+
+    def test_median_even_count_averages_middle_values(self):
+        tasks = [
+            {"evaluation_details": {"agent_metrics": {"steps": v}}}
+            for v in (1, 2, 3, 10)
+        ]
+        stats = calculate_metric_stats(tasks, "steps")
+        assert stats["median"] == 2.5
 
 
 class TestFilterTasksByLabel:


### PR DESCRIPTION
## Summary

Five fixes to model token accounting and cost computation, following up on the pricing work in #69:

1. **claude-code dropped all token counts** — only `total_cost_usd` was stored; the zero-token `AgentUsage` also passed `has_complete_usage_cost_fields`, so the shared enrichment never backfilled them. Now parses the result event's `usage` (Anthropic semantics normalized), with a timeout fallback that sums per-assistant-message usage.
2. **openclaw under-counted by design** — `agentMeta.lastCallUsage` only covers the final LLM call. Now aggregates usage across all assistant messages in the session log (lastCallUsage kept as fallback).
3. **Anthropic/OpenAI usage semantics mixed** — Anthropic `input_tokens` excludes cache reads/writes, but downstream cost math assumes the OpenAI convention (prompt includes cached) and subtracts cached again. The convention is now documented on `AgentUsage` and Anthropic-shaped sources (skyvern, claude-code, openclaw) normalize before reporting. Cache-creation tokens are now billed at their configured rate — the `cache_creation_input_cost_per_million_tokens` key in `model_pricing.yaml` was previously ignored.
4. **Judge cost hardcoded ¥10/¥40/¥2.5 per M** — `calculate_evaluation_cost` now resolves USD rates from the shared pricing tables using the eval model name (threaded from all four evaluators). Note: historical `evaluation_cost` values are CNY and not comparable.
5. **Stats rounding flattened costs** — mean/median round to 6dp (was 2dp, which turned per-task USD costs into 0.00); even-sized samples now use the true median.

## Tests

16 new tests (TDD, red→green each). Touched-area suites: 153 passed. Full suite: 566 passed; the 2 failures (`test_config_loader` override test, claude-code CLI smoke) reproduce identically on unmodified `main`.

## Smoke evidence (LexBench-Browser `--mode single`, per error-handling-testing.md)

- **claude-code**: green end-to-end, 109.7s, `[Claude Code] Done: 9 turns cost=$1.2944`; result.json now records `total_prompt_tokens=246992, total_completion_tokens=2214, entry_count=9` (all zero before this fix). Run against the local LiteLLM gateway via a param-stripping proxy (gateway rejects the CLI's `thinking`/`output_config`; consider `litellm_settings: drop_params: true` server-side).
- **openclaw**: green, 12 tool steps, 13 model calls scanned from the session log. Gateway returns zero usage in streaming responses, so usage stays empty in this environment (same as before the fix; unit tests cover the aggregation).
- **skyvern**: 15 live model calls (`LLM API handler duration metrics ... model=openai/gpt-5.4`), timed_out terminal state; `collect_usage_from_skyvern_artifacts` verified against the run's real artifacts (219487 prompt / 29440 cached / 7702 completion, 15 entries). Two pre-existing issues found while smoking (psycopg marker excludes py<3.13; artifact matching misses on timeout, losing usage/steps) — will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)