### PR TITLE
fix(openclaw): opt in to streaming usage for the bench provider

### DIFF
--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -383,6 +383,11 @@ class OpenClawAgent(CLIAgent):
                             "contextWindow": int(agent_config.get("context_window", 195000)),
                             "maxTokens": int(agent_config.get("max_tokens", 16000)),
                             "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                            # OpenClaw's auto-detection disables streaming usage
+                            # for custom providers, which zeroes all token
+                            # accounting; the bench gateway supports
+                            # stream_options.include_usage, so opt in.
+                            "compat": {"supportsUsageInStreaming": True},
                         }],
                     }
                 },

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -198,6 +198,9 @@ class TestOpenClawAgentRunTask:
         assert cfg["models"]["providers"]["bench"]["timeoutSeconds"] == 300
         # The api key written for the run must be scrubbed from the artifact.
         assert provider["apiKey"] == "***"
+        # Without this compat flag OpenClaw never sends stream_options
+        # include_usage to custom providers, so token usage is all zeros.
+        assert provider["models"][0]["compat"] == {"supportsUsageInStreaming": True}
 
     def test_cdp_url_written_as_attach_profile(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Summary

OpenClaw records zero tokens for every LLM call through the bench gateway because its compat auto-detection disables `stream_options.include_usage` for custom OpenAI-compatible providers (openclaw dist: `if (compat.supportsUsageInStreaming) params.stream_options = { include_usage: true }`, with the model-level `compat` field overriding detection). The gateway itself supports it — probed both ways: usage arrives on the final chunk with `include_usage: true`, and never arrives without it.

One-line fix: set `compat: {supportsUsageInStreaming: true}` on the model entry the agent writes into the per-task `openclaw.json`.

## Smoke evidence (LexBench-Browser `--mode single`)

Before (run 20260703_144920): task green, 13 LLM calls, all usage zeros → `metrics.usage = null`.
After (run 20260703_223150): task green, 8 steps / 9 LLM calls, `total_prompt_tokens=161044` (129536 cached), `total_completion_tokens=571`, cost enriched to `$0.1197` — validating the whole #74 pipeline (session aggregation → Anthropic-style fold → pricing) on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)