### PR TITLE
fix(deps): install psycopg for skyvern extra on all Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest-asyncio",
     "ruff",
     "mypy",
+    "packaging",
 ]
 
 # Agent-specific dependencies (use --extra to select)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,11 @@ skyvern = [
     # Local Skyvern execution imports forge/server components even when using
     # an OpenAI-compatible llm_config.
     "skyvern[local]>=1.0.37",
-    "psycopg[binary,pool]>=3.2.13; python_full_version >= '3.13'",
+    # Temporary-Postgres mode (agents/skyvern.py) imports psycopg v3 on every
+    # Python version; skyvern[local] does not provide it. Do not add a Python
+    # version marker here: the per-version psycopg pins upstream live in
+    # skyvern's unused "server" extra and do not constrain us.
+    "psycopg[binary,pool]>=3.2.13",
 ]
 
 openai-cua = [

--- a/tests/browseruse_bench/test_skyvern_agent.py
+++ b/tests/browseruse_bench/test_skyvern_agent.py
@@ -9,6 +9,7 @@ import tomllib
 from pathlib import Path
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 from browseruse_bench.agents import skyvern as skyvern_module
 from browseruse_bench.agents.skyvern import SkyvernAgent, _build_local_chromium_args
@@ -437,7 +438,9 @@ def test_skyvern_extra_provides_psycopg_on_all_supported_pythons() -> None:
     # broke every first `bubench run --agent skyvern`.
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     skyvern_deps = pyproject["project"]["optional-dependencies"]["skyvern"]
-    psycopg_reqs = [req for req in map(Requirement, skyvern_deps) if req.name == "psycopg"]
+    psycopg_reqs = [
+        req for req in map(Requirement, skyvern_deps) if canonicalize_name(req.name) == "psycopg"
+    ]
 
     assert psycopg_reqs, "skyvern extra must declare psycopg for temporary Postgres mode"
     for minor in (11, 12, 13):

--- a/tests/browseruse_bench/test_skyvern_agent.py
+++ b/tests/browseruse_bench/test_skyvern_agent.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+import tomllib
 from pathlib import Path
+
+from packaging.requirements import Requirement
 
 from browseruse_bench.agents import skyvern as skyvern_module
 from browseruse_bench.agents.skyvern import SkyvernAgent, _build_local_chromium_args
+from browseruse_bench.utils import REPO_ROOT
 
 
 def test_close_runtime_resources_closes_browser_and_client() -> None:
@@ -424,3 +428,23 @@ class TestExtractUsageFromResponseBlob:
         assert usage is not None
         assert usage["prompt_tokens"] == 14000  # anthropic-style fold
         assert usage["cached_tokens"] == 6000
+
+
+def test_skyvern_extra_provides_psycopg_on_all_supported_pythons() -> None:
+    # Temporary-Postgres mode imports psycopg v3 regardless of Python version,
+    # so the skyvern extra must install it on every version we support. A
+    # python_full_version marker here once skipped psycopg on 3.11/3.12 and
+    # broke every first `bubench run --agent skyvern`.
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    skyvern_deps = pyproject["project"]["optional-dependencies"]["skyvern"]
+    psycopg_reqs = [req for req in map(Requirement, skyvern_deps) if req.name == "psycopg"]
+
+    assert psycopg_reqs, "skyvern extra must declare psycopg for temporary Postgres mode"
+    for minor in (11, 12, 13):
+        environment = {
+            "python_version": f"3.{minor}",
+            "python_full_version": f"3.{minor}.0",
+        }
+        assert any(
+            req.marker is None or req.marker.evaluate(environment) for req in psycopg_reqs
+        ), f"skyvern extra does not install psycopg on Python 3.{minor}"


### PR DESCRIPTION
## Problem

The `skyvern` extra declared `psycopg[binary,pool]>=3.2.13; python_full_version >= '3.13'`, but the temporary-Postgres mode (`config_loader._skyvern_temp_database_string` uses the `postgresql+psycopg://` driver; `agents/skyvern.py` imports psycopg v3 in `_ensure_temp_postgres_database` / `_drop_temp_postgres_database`) needs psycopg on **all** Python versions. The `.venvs/skyvern` venv resolves to Python 3.12, so psycopg was skipped and every first `bubench run --agent skyvern` failed with "Skyvern temporary Postgres mode requires psycopg" until psycopg was installed manually.

## Why the marker existed

It traces to the initial public release with no dedicated commit. The pattern matches skyvern's own **`server`** extra, which pins psycopg per Python version (`==3.1.18` on 3.11–3.12, `>=3.2.2,<3.3.0` on 3.13). We install **`skyvern[local]`**, which declares no psycopg at all — so there is no upstream constraint and the unconditional requirement resolves cleanly. Verified with `uv pip compile --extra skyvern` on Python 3.11/3.12/3.13 (psycopg 3.3.4 everywhere; `psycopg2-binary` from main deps coexists — different distribution and module names).

## Changes

- `pyproject.toml`: drop the `python_full_version >= '3.13'` marker; comment explains why no marker belongs there. Also declare `packaging` in the dev extra (the new test imports it directly).
- `tests/browseruse_bench/test_skyvern_agent.py`: regression test asserting the skyvern extra provides psycopg on every supported Python version via PEP 508 marker evaluation (the old marker evaluates `False` on 3.12, so this test fails on the pre-fix pyproject). Requirement names are matched with PEP 503 `canonicalize_name`.

## Smoke test (per docs_4_codeagent/error-handling-testing.md)

`uv run scripts/run.py --agent skyvern --data LexBench-Browser --mode single` against a **freshly created Python 3.12 venv with no psycopg** (the exact first-run state that used to fail):

- Dependency install automatically included `+ psycopg==3.3.4` (+ binary/pool).
- Temporary Postgres DB bootstrapped; skyvern server booted and accepted the task (`POST /v1/run/tasks` → 200).
- Real subprocess work: `LLM API handler duration metrics ... model=openai/gpt-5.4`, `Task completed task_status=completed` (twice), final `Total: 1 | Success: 1 | Failed: 0`, exit code 0. Agent task wall-clock 623.6s (hit the configured 600s cap during a late browsing loop after the remote browser session closed — unrelated to this change; the psycopg boot path succeeded long before).

## Code review

Reviewed at high effort (8 finder angles + verification). Two low-priority notes deliberately left as-is:
- `marker.evaluate()` inherits host values for unspecified keys, so a hypothetical future platform-conditional marker would only be tested against the CI host's platform.
- The supported-minors tuple `(11, 12, 13)` is hardcoded and needs a manual bump when 3.14 support lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)