### PR TITLE
fix(skyvern): collect artifacts on client-side timeout and across task_v2 sibling dirs

### DIFF
--- a/browseruse_bench/agents/skyvern.py
+++ b/browseruse_bench/agents/skyvern.py
@@ -101,6 +101,16 @@ from browseruse_bench.utils.config_loader import canonicalize_skyvern_model_name
 
 logger = logging.getLogger(__name__)
 
+# Browser backends whose runs leave Skyvern's per-step artifacts on the local
+# filesystem (cloud-managed Skyvern browsers keep artifacts remote).
+_LOCAL_ARTIFACT_BROWSERS = ("local", "lexmount", "cdp")
+
+# Exception classes tolerated by best-effort screenshot capture; empty when
+# no TargetClosedError could be imported (then nothing extra is caught).
+_TARGET_CLOSED_ERRORS: tuple[type[BaseException], ...] = (
+    (TargetClosedError,) if TargetClosedError is not None else ()
+)
+
 Skyvern: type[Any] | None = None
 RunEngine: type[Any] | None = None
 RunStatus: type[Any] | None = None
@@ -580,12 +590,20 @@ def _normalize_answer_text(value: Any) -> tuple[str, Any | None]:
     return str(value), value
 
 
+def _task_dir_numeric_id(name: str) -> int:
+    suffix = name.removeprefix("tsk_")
+    if suffix.isdigit():
+        return int(suffix)
+    return 0
+
+
 def _resolve_artifact_task_dirs(
     start_time: float,
     end_time: float,
     org_id: str | None,
     existing_dirs_before_task: set[str] | None,
     task_prompt: str | None,
+    include_sibling_dirs: bool = False,
 ) -> list[Path]:
     artifacts_base = _get_skyvern_artifacts_base()
     if artifacts_base is None:
@@ -622,6 +640,21 @@ def _resolve_artifact_task_dirs(
         matched_task = _find_task_dir_by_prompt(
             artifacts_org_dir, task_prompt, candidate_dirs, start_time
         )
+        if matched_task and include_sibling_dirs:
+            # A task_v2 run spreads its steps across several tsk_ dirs
+            # (planner task + per-goal child tasks); the children never embed
+            # the user prompt, so once the prompt anchors one dir, every new
+            # in-window dir belongs to this run. Caveat: with concurrent
+            # skyvern tasks sharing this artifact store (run --concurrency
+            # > 1), attribution is best-effort and may claim a concurrent
+            # run's dirs.
+            ordered = sorted(candidate_dirs, key=_task_dir_numeric_id)
+            if len(ordered) > 1:
+                logger.info(
+                    f"Prompt anchored {matched_task}; attributing "
+                    f"{len(ordered)} sibling artifact dirs to this run"
+                )
+            return [artifacts_org_dir / name for name in ordered]
         if matched_task:
             return [artifacts_org_dir / matched_task]
         logger.warning(
@@ -647,9 +680,15 @@ def copy_screenshots_from_skyvern_artifacts(
     org_id: str | None = None,
     existing_dirs_before_task: set[str] | None = None,
     task_prompt: str | None = None,
+    include_sibling_dirs: bool = False,
 ) -> tuple[int, int, list[Path]]:
     task_dirs = _resolve_artifact_task_dirs(
-        start_time, end_time, org_id, existing_dirs_before_task, task_prompt
+        start_time,
+        end_time,
+        org_id,
+        existing_dirs_before_task,
+        task_prompt,
+        include_sibling_dirs=include_sibling_dirs,
     )
     if not task_dirs:
         return 0, 0, []
@@ -687,6 +726,57 @@ def copy_screenshots_from_skyvern_artifacts(
             logger.error(f"Failed to copy screenshot {src_file}: {exc}")
 
     return screenshot_count, total_steps, task_dirs
+
+
+def _collect_run_artifacts(
+    trajectory_dir: Path,
+    start_time: float,
+    end_time: float,
+    org_id: str | None,
+    existing_dirs_before_task: set[str] | None,
+    task_prompt: str | None,
+    include_sibling_dirs: bool,
+) -> tuple[int, int, list[str], dict[str, Any]]:
+    """Copy screenshots and aggregate steps, actions, and usage from local artifacts.
+
+    Shared by the normal completion path and the client-side timeout path so a
+    timed-out run still reports the work Skyvern actually did.
+    """
+    screenshot_count, steps, task_dirs = copy_screenshots_from_skyvern_artifacts(
+        trajectory_dir,
+        start_time,
+        end_time,
+        org_id=org_id,
+        existing_dirs_before_task=existing_dirs_before_task,
+        task_prompt=task_prompt,
+        include_sibling_dirs=include_sibling_dirs,
+    )
+    if not task_dirs:
+        return screenshot_count, steps, [], {}
+    return (
+        screenshot_count,
+        steps,
+        _collect_action_history(task_dirs),
+        collect_usage_from_skyvern_artifacts(task_dirs),
+    )
+
+
+async def _capture_page_screenshot(page: Any, screenshot_path: Path, label: str) -> bool:
+    """Best-effort page screenshot; tolerates a dead page/context.
+
+    A closed page (common when the remote browser session died or the task
+    timed out) must not turn a soft failure into a subprocess-level
+    exception. Returns True when a screenshot file was written.
+    """
+    try:
+        await page.screenshot(path=str(screenshot_path))
+        return True
+    except (OSError, RuntimeError) as exc:
+        logger.error(f"Failed to capture {label} screenshot: {exc}")
+        return False
+    except _TARGET_CLOSED_ERRORS as exc:
+        logger.warning("Skipped %s screenshot; page/context closed: %s", label, exc)
+        return False
 
 
 @register_agent
@@ -876,6 +966,9 @@ class SkyvernAgent(BaseAgent):
             "skyvern_v2": RunEngine.skyvern_v2,
         }
         engine = ENGINE_MAP.get(engine_str, RunEngine.skyvern_v2)
+        # task_v2 runs spread their artifacts across multiple tsk_ dirs
+        # (planner + child tasks), so artifact matching must claim siblings.
+        include_sibling_dirs = engine == RunEngine.skyvern_v2
 
         config_info = {
             "timeout_seconds": timeout,
@@ -1068,26 +1161,33 @@ class SkyvernAgent(BaseAgent):
             except TimeoutError:
                 error_msg = f"Timeout after {timeout} seconds"
                 logger.error(f"Task {task_id} timed out after {timeout} seconds")
-                end_to_end_ms = int((time.time() - start_time) * 1000)
+                timeout_end = time.time()
+                end_to_end_ms = int((timeout_end - start_time) * 1000)
 
-                if page:
-                    try:
-                        timeout_screenshot_path = trajectory_dir / "screenshot-1.png"
-                        await page.screenshot(path=str(timeout_screenshot_path))
+                # Skyvern already wrote per-step artifacts for the work done
+                # before the deadline; collect them so a timed-out run still
+                # reports steps, actions, screenshots, and token usage.
+                timeout_screenshots = 0
+                timeout_steps = 0
+                timeout_actions: list[str] = []
+                timeout_usage: dict[str, Any] = {}
+                if browser_id in _LOCAL_ARTIFACT_BROWSERS:
+                    timeout_screenshots, timeout_steps, timeout_actions, timeout_usage = (
+                        _collect_run_artifacts(
+                            trajectory_dir,
+                            start_time,
+                            timeout_end,
+                            org_id=org_id,
+                            existing_dirs_before_task=existing_artifact_dirs,
+                            task_prompt=task_prompt,
+                            include_sibling_dirs=include_sibling_dirs,
+                        )
+                    )
 
-                    except (OSError, RuntimeError) as exc:
-                        logger.error(f"Failed to capture timeout screenshot: {exc}")
-                    except Exception as exc:
-                        # Same reasoning as the final-screenshot path below —
-                        # a dead page/context on a timeout path shouldn't
-                        # turn the timeout into a subprocess-level exception.
-                        if TargetClosedError is not None and isinstance(exc, TargetClosedError):
-                            logger.warning(
-                                "Timeout screenshot skipped; page/context closed: %s",
-                                exc,
-                            )
-                        else:
-                            raise
+                if timeout_screenshots == 0 and page:
+                    await _capture_page_screenshot(
+                        page, trajectory_dir / "screenshot-1.png", "timeout"
+                    )
 
                 return AgentResult(
                     task_id=task_id,
@@ -1098,8 +1198,12 @@ class SkyvernAgent(BaseAgent):
                     agent_done="timeout",  # type: ignore[arg-type]
                     model_id=model_id,
                     browser_id=browser_id,
-                    action_history=[],
-                    metrics=AgentMetrics(end_to_end_ms=end_to_end_ms, steps=0),
+                    action_history=timeout_actions,
+                    metrics=AgentMetrics(
+                        end_to_end_ms=end_to_end_ms,
+                        steps=timeout_steps,
+                        usage=AgentUsage(**timeout_usage) if timeout_usage else None,
+                    ),
                     config=config_info,
                     error=error_msg,
                 )
@@ -1163,7 +1267,7 @@ class SkyvernAgent(BaseAgent):
                     except (OSError, urllib.error.URLError) as exc:
                         logger.error(f"Failed to download screenshot {i}: {exc}")
 
-            if screenshot_count == 0 and browser_id in ("local", "lexmount", "cdp"):
+            if screenshot_count == 0 and browser_id in _LOCAL_ARTIFACT_BROWSERS:
                 screenshot_count, actual_steps, matched_task_dirs = (
                     copy_screenshots_from_skyvern_artifacts(
                         trajectory_dir,
@@ -1172,6 +1276,7 @@ class SkyvernAgent(BaseAgent):
                         org_id=org_id,
                         existing_dirs_before_task=existing_artifact_dirs,
                         task_prompt=task_prompt,
+                        include_sibling_dirs=include_sibling_dirs,
                     )
                 )
 
@@ -1180,35 +1285,22 @@ class SkyvernAgent(BaseAgent):
             # LLM payloads to the *local* artifact dir regardless of where
             # screenshots come from. Skip for skyvern-cloud browsers since
             # those runs don't produce local artifacts at all.
-            if not matched_task_dirs and browser_id in ("local", "lexmount", "cdp"):
+            if not matched_task_dirs and browser_id in _LOCAL_ARTIFACT_BROWSERS:
                 matched_task_dirs = _resolve_artifact_task_dirs(
                     start_time,
                     end_time,
                     org_id=org_id,
                     existing_dirs_before_task=existing_artifact_dirs,
                     task_prompt=task_prompt,
+                    include_sibling_dirs=include_sibling_dirs,
                 )
 
             if screenshot_count == 0 and page:
-                try:
-                    final_screenshot_path = trajectory_dir / "screenshot-1.png"
-                    await page.screenshot(path=str(final_screenshot_path))
-
+                captured = await _capture_page_screenshot(
+                    page, trajectory_dir / "screenshot-1.png", "final"
+                )
+                if captured:
                     screenshot_count = 1
-                except (OSError, RuntimeError) as exc:
-                    logger.error(f"Failed to capture final screenshot: {exc}")
-                except Exception as exc:
-                    # Page/context may be closed (common when task failed
-                    # because the remote browser session died). Don't let a
-                    # best-effort screenshot attempt turn a soft failure into
-                    # an unhandled exception bubbling up to the subprocess.
-                    if TargetClosedError is not None and isinstance(exc, TargetClosedError):
-                        logger.warning(
-                            "Final screenshot skipped; page/context was already closed: %s",
-                            exc,
-                        )
-                    else:
-                        raise
 
             action_history = _collect_action_history(matched_task_dirs) if matched_task_dirs else []
 

--- a/tests/browseruse_bench/test_skyvern_agent.py
+++ b/tests/browseruse_bench/test_skyvern_agent.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import time
+from pathlib import Path
 
+from browseruse_bench.agents import skyvern as skyvern_module
 from browseruse_bench.agents.skyvern import SkyvernAgent, _build_local_chromium_args
 
 
@@ -161,3 +165,137 @@ def test_build_local_chromium_args_username_only_no_password() -> None:
         },
     )
     assert args == ["--proxy-server=http://alice@proxy.corp:3128"]
+
+
+# ---------------------------------------------------------------------------
+# Local artifact matching / collection (timeout-path regression: a task_v2 run
+# spreads steps across several tsk_ dirs; only the first embeds the user
+# prompt, and the client-side timeout branch must still collect usage/steps).
+# ---------------------------------------------------------------------------
+
+
+def _write_artifact_task_dir(
+    org_dir: Path,
+    name: str,
+    prompt_text: str | None,
+    step_count: int = 1,
+) -> None:
+    task_dir = org_dir / name
+    for i in range(step_count):
+        step_dir = task_dir / f"{i:02d}_0_stp_{name.removeprefix('tsk_')}{i}"
+        step_dir.mkdir(parents=True)
+        if prompt_text is not None and i == 0:
+            (step_dir / "a_llm_prompt.txt").write_text(prompt_text, encoding="utf-8")
+        (step_dir / "a_llm_response.json").write_text(
+            json.dumps({"usage": {"prompt_tokens": 10, "completion_tokens": 5}}),
+            encoding="utf-8",
+        )
+        (step_dir / "a_llm_response_parsed.json").write_text(
+            json.dumps({"actions": [{"action_type": "CLICK", "id": f"{name}-{i}"}]}),
+            encoding="utf-8",
+        )
+        (step_dir / "a_screenshot_action.png").write_bytes(b"png")
+
+
+def _patch_artifacts_base(monkeypatch, base: Path) -> None:
+    monkeypatch.setattr(skyvern_module, "_get_skyvern_artifacts_base", lambda: base)
+
+
+def test_resolve_artifact_task_dirs_expands_to_sibling_dirs(tmp_path, monkeypatch) -> None:
+    """A prompt-anchored v2 run must claim every new in-window tsk_ dir."""
+    prompt = "Find the highest rated braised pork recipe"
+    org_dir = tmp_path / "o_test"
+    org_dir.mkdir()
+    # Numeric ids chosen so lexicographic order would be wrong (1000 < 900).
+    _write_artifact_task_dir(org_dir, "tsk_900", prompt)
+    _write_artifact_task_dir(org_dir, "tsk_1000", "planner sub-goal, no user prompt")
+    _write_artifact_task_dir(org_dir, "tsk_1100", "extraction sub-goal")
+    _patch_artifacts_base(monkeypatch, tmp_path)
+
+    now = time.time()
+    dirs = skyvern_module._resolve_artifact_task_dirs(
+        now - 50,
+        now + 50,
+        org_id="o_test",
+        existing_dirs_before_task=set(),
+        task_prompt=prompt,
+        include_sibling_dirs=True,
+    )
+
+    assert [d.name for d in dirs] == ["tsk_900", "tsk_1000", "tsk_1100"]
+
+
+def test_resolve_artifact_task_dirs_default_keeps_anchor_only(tmp_path, monkeypatch) -> None:
+    prompt = "Find the highest rated braised pork recipe"
+    org_dir = tmp_path / "o_test"
+    org_dir.mkdir()
+    _write_artifact_task_dir(org_dir, "tsk_900", prompt)
+    _write_artifact_task_dir(org_dir, "tsk_1000", "planner sub-goal, no user prompt")
+    _patch_artifacts_base(monkeypatch, tmp_path)
+
+    now = time.time()
+    dirs = skyvern_module._resolve_artifact_task_dirs(
+        now - 50,
+        now + 50,
+        org_id="o_test",
+        existing_dirs_before_task=set(),
+        task_prompt=prompt,
+    )
+
+    assert [d.name for d in dirs] == ["tsk_900"]
+
+
+def test_resolve_artifact_task_dirs_sibling_expansion_skips_preexisting(
+    tmp_path, monkeypatch
+) -> None:
+    prompt = "Find the highest rated braised pork recipe"
+    org_dir = tmp_path / "o_test"
+    org_dir.mkdir()
+    _write_artifact_task_dir(org_dir, "tsk_800", "leftover from a previous task")
+    _write_artifact_task_dir(org_dir, "tsk_900", prompt)
+    _write_artifact_task_dir(org_dir, "tsk_1000", "planner sub-goal")
+    _patch_artifacts_base(monkeypatch, tmp_path)
+
+    now = time.time()
+    dirs = skyvern_module._resolve_artifact_task_dirs(
+        now - 50,
+        now + 50,
+        org_id="o_test",
+        existing_dirs_before_task={"tsk_800"},
+        task_prompt=prompt,
+        include_sibling_dirs=True,
+    )
+
+    assert [d.name for d in dirs] == ["tsk_900", "tsk_1000"]
+
+
+def test_collect_run_artifacts_aggregates_across_sibling_dirs(tmp_path, monkeypatch) -> None:
+    """The shared collection helper (used by the timeout path) must aggregate
+    screenshots, steps, actions, and usage across every matched tsk_ dir."""
+    prompt = "Find the highest rated braised pork recipe"
+    org_dir = tmp_path / "artifacts" / "o_test"
+    org_dir.mkdir(parents=True)
+    _write_artifact_task_dir(org_dir, "tsk_900", prompt, step_count=2)
+    _write_artifact_task_dir(org_dir, "tsk_1000", None, step_count=3)
+    _patch_artifacts_base(monkeypatch, tmp_path / "artifacts")
+
+    trajectory_dir = tmp_path / "trajectory"
+    trajectory_dir.mkdir()
+    now = time.time()
+
+    screenshot_count, steps, action_history, usage = skyvern_module._collect_run_artifacts(
+        trajectory_dir,
+        now - 50,
+        now + 50,
+        org_id="o_test",
+        existing_dirs_before_task=set(),
+        task_prompt=prompt,
+        include_sibling_dirs=True,
+    )
+
+    assert screenshot_count == 5
+    assert steps == 5
+    assert len(action_history) == 5
+    assert usage["total_prompt_tokens"] == 50
+    assert usage["total_completion_tokens"] == 25
+    assert usage["entry_count"] == 5


### PR DESCRIPTION
## Problem

A skyvern run that hits the client-side `asyncio.wait_for` timeout produced `result.json` with `usage=null`, `steps=0`, and an empty `action_history`, even though per-step `*_llm_response.json` artifacts existed locally. Reproduced 2026-07-03 in `experiments/LexBench-Browser/All/skyvern/gpt-5.4/20260703_150855/tasks/5/`.

Two root causes:

1. **Timeout branch skipped collection entirely.** The `except TimeoutError:` branch returned an `AgentResult` without ever calling artifact resolution (this is a different path from Skyvern's own `timed_out` RunStatus, which flows through the normal path).
2. **task_v2 sibling dirs were never claimed.** A v2 run spreads steps across several `tsk_` dirs (planner + child tasks). Only the first dir embeds the user prompt (verified: the child dirs contain no trace of it), so prompt matching returned a single dir — 2 of 15 usage entries — even on the normal path.

## Fix

- New `_collect_run_artifacts()` helper (screenshots + steps + action history + usage), called from both the normal completion path's building blocks and the timeout branch.
- New `include_sibling_dirs` flag, enabled for the `skyvern_v2` engine: once the prompt anchors one dir, all `tsk_` dirs that are new-since-task-start and inside the time window are attributed to the run, sorted by numeric task id. v1 keeps the strict single-dir match.
- Cleanups from self code-review: hoisted `_LOCAL_ARTIFACT_BROWSERS` (the literal tuple appeared 3x), unified the duplicated best-effort page-screenshot blocks into `_capture_page_screenshot` (also removes two `except Exception` blocks in favor of a precise exception tuple).

**Known limitation** (from adversarial review): under `--concurrency > 1`, concurrent skyvern tasks share the artifact store and each task's `existing_dirs_before_task` snapshot is taken at its own start, so sibling attribution may claim a concurrent v2 run's dirs. Sequential runs (the default) are unaffected; noted in a code comment.

## Tests

- 4 new targeted tests in `tests/browseruse_bench/test_skyvern_agent.py`: sibling expansion (with numeric-vs-lexicographic ordering), anchor-only default, pre-existing-dir exclusion, cross-dir aggregation of screenshots/steps/actions/usage. Written failing-first.
- Replay against the real failed run's artifacts recovers exactly the manually measured 219,487 prompt / 7,702 completion tokens (15 entries), 16 steps, 14 actions, 15 screenshots.

## Smoke (real end-to-end, per AGENTS.md)

- `uv run scripts/run.py --agent skyvern --data LexBench-Browser --mode single --agent-config <180s-timeout config copy>` — wall-clock 192.0s, subprocess proof: `LLM API handler duration metrics ... model=openai/gpt-5.4` then `Task 5 timed out after 180 seconds`.
- Timed-out `result.json` now reads `steps=3`, `usage.total_prompt_tokens=32580`, 2 actions, screenshots copied from artifacts (previously `steps=0 / usage=null`).
- Normal-path smoke (default 600s config) also run; launch path, LLM calls, and result writing verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)