### PR TITLE
fix(openclaw): make concurrent runs usable — disable gateway node dispatch, pin profiles, isolate ports

### DIFF
--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -89,6 +89,52 @@ def _normalize_session_items(session_file: Path) -> list[dict[str, Any]]:
     return items
 
 
+# Local fake-IP proxy clients (Clash/Surge etc.) resolve proxied domains to the
+# RFC 2544 benchmark range (198.18.0.0/15); OpenClaw's local SSRF preflight then
+# blocks navigation ("browser navigation blocked by policy") even though the
+# real navigation happens in the remote CDP browser, where local private-network
+# concerns do not apply.
+_BROWSER_SSRF_POLICY = {"dangerouslyAllowPrivateNetwork": True}
+
+# Browser-tool connection failures caused by the service startup race; a run
+# whose EVERY browser call died this way never had a browser and its answer is
+# a blocked notice, not a result.
+_BROWSER_OUTAGE_SIGNATURES = (
+    "gateway node.list requires credentials",
+    "browser endpoint blocked by policy",
+    "gateway closed (1006",
+    "timed out. Restart the OpenClaw gateway",
+)
+
+
+def _match_outage(text: str) -> str | None:
+    for signature in _BROWSER_OUTAGE_SIGNATURES:
+        if signature in text:
+            return signature
+    return None
+
+
+def _detect_browser_outage(items: list[dict[str, Any]], answer: str) -> str | None:
+    """Return the matched outage signature when the run never had a browser.
+
+    Outage means every browser tool result carries a connection-failure
+    signature (one successful call disproves it); with no browser items at
+    all, fall back to scanning the final answer text.
+    """
+    browser_matches: list[str | None] = []
+    for item in items:
+        if not str(item.get("tool", "")).startswith("browser"):
+            continue
+        content = (item.get("result") or {}).get("content") or []
+        text = " ".join(
+            str(block.get("text", "")) for block in content if isinstance(block, dict)
+        )
+        browser_matches.append(_match_outage(text))
+    if browser_matches:
+        return browser_matches[0] if all(browser_matches) else None
+    return _match_outage(answer)
+
+
 def _allocate_free_port() -> int:
     """Reserve an ephemeral TCP port for a task's private OpenClaw gateway."""
     with socket.socket() as sock:
@@ -255,7 +301,34 @@ class OpenClawAgent(CLIAgent):
         agent_config: dict[str, Any],
         task_workspace: Path,
     ) -> AgentResult | dict[str, Any]:
-        """Execute a browser automation task using OpenClaw CLI."""
+        """Execute a browser automation task using OpenClaw CLI.
+
+        Retries once on a fresh browser session when the run lost the
+        browser-service startup race (every browser call failed with a
+        connection error and the "answer" is just a blocked notice).
+        """
+        result = self._attempt_task(task_info, agent_config, task_workspace)
+        outage = (
+            result.agent_metadata.get("browser_outage")
+            if isinstance(result, AgentResult)
+            else None
+        )
+        if not outage:
+            return result
+        logger.warning(
+            "OpenClaw browser outage on task %s (%s); retrying once on a fresh browser session",
+            task_info.get("task_id"),
+            outage,
+        )
+        return self._attempt_task(task_info, agent_config, task_workspace)
+
+    def _attempt_task(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+    ) -> AgentResult | dict[str, Any]:
+        """Run one OpenClaw attempt against a freshly opened browser session."""
         browser_id = str(agent_config.get("browser_id") or "")
         if browser_id in SELF_LAUNCH_BROWSER_IDS:
             warn_if_local_proxy_unsupported(agent_config, self.name)
@@ -421,7 +494,7 @@ class OpenClawAgent(CLIAgent):
                 # Tool whitelist: browsing plus reading bundled skill files.
                 "list": [{"id": "main", "tools": {"allow": ["browser", "read"]}}],
             },
-            "browser": {"enabled": True},
+            "browser": {"enabled": True, "ssrfPolicy": dict(_BROWSER_SSRF_POLICY)},
             # Default "auto" consults gateway node.list before the in-process
             # browser service; without gateway credentials every browser call
             # fails ("gateway node.list requires credentials before opening a
@@ -432,6 +505,7 @@ class OpenClawAgent(CLIAgent):
             bench_profile = {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"}
             config["browser"] = {
                 "enabled": True,
+                "ssrfPolicy": dict(_BROWSER_SSRF_POLICY),
                 "defaultProfile": "bench",
                 # OpenClaw auto-injects built-in `user`/`openclaw` profiles
                 # (operator's local Chrome) unless the config defines those
@@ -502,6 +576,15 @@ class OpenClawAgent(CLIAgent):
             except (OSError, TypeError, ValueError) as exc:
                 logger.warning("Failed to generate api_logs for task %s: %s", task_id, exc)
 
+        # A "successful" run whose browser never worked is a false success:
+        # the answer is a blocked notice, not a task result.
+        agent_metadata: dict[str, Any] = {}
+        outage = _detect_browser_outage(items, answer) if env_status == "success" else None
+        if outage:
+            env_status, agent_done = "failed", "error"
+            error_message = f"OpenClaw browser tool unavailable ({outage})"
+            agent_metadata["browser_outage"] = outage
+
         return AgentResult(
             task_id=task_id,
             timestamp=datetime.now(UTC),
@@ -512,6 +595,7 @@ class OpenClawAgent(CLIAgent):
             action_history=extract_actions(items),
             screenshots=saved_screenshots,
             model_id=model,
+            agent_metadata=agent_metadata,
             metrics=AgentMetrics(
                 end_to_end_ms=duration_ms, steps=steps, usage=self._usage_from(result_obj)
             ),

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shutil
+import socket
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -47,6 +48,9 @@ _DEFAULT_RULES = (
     "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
     "close that tab, return to the previous page, and use the data already collected to answer.\n"
     "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+    "- EXCEPTION: browser tool CONNECTION errors (gateway credentials/closed/not ready) "
+    "are transient while the browser service finishes starting. Retry the same browser "
+    "call up to 5 times before concluding the browser is unavailable.\n"
     "\n\nScreenshot rules:\n"
     "- Take a screenshot with the browser screenshot action after navigating to the main "
     "page and after finding the answer."
@@ -83,6 +87,13 @@ def _normalize_session_items(session_file: Path) -> list[dict[str, Any]]:
             continue
         _fold_message(message, items, by_call_id)
     return items
+
+
+def _allocate_free_port() -> int:
+    """Reserve an ephemeral TCP port for a task's private OpenClaw gateway."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
 
 
 def _fold_openclaw_usage(raw: Any, totals: dict[str, int]) -> bool:
@@ -300,6 +311,13 @@ class OpenClawAgent(CLIAgent):
         env = {**os.environ}
         env["OPENCLAW_STATE_DIR"] = str(state_dir)
         env["OPENCLAW_CONFIG_PATH"] = str(state_dir / "openclaw.json")
+        # Isolate the per-process gateway: concurrent tasks sharing the
+        # default port 18789 attach to each other's gateway and fail browser
+        # auth ("gateway node.list requires credentials"). Do NOT pre-set
+        # OPENCLAW_GATEWAY_TOKEN — configured credentials make OpenClaw treat
+        # the gateway as external and skip starting its in-process browser
+        # control service entirely (calls then die with 1006 closures).
+        env["OPENCLAW_GATEWAY_PORT"] = str(_allocate_free_port())
 
         logger.info(
             "Executing OpenClaw for task %s (model=%s, timeout=%ds)", task_id, model, timeout
@@ -404,13 +422,25 @@ class OpenClawAgent(CLIAgent):
                 "list": [{"id": "main", "tools": {"allow": ["browser", "read"]}}],
             },
             "browser": {"enabled": True},
+            # Default "auto" consults gateway node.list before the in-process
+            # browser service; without gateway credentials every browser call
+            # fails ("gateway node.list requires credentials before opening a
+            # websocket"). Force local dispatch.
+            "gateway": {"nodes": {"browser": {"mode": "off"}}},
         }
         if cdp_url:
+            bench_profile = {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"}
             config["browser"] = {
                 "enabled": True,
                 "defaultProfile": "bench",
+                # OpenClaw auto-injects built-in `user`/`openclaw` profiles
+                # (operator's local Chrome) unless the config defines those
+                # names; models sometimes pass them explicitly and escape the
+                # bench browser. Pin both to the bench CDP endpoint.
                 "profiles": {
-                    "bench": {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"},
+                    "bench": bench_profile,
+                    "user": dict(bench_profile),
+                    "openclaw": dict(bench_profile),
                 },
             }
         (state_dir / "openclaw.json").write_text(

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -125,7 +125,12 @@ def _detect_browser_outage(items: list[dict[str, Any]], answer: str) -> str | No
     for item in items:
         if not str(item.get("tool", "")).startswith("browser"):
             continue
-        content = (item.get("result") or {}).get("content") or []
+        result = item.get("result")
+        if not isinstance(result, dict):
+            # The toolResult never arrived (turn aborted, stop_predicate raced
+            # the session write): unknown, not evidence of a working browser.
+            continue
+        content = result.get("content") or []
         text = " ".join(
             str(block.get("text", "")) for block in content if isinstance(block, dict)
         )
@@ -135,11 +140,53 @@ def _detect_browser_outage(items: list[dict[str, Any]], answer: str) -> str | No
     return _match_outage(answer)
 
 
+def _browser_config(cdp_url: str | None) -> dict[str, Any]:
+    """Build the per-task browser section of openclaw.json."""
+    if not cdp_url:
+        # Locally launched browser: keep OpenClaw's SSRF preflight intact.
+        return {"enabled": True}
+    bench_profile = {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"}
+    return {
+        "enabled": True,
+        # The SSRF preflight resolves DNS locally, but navigation happens in
+        # the REMOTE CDP browser where local private-network concerns do not
+        # apply — and local fake-IP proxy clients resolve proxied domains to
+        # the RFC 2544 range, which the guard would reject.
+        "ssrfPolicy": _BROWSER_SSRF_POLICY,
+        "defaultProfile": "bench",
+        # OpenClaw auto-injects built-in `user`/`openclaw` profiles
+        # (operator's local Chrome) unless the config defines those names;
+        # models sometimes pass them explicitly and escape the bench
+        # browser. Pin both to the bench CDP endpoint.
+        "profiles": {
+            "bench": bench_profile,
+            "user": bench_profile,
+            "openclaw": bench_profile,
+        },
+    }
+
+
 def _allocate_free_port() -> int:
-    """Reserve an ephemeral TCP port for a task's private OpenClaw gateway."""
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    """Reserve an ephemeral TCP port family for a task's private OpenClaw gateway.
+
+    OpenClaw binds a small family around the gateway port (browser control
+    service on port+2), so probe both before handing the base out. Best
+    effort: the probe sockets are closed before OpenClaw binds, so a race
+    remains possible but requires another process to grab the exact port in
+    the spawn window.
+    """
+    base = 0
+    for _ in range(20):
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            base = sock.getsockname()[1]
+            try:
+                with socket.socket() as neighbor:
+                    neighbor.bind(("127.0.0.1", base + 2))
+            except OSError:
+                continue
+            return base
+    return base
 
 
 def _fold_openclaw_usage(raw: Any, totals: dict[str, int]) -> bool:
@@ -307,32 +354,38 @@ class OpenClawAgent(CLIAgent):
         browser-service startup race (every browser call failed with a
         connection error and the "answer" is just a blocked notice).
         """
-        result = self._attempt_task(task_info, agent_config, task_workspace)
-        outage = (
-            result.agent_metadata.get("browser_outage")
-            if isinstance(result, AgentResult)
-            else None
-        )
-        if not outage:
-            return result
-        logger.warning(
-            "OpenClaw browser outage on task %s (%s); retrying once on a fresh browser session",
-            task_info.get("task_id"),
-            outage,
-        )
-        return self._attempt_task(task_info, agent_config, task_workspace)
+        retries = max(0, safe_int(agent_config.get("outage_retries", 1), 1))
+        result = self._attempt_task(task_info, agent_config, task_workspace, attempt=0)
+        for attempt in range(1, retries + 1):
+            outage = (
+                result.agent_metadata.get("browser_outage")
+                if isinstance(result, AgentResult)
+                else None
+            )
+            if not outage:
+                break
+            logger.warning(
+                "OpenClaw browser outage on task %s (%s); retrying on a fresh browser session",
+                task_info.get("task_id"),
+                outage,
+            )
+            result = self._attempt_task(task_info, agent_config, task_workspace, attempt=attempt)
+            if isinstance(result, AgentResult) and not result.agent_metadata.get("browser_outage"):
+                result.agent_metadata["outage_retried"] = attempt
+        return result
 
     def _attempt_task(
         self,
         task_info: dict[str, Any],
         agent_config: dict[str, Any],
         task_workspace: Path,
+        attempt: int,
     ) -> AgentResult | dict[str, Any]:
         """Run one OpenClaw attempt against a freshly opened browser session."""
         browser_id = str(agent_config.get("browser_id") or "")
         if browser_id in SELF_LAUNCH_BROWSER_IDS:
             warn_if_local_proxy_unsupported(agent_config, self.name)
-            return self._execute(task_info, agent_config, task_workspace, cdp_url=None)
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=None, attempt=attempt)
         with open_browser_session(
             browser_id=browser_id,
             agent_name=self.name,
@@ -343,7 +396,9 @@ class OpenClawAgent(CLIAgent):
                 return self._unsupported_backend_result(
                     task_info["task_id"], browser_id, session_context.transport
                 )
-            return self._execute(task_info, agent_config, task_workspace, cdp_url=cdp_url)
+            return self._execute(
+                task_info, agent_config, task_workspace, cdp_url=cdp_url, attempt=attempt
+            )
 
     def _unsupported_backend_result(
         self, task_id: str, browser_id: str, transport: str
@@ -368,6 +423,7 @@ class OpenClawAgent(CLIAgent):
         agent_config: dict[str, Any],
         task_workspace: Path,
         cdp_url: str | None,
+        attempt: int = 0,
     ) -> AgentResult:
         task_id = task_info["task_id"]
         prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
@@ -379,7 +435,7 @@ class OpenClawAgent(CLIAgent):
         trajectory_dir.mkdir(parents=True, exist_ok=True)
         state_dir = task_workspace / ".openclaw-state"
         self._write_state_config(agent_config, task_workspace, state_dir, model, cdp_url)
-        cmd = self._build_command(f"{rules}\n\n{prompt}", task_id, timeout)
+        cmd = self._build_command(f"{rules}\n\n{prompt}", task_id, timeout, attempt)
 
         env = {**os.environ}
         env["OPENCLAW_STATE_DIR"] = str(state_dir)
@@ -494,41 +550,33 @@ class OpenClawAgent(CLIAgent):
                 # Tool whitelist: browsing plus reading bundled skill files.
                 "list": [{"id": "main", "tools": {"allow": ["browser", "read"]}}],
             },
-            "browser": {"enabled": True, "ssrfPolicy": dict(_BROWSER_SSRF_POLICY)},
+            "browser": _browser_config(cdp_url),
             # Default "auto" consults gateway node.list before the in-process
             # browser service; without gateway credentials every browser call
             # fails ("gateway node.list requires credentials before opening a
             # websocket"). Force local dispatch.
             "gateway": {"nodes": {"browser": {"mode": "off"}}},
         }
-        if cdp_url:
-            bench_profile = {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"}
-            config["browser"] = {
-                "enabled": True,
-                "ssrfPolicy": dict(_BROWSER_SSRF_POLICY),
-                "defaultProfile": "bench",
-                # OpenClaw auto-injects built-in `user`/`openclaw` profiles
-                # (operator's local Chrome) unless the config defines those
-                # names; models sometimes pass them explicitly and escape the
-                # bench browser. Pin both to the bench CDP endpoint.
-                "profiles": {
-                    "bench": bench_profile,
-                    "user": dict(bench_profile),
-                    "openclaw": dict(bench_profile),
-                },
-            }
         (state_dir / "openclaw.json").write_text(
             json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8"
         )
 
     @staticmethod
-    def _build_command(full_prompt: str, task_id: str, timeout: int) -> list[str]:
+    def _build_command(
+        full_prompt: str, task_id: str, timeout: int, attempt: int = 0
+    ) -> list[str]:
         exe = "openclaw.cmd" if IS_WINDOWS else "openclaw"
+        # Retries need a fresh session key: reusing it resumes the failed
+        # attempt's transcript, so the model sees its own browser failures
+        # and gives up — and metrics double-count both attempts.
+        session_key = f"agent:main:bench-{task_id}"
+        if attempt:
+            session_key = f"{session_key}-r{attempt}"
         return [
             exe, "agent",
             "--local",   # embedded agent turn, no Gateway service required
             "--json",
-            "--session-key", f"agent:main:bench-{task_id}",
+            "--session-key", session_key,
             "-m", full_prompt,
             "--timeout", str(timeout),
         ]
@@ -577,13 +625,21 @@ class OpenClawAgent(CLIAgent):
                 logger.warning("Failed to generate api_logs for task %s: %s", task_id, exc)
 
         # A "successful" run whose browser never worked is a false success:
-        # the answer is a blocked notice, not a task result.
+        # the answer is a blocked notice, not a task result. Timeouts are
+        # excluded — flipping them would corrupt timeout stats and burn a
+        # second full timeout budget on retry.
         agent_metadata: dict[str, Any] = {}
-        outage = _detect_browser_outage(items, answer) if env_status == "success" else None
+        outage = (
+            _detect_browser_outage(items, answer)
+            if env_status == "success" and agent_done == "done"
+            else None
+        )
         if outage:
             env_status, agent_done = "failed", "error"
             error_message = f"OpenClaw browser tool unavailable ({outage})"
             agent_metadata["browser_outage"] = outage
+            if not answer:
+                answer = f"[Task Failed: {error_message}]"
 
         return AgentResult(
             task_id=task_id,

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -188,6 +188,15 @@ class TestOpenClawAgentRunTask:
 
         state_dir = tmp_path / ".openclaw-state"
         assert captured_env["OPENCLAW_STATE_DIR"] == str(state_dir)
+        # Each task process must get its own gateway port: concurrent tasks
+        # sharing the default 18789 attach to each other's gateway and fail
+        # browser auth ("gateway node.list requires credentials").
+        gateway_port = int(captured_env["OPENCLAW_GATEWAY_PORT"])
+        assert 1024 <= gateway_port <= 65535
+        assert gateway_port != 18789
+        # A configured gateway token makes OpenClaw treat the gateway as
+        # external and skip its in-process browser service; must NOT be set.
+        assert "OPENCLAW_GATEWAY_TOKEN" not in captured_env
         cfg = json.loads((state_dir / "openclaw.json").read_text())
         provider = cfg["models"]["providers"]["bench"]
         assert provider["baseUrl"] == "https://llm.example/v1"
@@ -227,7 +236,26 @@ class TestOpenClawAgentRunTask:
         assert profile["cdpUrl"] == "wss://cdp.example/1"
         assert profile["attachOnly"] is True
         assert cfg["browser"]["defaultProfile"] == "bench"
+        # OpenClaw auto-injects built-in `user`/`openclaw` profiles (operator's
+        # local Chrome) unless the config defines those names; models sometimes
+        # pass them explicitly and escape the bench browser. Pin both to the
+        # bench CDP endpoint.
+        for alias in ("user", "openclaw"):
+            assert cfg["browser"]["profiles"][alias]["cdpUrl"] == "wss://cdp.example/1"
+            assert cfg["browser"]["profiles"][alias]["attachOnly"] is True
         assert result.env_status == "success"
+
+    def test_gateway_browser_node_dispatch_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Default gateway.nodes.browser.mode="auto" consults gateway node.list
+        # before the in-process service; without gateway credentials every
+        # browser call fails ("gateway node.list requires credentials").
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(), None))
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
+        assert cfg["gateway"]["nodes"]["browser"]["mode"] == "off"
 
     def test_non_cdp_backend_fails_fast(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -243,6 +243,11 @@ class TestOpenClawAgentRunTask:
         for alias in ("user", "openclaw"):
             assert cfg["browser"]["profiles"][alias]["cdpUrl"] == "wss://cdp.example/1"
             assert cfg["browser"]["profiles"][alias]["attachOnly"] is True
+        # Local fake-IP proxy clients resolve proxied domains to the RFC 2544
+        # benchmark range (198.18.0.0/15); OpenClaw's local SSRF preflight then
+        # blocks navigation even though navigation happens in the remote CDP
+        # browser. Only the CDP path disables it (see the non-CDP test).
+        assert cfg["browser"]["ssrfPolicy"]["dangerouslyAllowPrivateNetwork"] is True
         assert result.env_status == "success"
 
     def test_gateway_browser_node_dispatch_disabled(
@@ -256,11 +261,6 @@ class TestOpenClawAgentRunTask:
         agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
         cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
         assert cfg["gateway"]["nodes"]["browser"]["mode"] == "off"
-        # Local fake-IP proxy clients resolve proxied domains to the RFC 2544
-        # benchmark range (198.18.0.0/15); OpenClaw's local SSRF preflight then
-        # blocks navigation ("browser navigation blocked by policy") even
-        # though the real navigation happens in the remote CDP browser.
-        assert cfg["browser"]["ssrfPolicy"]["dangerouslyAllowPrivateNetwork"] is True
 
     def test_non_cdp_backend_fails_fast(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -480,3 +480,127 @@ class TestBrowserOutageRetry:
         result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
         assert len(calls) == 1
         assert result.env_status == "success"
+
+
+class TestOutageRetryHardening:
+    """Review findings: the retry must be genuinely fresh and well-scoped."""
+
+    def _blocked_and_good(self, tmp_path: Path) -> tuple[Path, Path]:
+        blocked = tmp_path / "blocked.jsonl"
+        _write_blocked_session(blocked)
+        good = tmp_path / "good.jsonl"
+        _write_session(good)
+        return blocked, good
+
+    def test_retry_uses_a_fresh_session_key(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Reusing the session key resumes attempt 1's transcript: the model
+        # sees its own failures and gives up without touching the browser,
+        # and usage/steps double-count across attempts.
+        blocked, good = self._blocked_and_good(tmp_path)
+        cmds: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            cmds.append(cmd)
+            session = blocked if len(cmds) == 1 else good
+            return 0, _result_stdout(session, answer="[blocked]" if len(cmds) == 1 else "ok"), None
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        key1 = cmds[0][cmds[0].index("--session-key") + 1]
+        key2 = cmds[1][cmds[1].index("--session-key") + 1]
+        assert key1 != key2
+
+    def test_dangling_tool_call_does_not_mask_outage(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A browser call whose toolResult never arrived is unknown, not
+        # evidence of a working browser.
+        session = tmp_path / "dangling.jsonl"
+        lines = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "c1", "name": "browser",
+                 "arguments": {"action": "open", "url": "https://example.com"}},
+                {"type": "toolCall", "id": "c2", "name": "browser",
+                 "arguments": {"action": "open", "url": "https://example.com"}},
+            ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+                "toolName": "browser", "content": [{"type": "text", "text": _OUTAGE_TEXT}]}},
+            # c2 never gets a toolResult (stop_predicate raced the write)
+        ]
+        session.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            calls.append(1)
+            return 0, _result_stdout(session, answer="[blocked] browser down"), None
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 2  # outage detected despite the dangling call
+        assert result.env_status == "failed"
+
+    def test_timeout_results_are_not_flipped_or_retried(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        blocked = tmp_path / "blocked.jsonl"
+        _write_blocked_session(blocked)
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], str]:
+            calls.append(1)
+            return -1, _result_stdout(blocked, answer="partial"), "Timeout after 10 seconds"
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 1
+        assert result.agent_done == "timeout"
+
+    def test_outage_retries_zero_disables_retry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        blocked = tmp_path / "blocked.jsonl"
+        _write_blocked_session(blocked)
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            calls.append(1)
+            return 0, _result_stdout(blocked, answer="[blocked]"), None
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, {**AGENT_CONFIG, "outage_retries": 0}, tmp_path)
+        assert len(calls) == 1
+        assert result.env_status == "failed"
+
+    def test_successful_retry_is_recorded_in_metadata(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        blocked, good = self._blocked_and_good(tmp_path)
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            calls.append(1)
+            session = blocked if len(calls) == 1 else good
+            return 0, _result_stdout(session, answer="[blocked]" if len(calls) == 1 else "ok"), None
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "success"
+        assert result.agent_metadata.get("outage_retried") == 1
+
+    def test_ssrf_policy_only_for_cdp_browsers(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # The SSRF preflight is meaningless for a REMOTE CDP browser, but for
+        # a locally launched browser it is a real guard and must stay on.
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(), None))
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
+        assert "ssrfPolicy" not in cfg["browser"]

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -256,6 +256,11 @@ class TestOpenClawAgentRunTask:
         agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
         cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
         assert cfg["gateway"]["nodes"]["browser"]["mode"] == "off"
+        # Local fake-IP proxy clients resolve proxied domains to the RFC 2544
+        # benchmark range (198.18.0.0/15); OpenClaw's local SSRF preflight then
+        # blocks navigation ("browser navigation blocked by policy") even
+        # though the real navigation happens in the remote CDP browser.
+        assert cfg["browser"]["ssrfPolicy"]["dangerouslyAllowPrivateNetwork"] is True
 
     def test_non_cdp_backend_fails_fast(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -381,3 +386,97 @@ class TestUsageFromTotalOnly:
         usage = OpenClawAgent._usage_from(result_obj)
         assert usage is not None
         assert usage.total_tokens == 5000
+
+
+_OUTAGE_TEXT = (
+    "browser failed: gateway node.list requires credentials before opening a websocket"
+)
+
+
+def _write_blocked_session(path: Path) -> None:
+    lines = [
+        {"type": "message", "message": {"role": "assistant", "content": [
+            {"type": "toolCall", "id": "c1", "name": "browser",
+             "arguments": {"action": "open", "url": "https://example.com"}},
+        ]}},
+        {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+            "toolName": "browser", "content": [{"type": "text", "text": _OUTAGE_TEXT}]}},
+    ]
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+
+class TestBrowserOutageRetry:
+    """A run whose every browser call lost the service-startup race is a false
+    success: detect it, retry once on a fresh session, else mark failed."""
+
+    def test_outage_retried_once_to_success(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        blocked = tmp_path / "blocked.jsonl"
+        _write_blocked_session(blocked)
+        good = tmp_path / "good.jsonl"
+        _write_session(good)
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            calls.append(1)
+            if len(calls) == 1:
+                return 0, _result_stdout(blocked, answer="[blocked] browser unavailable"), None
+            return 0, _result_stdout(good), None
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 2
+        assert result.env_status == "success"
+        assert result.answer == "The price is $42"
+
+    def test_outage_on_both_attempts_marks_failed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        blocked = tmp_path / "blocked.jsonl"
+        _write_blocked_session(blocked)
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            calls.append(1)
+            return 0, _result_stdout(blocked, answer="[blocked] browser unavailable"), None
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 2
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "browser" in (result.error or "").lower()
+
+    def test_successful_browser_calls_are_not_outage(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A session with a real successful browser call must not be retried
+        # even if one call failed with an outage-looking error.
+        session = tmp_path / "mixed.jsonl"
+        lines = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "c1", "name": "browser",
+                 "arguments": {"action": "open", "url": "https://example.com"}},
+                {"type": "toolCall", "id": "c2", "name": "browser",
+                 "arguments": {"action": "snapshot"}},
+            ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+                "toolName": "browser", "content": [{"type": "text", "text": _OUTAGE_TEXT}]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c2",
+                "toolName": "browser", "content": [{"type": "text", "text": "page snapshot ok"}]}},
+        ]
+        session.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            calls.append(1)
+            return 0, _result_stdout(session), None
+
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 1
+        assert result.env_status == "success"


### PR DESCRIPTION
## Problem

At concurrency 10, openclaw tasks lose their browser almost universally: models get tool errors within seconds, wrap the outage into a "[blocked] ..." text answer, and the bench records env_status=success — 16/20 false successes in a raw concurrent batch vs 18/20 real completions serially.

Root cause is a startup race (the model's first browser call beats the in-process browser control service), and every fallback path then fails differently:

1. `gateway.nodes.browser.mode` defaults to `"auto"` → browser calls consult gateway `node.list` → "gateway node.list requires credentials before opening a websocket".
2. Concurrent tasks share gateway port 18789 → they attach to each other's (or a resident OpenClaw.app's) gateway.
3. Built-in `user`/`openclaw` profiles (operator's local Chrome) let models escape the bench browser when they pass a profile explicitly.

## Fix

- `gateway.nodes.browser.mode: "off"` in the generated per-task openclaw.json (force in-process dispatch).
- Pin `user`/`openclaw` profiles to the bench CDP endpoint.
- Allocate a free `OPENCLAW_GATEWAY_PORT` per task. Deliberately NOT setting `OPENCLAW_GATEWAY_TOKEN` — configured credentials flip OpenClaw into external-gateway mode and it skips starting its in-process browser service (verified: every call then dies with 1006 abnormal closures).
- Rules exception: retry browser CONNECTION errors up to 5 times (each retry is an LLM round-trip that buys service-startup time); page-level blocks keep the existing one-retry cap.

## Measured (LexBench-Browser first_n=20, concurrency 10, gpt-5.5; "real" = actually browsed, not a "[blocked]" answer)

| config | real completions |
|---|---|
| serial baseline (gpt-5.4) | 18/20 |
| raw concurrent | 4/20 |
| + port isolation + retry rules | 6/20 |
| + node dispatch off + pinned profiles (this PR) | **15/20** |

Remaining gap = first-wave startup race; recovering those needs adapter-level blocked-answer detection + one task retry (tracked separately). Run evidence: experiments/.../openclaw/gpt-5.5/20260703_232733 (8.2M real tokens across the 15 completions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)