### PR TITLE
fix(openclaw): stop provider env leak, disable image understanding, save base64 screenshots

### DIFF
--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -423,6 +423,10 @@ class OpenClawAgent(CLIAgent):
                 "list": [{"id": "main", "tools": {"allow": ["browser", "read"]}}],
             },
             "browser": {"enabled": True},
+            # Screenshots would otherwise trigger image understanding, which
+            # auto-detects an image model and burns a failing LLM call per
+            # image; the bench model gets no vision either way, so turn it off.
+            "tools": {"media": {"image": {"enabled": False}}},
         }
         if cdp_url:
             config["browser"] = {

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -54,6 +54,27 @@ _DEFAULT_RULES = (
 
 _MEDIA_PATH_RE = re.compile(r"MEDIA:(\S+)")
 
+# Non-*_API_KEY env vars that also trigger OpenClaw provider auto-detection.
+_PROVIDER_ENV_EXTRAS = ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")
+
+
+def _subprocess_env(state_dir: Path) -> dict[str, str]:
+    """Build the OpenClaw subprocess env without provider-autodetect vars.
+
+    The bench provider's credentials are delivered via the written
+    openclaw.json; any *_API_KEY (or Anthropic base-url/auth-token) inherited
+    from the parent env makes OpenClaw auto-detect an extra provider and route
+    media understanding through it, which fails on the bench gateway.
+    """
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.endswith("_API_KEY") and key not in _PROVIDER_ENV_EXTRAS
+    }
+    env["OPENCLAW_STATE_DIR"] = str(state_dir)
+    env["OPENCLAW_CONFIG_PATH"] = str(state_dir / "openclaw.json")
+    return env
+
 
 def _stdout_json(stdout_lines: list[str]) -> dict[str, Any] | None:
     """Parse the accumulated stdout as one JSON object, or None when incomplete."""
@@ -297,9 +318,7 @@ class OpenClawAgent(CLIAgent):
         self._write_state_config(agent_config, task_workspace, state_dir, model, cdp_url)
         cmd = self._build_command(f"{rules}\n\n{prompt}", task_id, timeout)
 
-        env = {**os.environ}
-        env["OPENCLAW_STATE_DIR"] = str(state_dir)
-        env["OPENCLAW_CONFIG_PATH"] = str(state_dir / "openclaw.json")
+        env = _subprocess_env(state_dir)
 
         logger.info(
             "Executing OpenClaw for task %s (model=%s, timeout=%ds)", task_id, model, timeout

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -10,6 +10,8 @@ browser profile with `cdpUrl` + `attachOnly`.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
 import os
@@ -53,6 +55,8 @@ _DEFAULT_RULES = (
 )
 
 _MEDIA_PATH_RE = re.compile(r"MEDIA:(\S+)")
+
+_MEDIA_MIME_EXT = {"image/png": ".png", "image/jpeg": ".jpeg", "image/jpg": ".jpg"}
 
 # Non-*_API_KEY env vars that also trigger OpenClaw provider auto-detection.
 _PROVIDER_ENV_EXTRAS = ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")
@@ -175,6 +179,10 @@ def _fold_message(
         media_path = _image_block_path(block)
         if media_path:
             texts.append(f"MEDIA:{media_path}")
+            continue
+        inline = _inline_image_data(block)
+        if inline:
+            item.setdefault("inline_media", []).append(inline)
     item["status"] = "completed"
     item["result"] = {"content": [{"type": "text", "text": "\n".join(texts)}]}
 
@@ -191,6 +199,16 @@ def _image_block_path(block: dict[str, Any]) -> str | None:
     if isinstance(source, dict) and isinstance(source.get("path"), str):
         return source["path"]
     return None
+
+
+def _inline_image_data(block: dict[str, Any]) -> tuple[str, str] | None:
+    """Return (mime_type, base64_data) from an inline image/media block."""
+    if block.get("type") not in ("image", "media"):
+        return None
+    data = block.get("data")
+    if not isinstance(data, str) or not data:
+        return None
+    return str(block.get("mimeType") or "image/png"), data
 
 
 def _normalize_tool_call(block: dict[str, Any]) -> dict[str, Any]:
@@ -216,16 +234,39 @@ def _normalize_tool_call(block: dict[str, Any]) -> dict[str, Any]:
 
 
 def _collect_media_screenshots(items: list[dict[str, Any]], trajectory_dir: Path) -> list[str]:
-    """Copy MEDIA:<path> screenshot files referenced by tool results into trajectory/."""
+    """Save screenshots referenced by tool results into trajectory/.
+
+    Handles both MEDIA:<path> file references and inline base64 image blocks
+    (popped off the item so the raw data never reaches api_logs).
+    """
     saved: list[str] = []
     for item in items:
         result = item.get("result")
-        if not isinstance(result, dict):
-            continue
-        for block in result.get("content", []):
-            if isinstance(block, dict):
-                _copy_media_paths(str(block.get("text", "")), trajectory_dir, saved)
+        if isinstance(result, dict):
+            for block in result.get("content", []):
+                if isinstance(block, dict):
+                    _copy_media_paths(str(block.get("text", "")), trajectory_dir, saved)
+        for mime, data in item.pop("inline_media", []):
+            _save_inline_media(mime, data, trajectory_dir, saved)
     return saved
+
+
+def _save_inline_media(mime: str, data: str, trajectory_dir: Path, saved: list[str]) -> None:
+    ext = _MEDIA_MIME_EXT.get(mime.lower())
+    if ext is None:
+        return
+    try:
+        raw = base64.b64decode(data, validate=True)
+    except binascii.Error as exc:
+        logger.warning("Failed to decode inline screenshot (%s): %s", mime, exc)
+        return
+    fname = f"screenshot-{len(saved) + 1}{ext}"
+    try:
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+        (trajectory_dir / fname).write_bytes(raw)
+        saved.append(fname)
+    except OSError as exc:
+        logger.warning("Failed to save screenshot %s: %s", fname, exc)
 
 
 def _copy_media_paths(text: str, trajectory_dir: Path, saved: list[str]) -> None:

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -10,8 +10,6 @@ browser profile with `cdpUrl` + `attachOnly`.
 
 from __future__ import annotations
 
-import base64
-import binascii
 import json
 import logging
 import os
@@ -34,6 +32,7 @@ from browseruse_bench.browsers import open_browser_session
 from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
 from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
 from browseruse_bench.utils import IS_WINDOWS
+from browseruse_bench.utils.image_utils import decode_base64_to_file
 from browseruse_bench.utils.parse_utils import safe_int
 
 logger = logging.getLogger(__name__)
@@ -58,22 +57,24 @@ _MEDIA_PATH_RE = re.compile(r"MEDIA:(\S+)")
 
 _MEDIA_MIME_EXT = {"image/png": ".png", "image/jpeg": ".jpeg", "image/jpg": ".jpg"}
 
-# Non-*_API_KEY env vars that also trigger OpenClaw provider auto-detection.
-_PROVIDER_ENV_EXTRAS = ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")
+# OpenClaw also resolves Anthropic credentials/endpoints from non-*_API_KEY
+# vars (ANTHROPIC_OAUTH_TOKEN, ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL, ...),
+# so the whole prefix is scrubbed.
+_PROVIDER_ENV_PREFIX = "ANTHROPIC_"
 
 
 def _subprocess_env(state_dir: Path) -> dict[str, str]:
     """Build the OpenClaw subprocess env without provider-autodetect vars.
 
     The bench provider's credentials are delivered via the written
-    openclaw.json; any *_API_KEY (or Anthropic base-url/auth-token) inherited
-    from the parent env makes OpenClaw auto-detect an extra provider and route
-    media understanding through it, which fails on the bench gateway.
+    openclaw.json; any *_API_KEY (or ANTHROPIC_* credential/endpoint var)
+    inherited from the parent env makes OpenClaw auto-detect an extra provider
+    and route media understanding through it, which fails on the bench gateway.
     """
     env = {
         key: value
         for key, value in os.environ.items()
-        if not key.endswith("_API_KEY") and key not in _PROVIDER_ENV_EXTRAS
+        if not key.endswith("_API_KEY") and not key.startswith(_PROVIDER_ENV_PREFIX)
     }
     env["OPENCLAW_STATE_DIR"] = str(state_dir)
     env["OPENCLAW_CONFIG_PATH"] = str(state_dir / "openclaw.json")
@@ -254,19 +255,16 @@ def _collect_media_screenshots(items: list[dict[str, Any]], trajectory_dir: Path
 def _save_inline_media(mime: str, data: str, trajectory_dir: Path, saved: list[str]) -> None:
     ext = _MEDIA_MIME_EXT.get(mime.lower())
     if ext is None:
-        return
-    try:
-        raw = base64.b64decode(data, validate=True)
-    except binascii.Error as exc:
-        logger.warning("Failed to decode inline screenshot (%s): %s", mime, exc)
+        logger.debug("Skipping inline media with unsupported mime type: %s", mime)
         return
     fname = f"screenshot-{len(saved) + 1}{ext}"
     try:
         trajectory_dir.mkdir(parents=True, exist_ok=True)
-        (trajectory_dir / fname).write_bytes(raw)
-        saved.append(fname)
     except OSError as exc:
-        logger.warning("Failed to save screenshot %s: %s", fname, exc)
+        logger.warning("Failed to create trajectory dir for %s: %s", fname, exc)
+        return
+    if decode_base64_to_file(data, trajectory_dir / fname):
+        saved.append(fname)
 
 
 def _copy_media_paths(text: str, trajectory_dir: Path, saved: list[str]) -> None:
@@ -528,6 +526,8 @@ class OpenClawAgent(CLIAgent):
             answer = f"[Task Failed: {error_message or 'No result JSON from OpenClaw'}]"
 
         items = self._session_items(result_obj, task_workspace)
+        # Must run before write_api_logs: it pops inline base64 blobs off the
+        # items so they never reach the api_logs artifacts.
         saved_screenshots = _collect_media_screenshots(items, trajectory_dir)
         steps = sum(1 for item in items if item.get("type") in STEP_ITEM_TYPES)
         if items:

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -202,6 +202,34 @@ class TestOpenClawAgentRunTask:
         # include_usage to custom providers, so token usage is all zeros.
         assert provider["models"][0]["compat"] == {"supportsUsageInStreaming": True}
 
+    def test_provider_autodetect_vars_scrubbed_from_subprocess_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # OpenClaw auto-detects providers from *_API_KEY / ANTHROPIC_* env vars
+        # and routes media understanding through them; the bench provider gets
+        # its credentials via the written openclaw.json, so none may leak.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-leak")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://gateway.local")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-leak")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-leak")
+        monkeypatch.setenv("BENCH_HARMLESS_VAR", "keep-me")
+        agent = OpenClawAgent()
+        captured_env: dict[str, str] = {}
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            captured_env.update(kw.get("env") or {})
+            return 0, _result_stdout(), None
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+
+        assert "ANTHROPIC_API_KEY" not in captured_env
+        assert "ANTHROPIC_BASE_URL" not in captured_env
+        assert "ANTHROPIC_AUTH_TOKEN" not in captured_env
+        assert "OPENAI_API_KEY" not in captured_env
+        assert captured_env["BENCH_HARMLESS_VAR"] == "keep-me"
+        assert captured_env["OPENCLAW_STATE_DIR"] == str(tmp_path / ".openclaw-state")
+
     def test_cdp_url_written_as_attach_profile(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -116,6 +116,65 @@ class TestCollectMediaScreenshots:
         assert _collect_media_screenshots(items, tmp_path / "trajectory") == []
 
 
+class TestInlineBase64Screenshots:
+    @staticmethod
+    def _session_with_inline_image(path: Path, data: str, mime: str = "image/png") -> None:
+        lines = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "c1", "name": "browser", "arguments": {"action": "screenshot"}},
+            ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1", "toolName": "browser",
+                "content": [{"type": "image", "data": data, "mimeType": mime}]}},
+        ]
+        path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+    def test_inline_base64_image_saved_to_trajectory(self, tmp_path: Path) -> None:
+        # OpenClaw returns screenshots as inline base64 blocks (no path key);
+        # they must be decoded into trajectory/ like path-based media.
+        import base64
+
+        payload = b"png-bytes"
+        session = tmp_path / "session.jsonl"
+        self._session_with_inline_image(session, base64.b64encode(payload).decode())
+        items = _normalize_session_items(session)
+        saved = _collect_media_screenshots(items, tmp_path / "trajectory")
+        assert saved == ["screenshot-1.png"]
+        assert (tmp_path / "trajectory" / "screenshot-1.png").read_bytes() == payload
+        # The raw base64 must not linger on items (it would bloat api_logs).
+        assert all("inline_media" not in item for item in items)
+
+    def test_invalid_base64_skipped(self, tmp_path: Path) -> None:
+        session = tmp_path / "session.jsonl"
+        self._session_with_inline_image(session, "not-valid-base64!!!")
+        items = _normalize_session_items(session)
+        assert _collect_media_screenshots(items, tmp_path / "trajectory") == []
+
+    def test_non_image_mime_skipped(self, tmp_path: Path) -> None:
+        import base64
+
+        session = tmp_path / "session.jsonl"
+        self._session_with_inline_image(
+            session, base64.b64encode(b"pdf").decode(), mime="application/pdf"
+        )
+        items = _normalize_session_items(session)
+        assert _collect_media_screenshots(items, tmp_path / "trajectory") == []
+
+    def test_run_task_reports_inline_screenshots(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import base64
+
+        session = tmp_path / "session.jsonl"
+        self._session_with_inline_image(session, base64.b64encode(b"shot").decode())
+        agent = OpenClawAgent()
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(session), None)
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.screenshots == ["screenshot-1.png"]
+        assert (tmp_path / "trajectory" / "screenshot-1.png").read_bytes() == b"shot"
+
+
 class TestOpenClawAgentRunTask:
     def test_successful_run_returns_answer(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -202,6 +202,18 @@ class TestOpenClawAgentRunTask:
         # include_usage to custom providers, so token usage is all zeros.
         assert provider["models"][0]["compat"] == {"supportsUsageInStreaming": True}
 
+    def test_media_understanding_disabled_in_state_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Screenshots would otherwise trigger OpenClaw's image understanding,
+        # which auto-detects an image model and burns a failing LLM call per
+        # image; the bench model gets no vision either way, so turn it off.
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(), None))
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
+        assert cfg["tools"]["media"]["image"]["enabled"] is False
+
     def test_provider_autodetect_vars_scrubbed_from_subprocess_env(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 from typing import Any
@@ -131,8 +132,6 @@ class TestInlineBase64Screenshots:
     def test_inline_base64_image_saved_to_trajectory(self, tmp_path: Path) -> None:
         # OpenClaw returns screenshots as inline base64 blocks (no path key);
         # they must be decoded into trajectory/ like path-based media.
-        import base64
-
         payload = b"png-bytes"
         session = tmp_path / "session.jsonl"
         self._session_with_inline_image(session, base64.b64encode(payload).decode())
@@ -150,8 +149,6 @@ class TestInlineBase64Screenshots:
         assert _collect_media_screenshots(items, tmp_path / "trajectory") == []
 
     def test_non_image_mime_skipped(self, tmp_path: Path) -> None:
-        import base64
-
         session = tmp_path / "session.jsonl"
         self._session_with_inline_image(
             session, base64.b64encode(b"pdf").decode(), mime="application/pdf"
@@ -162,8 +159,6 @@ class TestInlineBase64Screenshots:
     def test_run_task_reports_inline_screenshots(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        import base64
-
         session = tmp_path / "session.jsonl"
         self._session_with_inline_image(session, base64.b64encode(b"shot").decode())
         agent = OpenClawAgent()
@@ -282,6 +277,7 @@ class TestOpenClawAgentRunTask:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-leak")
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://gateway.local")
         monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-leak")
+        monkeypatch.setenv("ANTHROPIC_OAUTH_TOKEN", "oauth-leak")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-leak")
         monkeypatch.setenv("BENCH_HARMLESS_VAR", "keep-me")
         agent = OpenClawAgent()
@@ -297,6 +293,7 @@ class TestOpenClawAgentRunTask:
         assert "ANTHROPIC_API_KEY" not in captured_env
         assert "ANTHROPIC_BASE_URL" not in captured_env
         assert "ANTHROPIC_AUTH_TOKEN" not in captured_env
+        assert "ANTHROPIC_OAUTH_TOKEN" not in captured_env
         assert "OPENAI_API_KEY" not in captured_env
         assert captured_env["BENCH_HARMLESS_VAR"] == "keep-me"
         assert captured_env["OPENCLAW_STATE_DIR"] == str(tmp_path / ".openclaw-state")


### PR DESCRIPTION
## Problem

The openclaw agent launched the CLI with the full parent environment, including `ANTHROPIC_API_KEY`/`ANTHROPIC_BASE_URL` preloaded from the repo `.env`. OpenClaw auto-detected an anthropic provider from those vars and routed media understanding (image description) through `anthropic/claude-opus-4-8`, which always fails through the bench LiteLLM gateway — every screenshot-bearing task logged `[media-understanding] image: failed` and burned a failing gateway round-trip per image (8/20 tasks in run `20260703_224231`).

## Changes (4 commits)

1. **`382d63f` env scrub** — `_subprocess_env()` builds the subprocess env without any `*_API_KEY` vars or `ANTHROPIC_*` vars. The bench provider's credentials are delivered via the written per-task `openclaw.json`, so the subprocess needs none of them. Gateway pairing vars (`OPENCLAW_GATEWAY_TOKEN/PASSWORD`) are unaffected.
2. **`caedb92` media understanding off** — even with no leaked key, OpenClaw's auto-detect still attempts an image model per screenshot and fails with `ProviderAuthError`; `tools.media.image.enabled=false` in the per-task config skips the attempt entirely (the bench model is registered text-only, so image descriptions were never available).
3. **`50b9a23` base64 screenshots** — OpenClaw returns screenshots as inline base64 image blocks (no path key), so `result.screenshots` was always empty (0 screenshots across 41 tasks in all 2026-07-03 runs). Inline blocks are now decoded into `trajectory/screenshot-N.<ext>` and popped off the items so the raw base64 never reaches `api_logs`.
4. **`fe8ce9c` code-review fixes** — scrub the whole `ANTHROPIC_` prefix (OpenClaw also reads `ANTHROPIC_OAUTH_TOKEN`/`ANTHROPIC_API_TOKEN` as credentials); reuse `utils.image_utils.decode_base64_to_file` instead of duplicating decode logic; log skipped mime types; document the collect-before-`write_api_logs` ordering invariant; move test imports to module top.

## Tests

- 9 new targeted tests (env scrub, media config, inline base64 decode incl. invalid-base64 / non-image-mime negatives, run_task-level screenshots); `tests/browseruse_bench/test_openclaw_agent.py` 25/25 green.

## Smoke (per error-handling-testing.md)

`bubench run --agent openclaw --data LexBench-Browser --mode single` on lexmount, model gpt-5.4, after each commit. Final run `20260704_003342`: task success, 12 steps, full browse of xiachufang with real answer, **3 screenshots saved (incl. one .jpeg through the shared decode helper)**, stderr contains **zero** `media-understanding`/anthropic lines (pre-fix baseline: 8/20 tasks failing).

## Note for reviewers

There is in-flight uncommitted work in the local main repo (per-task `OPENCLAW_GATEWAY_PORT`, `gateway.nodes.browser.mode=off`, profile pinning) that touches the same `_execute` env block. The two compose cleanly — verified in a combined run (`20260703_235457`) — but whichever lands second will hit a small textual conflict there; resolution is `env = _subprocess_env(state_dir)` first, then `env["OPENCLAW_GATEWAY_PORT"] = ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)