### PR TITLE
fix(openclaw): merge scoring-run patch — CLI compat, output recovery, process-group cleanup, runner watchdog

### DIFF
--- a/browseruse_bench/agents/cli_agent.py
+++ b/browseruse_bench/agents/cli_agent.py
@@ -10,6 +10,7 @@ from this class instead of BaseAgent directly. It provides:
 
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import subprocess
@@ -22,6 +23,33 @@ from typing import TextIO
 
 from browseruse_bench.agents.base import BaseAgent
 from browseruse_bench.utils import IS_WINDOWS
+
+logger = logging.getLogger(__name__)
+
+
+def _escalate_stop(
+    process: subprocess.Popen,
+    signal_group: Callable[[int], None],
+    early_grace_seconds: float,
+    kill_grace_seconds: float,
+) -> int:
+    """Wait for a process already sent SIGTERM, escalating to SIGKILL.
+
+    Returns the exit code, or -1 when the process outlives even the
+    post-SIGKILL grace (e.g. stuck in uninterruptible I/O) — never raises,
+    so a captured result is not lost to a shutdown hiccup.
+    """
+    try:
+        return process.wait(timeout=early_grace_seconds)
+    except subprocess.TimeoutExpired:
+        signal_group(getattr(signal, "SIGKILL", signal.SIGTERM))
+    try:
+        return process.wait(timeout=kill_grace_seconds)
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "Process %s survived SIGKILL for %ss; abandoning wait", process.pid, kill_grace_seconds
+        )
+        return -1
 
 
 class CLIAgent(BaseAgent):
@@ -119,6 +147,9 @@ class CLIAgent(BaseAgent):
                 }
                 if terminate_process_group:
                     if IS_WINDOWS:
+                        # Known limitation: without a CTRL_BREAK_EVENT sender
+                        # only the direct child is terminated on Windows;
+                        # helper processes are reaped by the runner watchdog.
                         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
                     else:
                         popen_kwargs["start_new_session"] = True
@@ -132,8 +163,11 @@ class CLIAgent(BaseAgent):
                             return
                         except ProcessLookupError:
                             return
-                        except OSError:
-                            pass
+                        except OSError as exc:
+                            logger.error(
+                                "killpg(%s, %s) failed: %s; falling back to the direct child",
+                                process.pid, sig, exc,
+                            )
                     with suppress(ProcessLookupError, OSError):
                         kill_signal = getattr(signal, "SIGKILL", None)
                         if kill_signal is not None and sig == kill_signal:
@@ -181,11 +215,10 @@ class CLIAgent(BaseAgent):
                 deadline = time.monotonic() + timeout
                 while True:
                     if stopped_early:
-                        try:
-                            returncode = process.wait(timeout=early_stop_grace_seconds)
-                        except subprocess.TimeoutExpired:
-                            _signal_process_group(getattr(signal, "SIGKILL", signal.SIGTERM))
-                            returncode = process.wait(timeout=kill_grace_seconds)
+                        returncode = _escalate_stop(
+                            process, _signal_process_group,
+                            early_stop_grace_seconds, kill_grace_seconds,
+                        )
                         break
                     if stop_predicate and not stopped_early and stop_predicate(stdout_lines):
                         stopped_early = True
@@ -198,12 +231,10 @@ class CLIAgent(BaseAgent):
                         if time.monotonic() < deadline:
                             continue
                         _signal_process_group(signal.SIGTERM)
-                        try:
-                            process.wait(timeout=early_stop_grace_seconds)
-                        except subprocess.TimeoutExpired:
-                            _signal_process_group(getattr(signal, "SIGKILL", signal.SIGTERM))
-                            with suppress(subprocess.TimeoutExpired):
-                                process.wait(timeout=kill_grace_seconds)
+                        _escalate_stop(
+                            process, _signal_process_group,
+                            early_stop_grace_seconds, kill_grace_seconds,
+                        )
                         execution_error = f"Timeout after {timeout} seconds"
                         returncode = -1
                         break
@@ -211,9 +242,11 @@ class CLIAgent(BaseAgent):
                 t_out.join(timeout=kill_grace_seconds)
                 t_err.join(timeout=kill_grace_seconds)
 
-                if stopped_early:
+                # A drain thread can match the predicate on the dying
+                # process's final output flush AFTER the timeout branch has
+                # already decided; never rewrite a timeout into a success.
+                if stopped_early and execution_error is None:
                     returncode = 0
-                    execution_error = None
 
         except FileNotFoundError:
             raise

--- a/browseruse_bench/agents/cli_agent.py
+++ b/browseruse_bench/agents/cli_agent.py
@@ -10,13 +10,18 @@ from this class instead of BaseAgent directly. It provides:
 
 from __future__ import annotations
 
+import os
+import signal
 import subprocess
+import time
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 from threading import Thread
 from typing import TextIO
 
 from browseruse_bench.agents.base import BaseAgent
+from browseruse_bench.utils import IS_WINDOWS
 
 
 class CLIAgent(BaseAgent):
@@ -36,9 +41,13 @@ class CLIAgent(BaseAgent):
         cwd: Path | None = None,
         env: dict[str, str] | None = None,
         collect_stdout: bool = True,
+        collect_stderr_as_stdout: bool = False,
         stdout_line_hook: Callable[[str], None] | None = None,
         stderr_line_hook: Callable[[str], None] | None = None,
         stop_predicate: Callable[[list[str]], bool] | None = None,
+        terminate_process_group: bool = False,
+        early_stop_grace_seconds: float = 5.0,
+        kill_grace_seconds: float = 5.0,
     ) -> tuple[int, list[str], str | None]:
         """Launch *cmd*, draining stdout/stderr to files in *task_workspace*.
 
@@ -54,6 +63,10 @@ class CLIAgent(BaseAgent):
             collect_stdout: Whether to accumulate stdout lines and return them.
                             Set False when output is written to disk by the
                             child process and parsed later (e.g. Agent-TARS).
+            collect_stderr_as_stdout: Whether to append stderr lines to the
+                            returned line buffer and evaluate stop_predicate on
+                            them. Use only for CLIs that emit their machine
+                            readable result on stderr.
             stdout_line_hook: Called with each raw stdout line for live logging.
             stderr_line_hook: Called with each raw stderr line for live logging.
             stop_predicate: Called with the collected stdout lines after each
@@ -62,6 +75,13 @@ class CLIAgent(BaseAgent):
                             output is complete before the process exits (e.g.
                             a child service keeps it alive). Requires
                             collect_stdout=True.
+            terminate_process_group: Start the subprocess in its own process
+                            group/session and terminate the whole group on
+                            timeout or early stop. Use for CLIs that spawn
+                            long-lived helper processes.
+            early_stop_grace_seconds: Seconds to wait after stop_predicate
+                            matches before force-killing.
+            kill_grace_seconds: Seconds to wait after force-killing.
 
         Returns:
             ``(returncode, stdout_lines, execution_error)``
@@ -87,17 +107,39 @@ class CLIAgent(BaseAgent):
                 open(stderr_file, "w", encoding="utf-8") as f_err,
             ):
                 # FileNotFoundError propagates to caller if exe not found
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    bufsize=1,
-                    cwd=str(cwd) if cwd is not None else None,
-                    env=env,
-                )
+                popen_kwargs: dict[str, object] = {
+                    "stdout": subprocess.PIPE,
+                    "stderr": subprocess.PIPE,
+                    "text": True,
+                    "encoding": "utf-8",
+                    "errors": "replace",
+                    "bufsize": 1,
+                    "cwd": str(cwd) if cwd is not None else None,
+                    "env": env,
+                }
+                if terminate_process_group:
+                    if IS_WINDOWS:
+                        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+                    else:
+                        popen_kwargs["start_new_session"] = True
+
+                process = subprocess.Popen(cmd, **popen_kwargs)
+
+                def _signal_process_group(sig: int) -> None:
+                    if terminate_process_group and not IS_WINDOWS:
+                        try:
+                            os.killpg(process.pid, sig)
+                            return
+                        except ProcessLookupError:
+                            return
+                        except OSError:
+                            pass
+                    with suppress(ProcessLookupError, OSError):
+                        kill_signal = getattr(signal, "SIGKILL", None)
+                        if kill_signal is not None and sig == kill_signal:
+                            process.kill()
+                        else:
+                            process.terminate()
 
                 def _drain_stdout(stream: TextIO, fh: TextIO) -> None:
                     nonlocal stopped_early
@@ -112,36 +154,62 @@ class CLIAgent(BaseAgent):
                             stdout_line_hook(line)
                         if stop_predicate and not stopped_early and stop_predicate(stdout_lines):
                             stopped_early = True
-                            process.terminate()
+                            _signal_process_group(signal.SIGTERM)
                             return
 
                 def _drain_stderr(stream: TextIO, fh: TextIO) -> None:
+                    nonlocal stopped_early
                     for line in iter(stream.readline, ""):
                         if not line:
                             continue
                         fh.write(line)
                         fh.flush()
+                        if collect_stdout and collect_stderr_as_stdout:
+                            stdout_lines.append(line)
                         if stderr_line_hook:
                             stderr_line_hook(line)
+                        if stop_predicate and not stopped_early and stop_predicate(stdout_lines):
+                            stopped_early = True
+                            _signal_process_group(signal.SIGTERM)
+                            return
 
                 t_out = Thread(target=_drain_stdout, args=(process.stdout, f_out))
                 t_err = Thread(target=_drain_stderr, args=(process.stderr, f_err))
                 t_out.start()
                 t_err.start()
 
-                try:
-                    returncode = process.wait(timeout=timeout)
-                except subprocess.TimeoutExpired:
-                    process.terminate()
+                deadline = time.monotonic() + timeout
+                while True:
+                    if stopped_early:
+                        try:
+                            returncode = process.wait(timeout=early_stop_grace_seconds)
+                        except subprocess.TimeoutExpired:
+                            _signal_process_group(getattr(signal, "SIGKILL", signal.SIGTERM))
+                            returncode = process.wait(timeout=kill_grace_seconds)
+                        break
+                    if stop_predicate and not stopped_early and stop_predicate(stdout_lines):
+                        stopped_early = True
+                        _signal_process_group(signal.SIGTERM)
+                        continue
                     try:
-                        process.wait(timeout=5)
+                        returncode = process.wait(timeout=0.25)
+                        break
                     except subprocess.TimeoutExpired:
-                        process.kill()
-                    execution_error = f"Timeout after {timeout} seconds"
-                    returncode = -1
+                        if time.monotonic() < deadline:
+                            continue
+                        _signal_process_group(signal.SIGTERM)
+                        try:
+                            process.wait(timeout=early_stop_grace_seconds)
+                        except subprocess.TimeoutExpired:
+                            _signal_process_group(getattr(signal, "SIGKILL", signal.SIGTERM))
+                            with suppress(subprocess.TimeoutExpired):
+                                process.wait(timeout=kill_grace_seconds)
+                        execution_error = f"Timeout after {timeout} seconds"
+                        returncode = -1
+                        break
 
-                t_out.join(timeout=5)
-                t_err.join(timeout=5)
+                t_out.join(timeout=kill_grace_seconds)
+                t_err.join(timeout=kill_grace_seconds)
 
                 if stopped_early:
                     returncode = 0

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -341,12 +341,63 @@ def _copy_media_paths(text: str, trajectory_dir: Path, saved: list[str]) -> None
             logger.warning("Failed to copy screenshot %s: %s", source, exc)
 
 
+def _terminal_assistant_answer(raw_lines: list[str]) -> tuple[str, dict[str, Any]]:
+    """Return (answer, usage) from the last text-only assistant message.
+
+    Terminal means nothing but tool plumbing follows it: a tool call AFTER a
+    text-only message marks that text as mid-turn commentary, not an answer
+    (returning it would let the stop predicate kill a healthy run).
+    """
+    answer = ""
+    usage: dict[str, Any] = {}
+    for raw_line in raw_lines:
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        message = obj.get("message")
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        has_tool_call = any(
+            isinstance(block, dict) and block.get("type") == "toolCall" for block in content
+        )
+        if has_tool_call:
+            answer, usage = "", {}
+            continue
+        texts = [
+            str(block.get("text", ""))
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text" and block.get("text")
+        ]
+        if texts:
+            answer = "\n".join(texts).strip()
+            raw_usage = message.get("usage")
+            usage = raw_usage if isinstance(raw_usage, dict) else {}
+    return answer, usage
+
+
+def _openclaw_exe() -> str:
+    """The one place that knows the CLI executable name per platform."""
+    return "openclaw.cmd" if IS_WINDOWS else "openclaw"
+
+
+def _session_file_path(task_workspace: Path, session_id: str) -> Path:
+    """The one place that knows OpenClaw's per-task session JSONL layout."""
+    return (
+        task_workspace / ".openclaw-state" / "agents" / "main" / "sessions"
+        / f"{session_id}.jsonl"
+    )
+
+
 @cache
 def _openclaw_cli_version() -> str:
     """One `openclaw --version` per process; compat failures (e.g. rejected
     CLI flags or config fields) are version-dependent, so every result must
     record which CLI it ran against."""
-    exe = "openclaw.cmd" if IS_WINDOWS else "openclaw"
+    exe = _openclaw_exe()
     try:
         proc = subprocess.run(
             [exe, "--version"], capture_output=True, text=True, timeout=30, check=False
@@ -504,11 +555,21 @@ class OpenClawAgent(CLIAgent):
         t_start = time.monotonic()
 
         session_id = self._session_id(task_id, attempt)
+        # The predicate runs per output line; the filesystem fallbacks
+        # (re-reading stdout.txt/stderr.txt and parsing the session JSONL)
+        # are too expensive for that cadence, so probe them at most once a
+        # second — the wait loop re-evaluates every 0.25s regardless.
+        next_probe_at = [0.0]
 
         def _has_result(lines: list[str]) -> bool:
+            if _stdout_json(lines) is not None:
+                return True
+            now = time.monotonic()
+            if now < next_probe_at[0]:
+                return False
+            next_probe_at[0] = now + 1.0
             return (
-                _stdout_json(lines) is not None
-                or self._workspace_json(task_workspace) is not None
+                self._workspace_json(task_workspace) is not None
                 or self._session_result(task_workspace, session_id) is not None
             )
 
@@ -583,6 +644,11 @@ class OpenClawAgent(CLIAgent):
     ) -> None:
         """Write the per-task openclaw.json (provider, workspace, tools, browser)."""
         state_dir.mkdir(parents=True, exist_ok=True)
+        if agent_config.get("llm_timeout"):
+            logger.warning(
+                "llm_timeout is ignored: provider timeoutSeconds was dropped for "
+                "OpenClaw CLI config-schema compatibility"
+            )
         provider_api = str(agent_config.get("api") or "openai-completions")
         # OpenClaw's auto-detection disables streaming usage for custom
         # providers, which zeroes all token accounting; the bench gateway
@@ -653,7 +719,7 @@ class OpenClawAgent(CLIAgent):
         agent_config: dict[str, Any],
         attempt: int = 0,
     ) -> list[str]:
-        exe = "openclaw.cmd" if IS_WINDOWS else "openclaw"
+        exe = _openclaw_exe()
         cmd = [
             # --dev keeps the embedded gateway/browser-control ports off the
             # defaults, so bench runs never collide with an operator's own
@@ -799,42 +865,14 @@ class OpenClawAgent(CLIAgent):
         as the terminal answer so the benchmark can terminate the lingering
         process group and continue.
         """
-        session_file = (
-            task_workspace / ".openclaw-state" / "agents" / "main" / "sessions"
-            / f"{session_id}.jsonl"
-        )
+        session_file = _session_file_path(task_workspace, session_id)
         if not session_file.is_file():
             return None
         try:
             raw_lines = session_file.read_text(encoding="utf-8", errors="replace").splitlines()
         except OSError:
             return None
-
-        answer = ""
-        usage: dict[str, Any] = {}
-        for raw_line in raw_lines:
-            try:
-                obj = json.loads(raw_line)
-            except json.JSONDecodeError:
-                continue
-            message = obj.get("message")
-            if not isinstance(message, dict) or message.get("role") != "assistant":
-                continue
-            content = message.get("content")
-            if not isinstance(content, list):
-                continue
-            has_tool_call = any(
-                isinstance(block, dict) and block.get("type") == "toolCall" for block in content
-            )
-            texts = [
-                str(block.get("text", ""))
-                for block in content
-                if isinstance(block, dict) and block.get("type") == "text" and block.get("text")
-            ]
-            if texts and not has_tool_call:
-                answer = "\n".join(texts).strip()
-                raw_usage = message.get("usage")
-                usage = raw_usage if isinstance(raw_usage, dict) else {}
+        answer, usage = _terminal_assistant_answer(raw_lines)
         if not answer:
             return None
 
@@ -874,11 +912,7 @@ class OpenClawAgent(CLIAgent):
         session_id = agent_meta.get("sessionId") if agent_meta else None
         if not session_id:
             return []
-        fallback = (
-            task_workspace / ".openclaw-state" / "agents" / "main" / "sessions"
-            / f"{session_id}.jsonl"
-        )
-        return _normalize_session_items(fallback)
+        return _normalize_session_items(_session_file_path(task_workspace, str(session_id)))
 
     @staticmethod
     def _usage_from(result_obj: dict[str, Any]) -> AgentUsage | None:

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -16,8 +16,10 @@ import os
 import re
 import shutil
 import socket
+import subprocess
 import time
 from datetime import UTC, datetime
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -339,6 +341,23 @@ def _copy_media_paths(text: str, trajectory_dir: Path, saved: list[str]) -> None
             logger.warning("Failed to copy screenshot %s: %s", source, exc)
 
 
+@cache
+def _openclaw_cli_version() -> str:
+    """One `openclaw --version` per process; compat failures (e.g. rejected
+    CLI flags or config fields) are version-dependent, so every result must
+    record which CLI it ran against."""
+    exe = "openclaw.cmd" if IS_WINDOWS else "openclaw"
+    try:
+        proc = subprocess.run(
+            [exe, "--version"], capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("Could not determine OpenClaw CLI version: %s", exc)
+        return "unknown"
+    lines = (proc.stdout or proc.stderr or "").strip().splitlines()
+    return lines[0].strip() if lines else "unknown"
+
+
 def _normalize_thinking_level(value: Any) -> str | None:
     """Map config reasoning-effort spellings to OpenClaw --thinking levels."""
     if not value:
@@ -378,6 +397,8 @@ class OpenClawAgent(CLIAgent):
         browser-service startup race (every browser call failed with a
         connection error and the "answer" is just a blocked notice).
         """
+        cli_version = self._cli_version()
+        logger.info("OpenClaw CLI version: %s", cli_version)
         retries = max(0, safe_int(agent_config.get("outage_retries", 1), 1))
         result = self._attempt_task(task_info, agent_config, task_workspace, attempt=0)
         for attempt in range(1, retries + 1):
@@ -396,7 +417,12 @@ class OpenClawAgent(CLIAgent):
             result = self._attempt_task(task_info, agent_config, task_workspace, attempt=attempt)
             if isinstance(result, AgentResult) and not result.agent_metadata.get("browser_outage"):
                 result.agent_metadata["outage_retried"] = attempt
+        if isinstance(result, AgentResult):
+            result.agent_metadata["openclaw_cli_version"] = cli_version
         return result
+
+    # Class attribute so tests can patch/clear the process-wide cache.
+    _cli_version = staticmethod(_openclaw_cli_version)
 
     def _attempt_task(
         self,

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -54,17 +54,50 @@ _DEFAULT_RULES = (
 
 _MEDIA_PATH_RE = re.compile(r"MEDIA:(\S+)")
 
+# Failure signature of a transient OpenClaw browser-control outage: the very
+# first browser tool call errors with this text after ~30s and the agent gives
+# up. Adjacent tasks succeed, so one retry on a fresh browser session recovers.
+_GATEWAY_TIMEOUT_SNIPPET = "Restart the OpenClaw gateway"
+_GATEWAY_TIMEOUT_ERROR = "OpenClaw gateway timed out on the first browser tool call"
+_GATEWAY_TIMEOUT_MAX_STEPS = 2
+
+
+def _first_browser_call_gateway_timeout(items: list[dict[str, Any]]) -> bool:
+    """True when the first browser tool call failed with the gateway-timeout signature."""
+    for item in items:
+        if item.get("type") != "mcp_tool_call":
+            continue
+        if not str(item.get("tool", "")).startswith("browser"):
+            continue
+        result = item.get("result")
+        if not isinstance(result, dict):
+            return False
+        texts = [
+            str(block.get("text", ""))
+            for block in result.get("content", [])
+            if isinstance(block, dict)
+        ]
+        return _GATEWAY_TIMEOUT_SNIPPET in "\n".join(texts)
+    return False
+
 
 def _stdout_json(stdout_lines: list[str]) -> dict[str, Any] | None:
-    """Parse the accumulated stdout as one JSON object, or None when incomplete."""
+    """Find the CLI result JSON object in the accumulated output, or None.
+
+    OpenClaw interleaves log lines with the result object and sometimes emits
+    it on stderr, so scan the combined text for the first JSON object that
+    looks like a result payload instead of requiring clean stdout.
+    """
     text = "".join(stdout_lines).strip()
-    if not text.startswith("{"):
-        return None
-    try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"{", text):
+        try:
+            parsed, _ = decoder.raw_decode(text[match.start():])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and ("payloads" in parsed or "meta" in parsed):
+            return parsed
+    return None
 
 
 def _normalize_session_items(session_file: Path) -> list[dict[str, Any]]:
@@ -154,6 +187,13 @@ def _fold_message(
         media_path = _image_block_path(block)
         if media_path:
             texts.append(f"MEDIA:{media_path}")
+    details = message.get("details")
+    if isinstance(details, dict):
+        media = details.get("media")
+        if isinstance(media, dict) and isinstance(media.get("mediaUrl"), str):
+            texts.append(f"MEDIA:{media['mediaUrl']}")
+        elif isinstance(details.get("path"), str):
+            texts.append(f"MEDIA:{details['path']}")
     item["status"] = "completed"
     item["result"] = {"content": [{"type": "text", "text": "\n".join(texts)}]}
 
@@ -221,6 +261,16 @@ def _copy_media_paths(text: str, trajectory_dir: Path, saved: list[str]) -> None
             logger.warning("Failed to copy screenshot %s: %s", source, exc)
 
 
+def _normalize_thinking_level(value: Any) -> str | None:
+    """Map config reasoning-effort spellings to OpenClaw --thinking levels."""
+    if not value:
+        return None
+    level = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    if level in ("extra_high", "extrahigh"):
+        return "xhigh"
+    return level
+
+
 @register_agent
 class OpenClawAgent(CLIAgent):
     """
@@ -244,7 +294,36 @@ class OpenClawAgent(CLIAgent):
         agent_config: dict[str, Any],
         task_workspace: Path,
     ) -> AgentResult | dict[str, Any]:
-        """Execute a browser automation task using OpenClaw CLI."""
+        """Execute a browser automation task using OpenClaw CLI.
+
+        A first-browser-call gateway timeout is a transient infrastructure
+        failure, not an agent outcome: retry once on a fresh browser session
+        with a clean per-task OpenClaw state.
+        """
+        result = self._run_once(task_info, agent_config, task_workspace)
+        if not self._is_first_call_gateway_timeout(result):
+            return result
+        logger.warning(
+            "OpenClaw gateway timed out on the first browser call for task %s; "
+            "retrying once with a fresh browser session",
+            task_info["task_id"],
+        )
+        shutil.rmtree(task_workspace / ".openclaw-state", ignore_errors=True)
+        return self._run_once(task_info, agent_config, task_workspace)
+
+    @staticmethod
+    def _is_first_call_gateway_timeout(result: AgentResult | dict[str, Any]) -> bool:
+        if not isinstance(result, AgentResult):
+            return False
+        return bool(result.error and _GATEWAY_TIMEOUT_ERROR in result.error)
+
+    def _run_once(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+    ) -> AgentResult | dict[str, Any]:
+        """One OpenClaw attempt on its own browser session."""
         browser_id = str(agent_config.get("browser_id") or "")
         if browser_id in SELF_LAUNCH_BROWSER_IDS:
             warn_if_local_proxy_unsupported(agent_config, self.name)
@@ -295,7 +374,7 @@ class OpenClawAgent(CLIAgent):
         trajectory_dir.mkdir(parents=True, exist_ok=True)
         state_dir = task_workspace / ".openclaw-state"
         self._write_state_config(agent_config, task_workspace, state_dir, model, cdp_url)
-        cmd = self._build_command(f"{rules}\n\n{prompt}", task_id, timeout)
+        cmd = self._build_command(f"{rules}\n\n{prompt}", task_id, timeout, agent_config)
 
         env = {**os.environ}
         env["OPENCLAW_STATE_DIR"] = str(state_dir)
@@ -305,6 +384,14 @@ class OpenClawAgent(CLIAgent):
             "Executing OpenClaw for task %s (model=%s, timeout=%ds)", task_id, model, timeout
         )
         t_start = time.monotonic()
+
+        def _has_result(lines: list[str]) -> bool:
+            return (
+                _stdout_json(lines) is not None
+                or self._workspace_json(task_workspace) is not None
+                or self._session_result(task_workspace, task_id) is not None
+            )
+
         try:
             returncode, stdout_lines, execution_error = self._run_subprocess(
                 cmd,
@@ -313,10 +400,18 @@ class OpenClawAgent(CLIAgent):
                 cwd=task_workspace,
                 env=env,
                 collect_stdout=True,
+                # The result JSON is sometimes emitted on stderr only.
+                collect_stderr_as_stdout=True,
                 stderr_line_hook=_stderr_hook,
                 # The CLI keeps running after the turn (embedded browser
                 # service); terminate as soon as the result JSON is complete.
-                stop_predicate=lambda lines: _stdout_json(lines) is not None,
+                stop_predicate=_has_result,
+                # OpenClaw spawns openclaw-agent and browser/gateway helpers.
+                # Kill the whole group once the result exists, otherwise those
+                # helpers can keep the benchmark runner alive.
+                terminate_process_group=True,
+                early_stop_grace_seconds=float(agent_config.get("early_stop_grace_seconds", 2)),
+                kill_grace_seconds=float(agent_config.get("kill_grace_seconds", 5)),
             )
         except FileNotFoundError:
             return AgentResult(
@@ -367,6 +462,24 @@ class OpenClawAgent(CLIAgent):
     ) -> None:
         """Write the per-task openclaw.json (provider, workspace, tools, browser)."""
         state_dir.mkdir(parents=True, exist_ok=True)
+        provider_api = str(agent_config.get("api") or "openai-completions")
+        # OpenClaw's auto-detection disables streaming usage for custom
+        # providers, which zeroes all token accounting; the bench gateway
+        # supports stream_options.include_usage, so opt in.
+        compat: dict[str, Any] = {"supportsUsageInStreaming": True}
+        if agent_config.get("supports_reasoning_effort") is not None:
+            compat["supportsReasoningEffort"] = bool(agent_config.get("supports_reasoning_effort"))
+        model_def: dict[str, Any] = {
+            "id": model,
+            "name": model,
+            "api": provider_api,
+            "reasoning": bool(agent_config.get("reasoning", False)),
+            "input": ["text"],
+            "contextWindow": int(agent_config.get("context_window", 195000)),
+            "maxTokens": int(agent_config.get("max_tokens", 16000)),
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "compat": compat,
+        }
         config: dict[str, Any] = {
             "models": {
                 "mode": "merge",
@@ -374,21 +487,10 @@ class OpenClawAgent(CLIAgent):
                     "bench": {
                         "baseUrl": agent_config.get("base_url", ""),
                         "apiKey": agent_config.get("api_key", ""),
-                        "api": "openai-completions",
-                        "timeoutSeconds": int(agent_config.get("llm_timeout", 300)),
-                        "models": [{
-                            "id": model,
-                            "name": model,
-                            "input": ["text"],
-                            "contextWindow": int(agent_config.get("context_window", 195000)),
-                            "maxTokens": int(agent_config.get("max_tokens", 16000)),
-                            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-                            # OpenClaw's auto-detection disables streaming usage
-                            # for custom providers, which zeroes all token
-                            # accounting; the bench gateway supports
-                            # stream_options.include_usage, so opt in.
-                            "compat": {"supportsUsageInStreaming": True},
-                        }],
+                        # No timeoutSeconds: the current OpenClaw CLI rejects
+                        # it in the provider config schema.
+                        "api": provider_api,
+                        "models": [model_def],
                     }
                 },
             },
@@ -404,13 +506,24 @@ class OpenClawAgent(CLIAgent):
                 "list": [{"id": "main", "tools": {"allow": ["browser", "read"]}}],
             },
             "browser": {"enabled": True},
+            # Never route browser calls through gateway node proxies: a call
+            # with no explicit target otherwise consults gateway node.list,
+            # which fails on machines without gateway credentials.
+            "gateway": {"nodes": {"browser": {"mode": "off"}}},
         }
         if cdp_url:
+            bench_profile = {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"}
             config["browser"] = {
                 "enabled": True,
                 "defaultProfile": "bench",
+                # Also pin the built-in profile names: OpenClaw otherwise
+                # injects "user" (attach the operator's local Chrome) and
+                # "openclaw" (managed local Chrome), and the model sometimes
+                # requests them explicitly, escaping the bench browser.
                 "profiles": {
-                    "bench": {"cdpUrl": cdp_url, "attachOnly": True, "color": "#00AA00"},
+                    "bench": bench_profile,
+                    "user": dict(bench_profile),
+                    "openclaw": dict(bench_profile),
                 },
             }
         (state_dir / "openclaw.json").write_text(
@@ -418,16 +531,33 @@ class OpenClawAgent(CLIAgent):
         )
 
     @staticmethod
-    def _build_command(full_prompt: str, task_id: str, timeout: int) -> list[str]:
+    def _build_command(
+        full_prompt: str,
+        task_id: str,
+        timeout: int,
+        agent_config: dict[str, Any],
+    ) -> list[str]:
         exe = "openclaw.cmd" if IS_WINDOWS else "openclaw"
-        return [
-            exe, "agent",
+        cmd = [
+            # --dev keeps the embedded gateway/browser-control ports off the
+            # defaults, so bench runs never collide with an operator's own
+            # OpenClaw app; state still goes to OPENCLAW_STATE_DIR.
+            exe, "--dev", "agent",
             "--local",   # embedded agent turn, no Gateway service required
             "--json",
-            "--session-key", f"agent:main:bench-{task_id}",
+            "--agent", "main",
+            "--session-id", f"bench-{task_id}",
             "-m", full_prompt,
             "--timeout", str(timeout),
         ]
+        thinking = _normalize_thinking_level(
+            agent_config.get("thinking")
+            or agent_config.get("reasoning_effort")
+            or agent_config.get("thinking_effort")
+        )
+        if thinking:
+            cmd += ["--thinking", thinking]
+        return cmd
 
     def _finalize_result(
         self,
@@ -441,7 +571,12 @@ class OpenClawAgent(CLIAgent):
         task_workspace: Path,
         trajectory_dir: Path,
     ) -> AgentResult:
-        result_obj = _stdout_json(stdout_lines) or {}
+        result_obj = (
+            _stdout_json(stdout_lines)
+            or self._workspace_json(task_workspace)
+            or self._session_result(task_workspace, task_id)
+            or {}
+        )
         payloads = result_obj.get("payloads")
         answer = ""
         if isinstance(payloads, list):
@@ -466,6 +601,11 @@ class OpenClawAgent(CLIAgent):
         items = self._session_items(result_obj, task_workspace)
         saved_screenshots = _collect_media_screenshots(items, trajectory_dir)
         steps = sum(1 for item in items if item.get("type") in STEP_ITEM_TYPES)
+        if steps <= _GATEWAY_TIMEOUT_MAX_STEPS and _first_browser_call_gateway_timeout(items):
+            # The agent only wrapped the outage into a text answer; this is an
+            # environment failure, never env_status=success.
+            env_status, agent_done = "failed", "error"
+            error_message = _GATEWAY_TIMEOUT_ERROR
         if items:
             try:
                 write_api_logs(task_id, model, rules, items, task_workspace / "api_logs")
@@ -505,6 +645,85 @@ class OpenClawAgent(CLIAgent):
             logger.warning("Failed to scrub state config secrets: %s", exc)
 
     @staticmethod
+    def _workspace_json(task_workspace: Path) -> dict[str, Any] | None:
+        """Recover the result JSON from the drained stdout.txt / stderr.txt."""
+        lines: list[str] = []
+        for name in ("stdout.txt", "stderr.txt"):
+            path = task_workspace / name
+            if not path.is_file():
+                continue
+            try:
+                lines.append(path.read_text(encoding="utf-8", errors="replace"))
+            except OSError:
+                continue
+        return _stdout_json(lines)
+
+    @staticmethod
+    def _session_result(task_workspace: Path, task_id: str) -> dict[str, Any] | None:
+        """Recover a completed answer from OpenClaw's session JSONL.
+
+        Some OpenClaw CLI runs finish the agent turn and write the final
+        assistant text to the session file, but never emit the ``--json``
+        payload to stdout or exit. Treat the last assistant text-only message
+        as the terminal answer so the benchmark can terminate the lingering
+        process group and continue.
+        """
+        session_id = f"bench-{task_id}"
+        session_file = (
+            task_workspace / ".openclaw-state" / "agents" / "main" / "sessions"
+            / f"{session_id}.jsonl"
+        )
+        if not session_file.is_file():
+            return None
+        try:
+            raw_lines = session_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            return None
+
+        answer = ""
+        usage: dict[str, Any] = {}
+        for raw_line in raw_lines:
+            try:
+                obj = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            message = obj.get("message")
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            has_tool_call = any(
+                isinstance(block, dict) and block.get("type") == "toolCall" for block in content
+            )
+            texts = [
+                str(block.get("text", ""))
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text" and block.get("text")
+            ]
+            if texts and not has_tool_call:
+                answer = "\n".join(texts).strip()
+                raw_usage = message.get("usage")
+                usage = raw_usage if isinstance(raw_usage, dict) else {}
+        if not answer:
+            return None
+
+        agent_meta: dict[str, Any] = {
+            "sessionId": session_id,
+            "sessionFile": str(session_file),
+        }
+        total_tokens = safe_int(usage.get("total") or usage.get("totalTokens"))
+        if total_tokens:
+            agent_meta["lastCallUsage"] = {
+                "input": safe_int(usage.get("input")),
+                "output": safe_int(usage.get("output")),
+                "cacheRead": safe_int(usage.get("cacheRead")),
+                "cacheWrite": safe_int(usage.get("cacheWrite")),
+                "total": total_tokens,
+            }
+        return {"payloads": [{"text": answer}], "meta": {"agentMeta": agent_meta}}
+
+    @staticmethod
     def _agent_meta(result_obj: dict[str, Any]) -> dict[str, Any] | None:
         meta = result_obj.get("meta")
         agent_meta = meta.get("agentMeta") if isinstance(meta, dict) else None
@@ -519,9 +738,17 @@ class OpenClawAgent(CLIAgent):
     @staticmethod
     def _session_items(result_obj: dict[str, Any], task_workspace: Path) -> list[dict[str, Any]]:
         session_file = OpenClawAgent._session_file_from(result_obj)
-        if session_file is None:
+        if session_file is not None:
+            return _normalize_session_items(session_file)
+        agent_meta = OpenClawAgent._agent_meta(result_obj)
+        session_id = agent_meta.get("sessionId") if agent_meta else None
+        if not session_id:
             return []
-        return _normalize_session_items(session_file)
+        fallback = (
+            task_workspace / ".openclaw-state" / "agents" / "main" / "sessions"
+            / f"{session_id}.jsonl"
+        )
+        return _normalize_session_items(fallback)
 
     @staticmethod
     def _usage_from(result_obj: dict[str, Any]) -> AgentUsage | None:

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -490,32 +490,68 @@ def _cleanup_orphaned_browser_session(
         logger.error("Parent-side browser session cleanup failed (exit code=%s)", result.returncode)
 
 
-def _is_task_env_success_by_result_json(
+# Filesystem mtime granularity / clock-step slack for the freshness check.
+_RESULT_MTIME_SLACK_SECONDS = 2
+
+
+def _read_fresh_result_json(
     task_id: str,
     output_dir: Path,
     newer_than: float | None = None,
-) -> bool:
-    """True when result.json holds a usable non-env-failed result.
+) -> dict[str, Any] | None:
+    """Parse tasks/<id>/result.json when non-empty and fresh.
 
     ``newer_than`` (epoch seconds) guards against result.json files left over
     from a previous run of the same output directory: only files modified
-    after it count.
+    after it (minus a small mtime slack) count.
     """
     result_file = output_dir / "tasks" / task_id / "result.json"
     try:
         stat = result_file.stat()
     except OSError:
-        return False
+        return None
     if stat.st_size == 0:
-        return False
-    if newer_than is not None and stat.st_mtime < newer_than:
-        return False
+        return None
+    if newer_than is not None and stat.st_mtime < newer_than - _RESULT_MTIME_SLACK_SECONDS:
+        return None
     try:
         result = json.loads(result_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
+        return None
+    return result if isinstance(result, dict) else None
+
+
+def _is_task_env_success_by_result_json(
+    task_id: str,
+    output_dir: Path,
+    newer_than: float | None = None,
+) -> bool:
+    """True when result.json holds a usable non-env-failed result."""
+    result = _read_fresh_result_json(task_id, output_dir, newer_than)
+    if result is None:
         return False
     status = result.get("env_status") or result.get("status")
     return status == "success" and not result.get("error")
+
+
+def _is_task_result_terminal(
+    task_id: str,
+    output_dir: Path,
+    newer_than: float | None = None,
+) -> bool:
+    """True when result.json is complete (success OR failure): the runner is done."""
+    result = _read_fresh_result_json(task_id, output_dir, newer_than)
+    return result is not None and bool(result.get("env_status") or result.get("status"))
+
+
+def _watchdog_deadline_seconds(task_timeout: int) -> int:
+    """Hard deadline for one agent_runner subprocess.
+
+    Agents may legitimately run one full-timeout retry on top of the first
+    attempt (e.g. OpenClaw outage_retries=1), so cover two attempts plus
+    grace; this still bounds runaway runners.
+    """
+    return 2 * task_timeout + _TASK_RUNNER_WATCHDOG_GRACE_SECONDS
 
 
 def _wait_for_task_runner(
@@ -529,12 +565,13 @@ def _wait_for_task_runner(
 
     Some agent CLIs (e.g. OpenClaw) spawn helpers that can keep agent_runner
     alive after result.json is complete. Returns ``(returncode,
-    killed_after_result)``; the latter is True when the runner was reaped
-    after its result.json already reported success. A hard deadline of task
-    timeout plus grace reaps runaway runners either way.
+    reaped_after_result)``; the latter is True when the runner was reaped
+    after its result.json was already terminal (success or failure). A hard
+    deadline covering the agent-level retry budget reaps runaway runners
+    either way.
     """
     started_at = time.time()
-    watchdog_deadline = time.monotonic() + task_timeout + _TASK_RUNNER_WATCHDOG_GRACE_SECONDS
+    watchdog_deadline = time.monotonic() + _watchdog_deadline_seconds(task_timeout)
     result_seen_at: float | None = None
     while True:
         try:
@@ -542,13 +579,13 @@ def _wait_for_task_runner(
         except subprocess.TimeoutExpired:
             pass
         now = time.monotonic()
-        if not _is_task_env_success_by_result_json(task_id, output_dir, newer_than=started_at):
+        if not _is_task_result_terminal(task_id, output_dir, newer_than=started_at):
             result_seen_at = None
         elif result_seen_at is None:
             result_seen_at = now
         elif now - result_seen_at >= _TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS:
             logger.warning(
-                "[WATCHDOG] %s result.json is already successful but agent_runner "
+                "[WATCHDOG] %s result.json is already terminal but agent_runner "
                 "is still alive after %ss; terminating the task process group",
                 prefix,
                 _TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS,
@@ -558,8 +595,8 @@ def _wait_for_task_runner(
             return (returncode if returncode is not None else -1), True
         if now >= watchdog_deadline:
             logger.error(
-                "[TIMEOUT] %s agent_runner exceeded watchdog timeout "
-                "(task timeout %ss + grace %ss); terminating",
+                "[TIMEOUT] %s agent_runner exceeded watchdog deadline "
+                "(2 x task timeout %ss + grace %ss); terminating",
                 prefix,
                 task_timeout,
                 _TASK_RUNNER_WATCHDOG_GRACE_SECONDS,
@@ -1049,16 +1086,21 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
             stdout_thread.start()
 
             task_timeout = resolve_timeout_value(args.timeout, task_inline_cfg or {})
-            returncode, killed_after_result = _wait_for_task_runner(
+            returncode, reaped_after_result = _wait_for_task_runner(
                 proc, current_task_id, output_dir, task_timeout, prefix
             )
             stdout_thread.join(timeout=5)
 
-            if killed_after_result:
+            if reaped_after_result:
+                if _is_task_env_success_by_result_json(current_task_id, output_dir):
+                    logger.info(
+                        "[SUCCESS] %s completed; killed lingering runner after result", prefix
+                    )
+                    return True
                 logger.info(
-                    "[SUCCESS] %s completed; killed lingering runner after result", prefix
+                    "[FAILED] %s result is terminal but failed; killed lingering runner", prefix
                 )
-                return True
+                return False
 
             if returncode == 0:
                 logger.info("[SUCCESS] %s completed", prefix)

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -4,11 +4,13 @@ import argparse
 import json
 import os
 import re
-import signal
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 from contextlib import suppress
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -55,6 +57,7 @@ from browseruse_bench.utils import (
     resolve_agent_inline_config,
     resolve_agent_venv_path,
     resolve_split,
+    resolve_timeout_value,
     setup_logger,
 )
 from browseruse_bench.utils.run_identity import (
@@ -430,6 +433,14 @@ _SESSION_CLEANUP_TIMEOUT_SECONDS = _read_positive_int_from_env(
     "BUBENCH_SESSION_CLEANUP_TIMEOUT_SECONDS",
     30,
 )
+_TASK_RUNNER_WATCHDOG_GRACE_SECONDS = _read_positive_int_from_env(
+    "BUBENCH_TASK_RUNNER_WATCHDOG_GRACE_SECONDS",
+    60,
+)
+_TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS = _read_positive_int_from_env(
+    "BUBENCH_TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS",
+    20,
+)
 
 
 def _cleanup_orphaned_browser_session(
@@ -477,6 +488,85 @@ def _cleanup_orphaned_browser_session(
         logger.info("Parent-side browser session cleanup finished")
     else:
         logger.error("Parent-side browser session cleanup failed (exit code=%s)", result.returncode)
+
+
+def _is_task_env_success_by_result_json(
+    task_id: str,
+    output_dir: Path,
+    newer_than: float | None = None,
+) -> bool:
+    """True when result.json holds a usable non-env-failed result.
+
+    ``newer_than`` (epoch seconds) guards against result.json files left over
+    from a previous run of the same output directory: only files modified
+    after it count.
+    """
+    result_file = output_dir / "tasks" / task_id / "result.json"
+    try:
+        stat = result_file.stat()
+    except OSError:
+        return False
+    if stat.st_size == 0:
+        return False
+    if newer_than is not None and stat.st_mtime < newer_than:
+        return False
+    try:
+        result = json.loads(result_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    status = result.get("env_status") or result.get("status")
+    return status == "success" and not result.get("error")
+
+
+def _wait_for_task_runner(
+    proc: subprocess.Popen,
+    task_id: str,
+    output_dir: Path,
+    task_timeout: int,
+    prefix: str,
+) -> tuple[int, bool]:
+    """Wait for one agent_runner subprocess with a lingering-process watchdog.
+
+    Some agent CLIs (e.g. OpenClaw) spawn helpers that can keep agent_runner
+    alive after result.json is complete. Returns ``(returncode,
+    killed_after_result)``; the latter is True when the runner was reaped
+    after its result.json already reported success. A hard deadline of task
+    timeout plus grace reaps runaway runners either way.
+    """
+    started_at = time.time()
+    watchdog_deadline = time.monotonic() + task_timeout + _TASK_RUNNER_WATCHDOG_GRACE_SECONDS
+    result_seen_at: float | None = None
+    while True:
+        try:
+            return proc.wait(timeout=1), False
+        except subprocess.TimeoutExpired:
+            pass
+        now = time.monotonic()
+        if not _is_task_env_success_by_result_json(task_id, output_dir, newer_than=started_at):
+            result_seen_at = None
+        elif result_seen_at is None:
+            result_seen_at = now
+        elif now - result_seen_at >= _TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS:
+            logger.warning(
+                "[WATCHDOG] %s result.json is already successful but agent_runner "
+                "is still alive after %ss; terminating the task process group",
+                prefix,
+                _TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS,
+            )
+            _terminate_one(proc)
+            returncode = proc.poll()
+            return (returncode if returncode is not None else -1), True
+        if now >= watchdog_deadline:
+            logger.error(
+                "[TIMEOUT] %s agent_runner exceeded watchdog timeout "
+                "(task timeout %ss + grace %ss); terminating",
+                prefix,
+                task_timeout,
+                _TASK_RUNNER_WATCHDOG_GRACE_SECONDS,
+            )
+            _terminate_one(proc)
+            returncode = proc.poll()
+            return (returncode if returncode is not None else -1), False
 
 
 def _terminate_one(proc: subprocess.Popen) -> None:
@@ -938,17 +1028,37 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
             with _processes_lock:
                 _processes[proc.pid] = proc
 
-            if proc.stdout:
+            def _drain_runner_stdout() -> None:
+                if not proc.stdout:
+                    return
                 for line in iter(proc.stdout.readline, ""):
-                    if line:
-                        display_line = _clarify_agent_stdout_line(line.rstrip("\n"))
-                        # Prefix each output line with task id when concurrent.
-                        if concurrency > 1:
-                            logger.info("[%s] %s", current_task_id, display_line)
-                        else:
-                            logger.info(display_line)
+                    if not line:
+                        continue
+                    display_line = _clarify_agent_stdout_line(line.rstrip("\n"))
+                    # Prefix each output line with task id when concurrent.
+                    if concurrency > 1:
+                        logger.info("[%s] %s", current_task_id, display_line)
+                    else:
+                        logger.info(display_line)
 
-            returncode = proc.wait()
+            stdout_thread = threading.Thread(
+                target=_drain_runner_stdout,
+                name=f"bubench-output-{current_task_id}",
+                daemon=True,
+            )
+            stdout_thread.start()
+
+            task_timeout = resolve_timeout_value(args.timeout, task_inline_cfg or {})
+            returncode, killed_after_result = _wait_for_task_runner(
+                proc, current_task_id, output_dir, task_timeout, prefix
+            )
+            stdout_thread.join(timeout=5)
+
+            if killed_after_result:
+                logger.info(
+                    "[SUCCESS] %s completed; killed lingering runner after result", prefix
+                )
+                return True
 
             if returncode == 0:
                 logger.info("[SUCCESS] %s completed", prefix)
@@ -974,7 +1084,6 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
     # ------------------------------------------------------------------ #
     # Execute tasks                                                        #
     # ------------------------------------------------------------------ #
-    import threading
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     success_count = 0

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -155,6 +155,11 @@ models:
     model_id: gpt-5.4
     api_key: $OPENAI_API_KEY
     base_url: $OPENAI_BASE_URL
+    # Optional provider tuning, forwarded into the per-task OpenClaw config:
+    # api: openai-responses          # provider wire API (default: openai-completions)
+    # reasoning: true                # mark the model as a reasoning model
+    # supports_reasoning_effort: true
+    # thinking: medium               # OpenClaw --thinking level (off|minimal|low|medium|high|xhigh)
 browsers:
   lexmount:
     browser_id: lexmount

--- a/tests/browseruse_bench/test_cli_agent.py
+++ b/tests/browseruse_bench/test_cli_agent.py
@@ -9,7 +9,6 @@ import pytest
 
 from browseruse_bench.agents.cli_agent import CLIAgent
 
-
 # ---------------------------------------------------------------------------
 # Concrete minimal subclass (CLIAgent is abstract via BaseAgent)
 # ---------------------------------------------------------------------------
@@ -183,3 +182,56 @@ class TestRunSubprocess:
             cwd=cwd_dir,
         )
         assert any(str(cwd_dir) in l for l in lines)
+
+    def test_stderr_collected_as_stdout_feeds_stop_predicate(self, tmp_path: Path) -> None:
+        # CLIs (e.g. openclaw) may emit the machine-readable result on stderr;
+        # with collect_stderr_as_stdout the predicate must see it and stop early.
+        import time as time_module
+
+        agent = self._agent()
+        code = (
+            "import sys, time\n"
+            "sys.stderr.write('RESULT_ON_STDERR\\n')\n"
+            "sys.stderr.flush()\n"
+            "time.sleep(60)\n"
+        )
+        t0 = time_module.monotonic()
+        rc, lines, err = agent._run_subprocess(
+            [sys.executable, "-u", "-c", code],
+            timeout=20,
+            task_workspace=tmp_path,
+            collect_stderr_as_stdout=True,
+            stop_predicate=lambda seen: any("RESULT_ON_STDERR" in line for line in seen),
+        )
+        elapsed = time_module.monotonic() - t0
+        assert rc == 0
+        assert err is None
+        assert any("RESULT_ON_STDERR" in line for line in lines)
+        assert elapsed < 10
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="process-group semantics differ on Windows")
+    def test_stop_predicate_terminates_process_group_children(self, tmp_path: Path) -> None:
+        import time as time_module
+
+        agent = self._agent()
+        code = (
+            "import subprocess, sys, time\n"
+            "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])\n"
+            "print('RESULT_READY', flush=True)\n"
+            "time.sleep(60)\n"
+        )
+        t0 = time_module.monotonic()
+        rc, lines, err = agent._run_subprocess(
+            [sys.executable, "-u", "-c", code],
+            timeout=20,
+            task_workspace=tmp_path,
+            stop_predicate=lambda seen: any("RESULT_READY" in line for line in seen),
+            terminate_process_group=True,
+            early_stop_grace_seconds=0.5,
+            kill_grace_seconds=2,
+        )
+        elapsed = time_module.monotonic() - t0
+        assert rc == 0
+        assert err is None
+        assert any("RESULT_READY" in line for line in lines)
+        assert elapsed < 5

--- a/tests/browseruse_bench/test_cli_agent.py
+++ b/tests/browseruse_bench/test_cli_agent.py
@@ -209,6 +209,30 @@ class TestRunSubprocess:
         assert any("RESULT_ON_STDERR" in line for line in lines)
         assert elapsed < 10
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="signal semantics differ on Windows")
+    def test_late_predicate_match_does_not_rewrite_timeout(self, tmp_path: Path) -> None:
+        # A dying process can flush a line matching the predicate AFTER the
+        # timeout was decided; the run must stay a timeout, not a success.
+        agent = self._agent()
+        code = (
+            "import signal, sys, time\n"
+            "signal.signal(signal.SIGTERM, lambda s, f: print('RESULT_READY', flush=True))\n"
+            "print('started', flush=True)\n"
+            "time.sleep(60)\n"
+        )
+        rc, lines, err = agent._run_subprocess(
+            [sys.executable, "-u", "-c", code],
+            timeout=1,
+            task_workspace=tmp_path,
+            stop_predicate=lambda seen: any("RESULT_READY" in line for line in seen),
+            terminate_process_group=True,
+            early_stop_grace_seconds=2,
+            kill_grace_seconds=2,
+        )
+        assert err is not None
+        assert "Timeout" in err
+        assert rc == -1
+
     @pytest.mark.skipif(sys.platform == "win32", reason="process-group semantics differ on Windows")
     def test_stop_predicate_terminates_process_group_children(self, tmp_path: Path) -> None:
         import time as time_module

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -490,6 +490,30 @@ class TestOpenClawAgentRunTask:
         assert "not found" in (result.error or "").lower()
 
 
+class TestSessionResultTerminality:
+    def test_tool_call_after_text_message_is_not_terminal(self, tmp_path: Path) -> None:
+        # A text-only assistant message followed by more tool calls is
+        # mid-turn commentary, not a final answer; treating it as terminal
+        # would let the stop predicate kill a healthy run.
+        session_dir = tmp_path / ".openclaw-state" / "agents" / "main" / "sessions"
+        session_dir.mkdir(parents=True)
+        rows = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "text", "text": "I will open the site now."},
+            ]}},
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "c1", "name": "browser",
+                 "arguments": {"action": "open", "url": "https://example.com"}},
+            ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+                "content": [{"type": "text", "text": "opened"}]}},
+        ]
+        (session_dir / "bench-t1.jsonl").write_text(
+            "\n".join(json.dumps(row) for row in rows), encoding="utf-8"
+        )
+        assert OpenClawAgent._session_result(tmp_path, "bench-t1") is None
+
+
 class TestCliVersionRecording:
     def test_version_recorded_in_agent_metadata(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -48,6 +48,41 @@ def _result_stdout(session_file: Path | None = None, answer: str = "The price is
     return [line + "\n" for line in text.split("\n")]
 
 
+_GATEWAY_TIMEOUT_TEXT = (
+    '{\n  "status": "error",\n  "tool": "browser",\n'
+    '  "error": "timed out. Restart the OpenClaw gateway (OpenClaw.app menubar, or '
+    "`openclaw --profile dev gateway`). Do NOT retry the browser tool — it will keep "
+    'failing. Use an alternative approach or inform the user that the browser is '
+    'currently unavailable."\n}'
+)
+
+
+def _write_gateway_timeout_session(path: Path, extra_ok_calls: int = 0) -> None:
+    """Session where a browser call fails with the gateway-timeout signature.
+
+    With extra_ok_calls > 0 the failing call comes after that many successful
+    browser calls (late failure, not a first-call failure).
+    """
+    rows: list[dict[str, Any]] = []
+    for i in range(extra_ok_calls):
+        rows.append({"type": "message", "message": {"role": "assistant", "content": [
+            {"type": "toolCall", "id": f"ok{i}", "name": "browser",
+             "arguments": {"action": "snapshot"}},
+        ]}})
+        rows.append({"type": "message", "message": {"role": "toolResult",
+            "toolCallId": f"ok{i}", "content": [{"type": "text", "text": "ok"}]}})
+    rows.append({"type": "message", "message": {"role": "assistant", "content": [
+        {"type": "toolCall", "id": "c1", "name": "browser",
+         "arguments": {"action": "open", "url": "https://example.com", "target": "host"}},
+    ]}})
+    rows.append({"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+        "content": [{"type": "text", "text": _GATEWAY_TIMEOUT_TEXT}]}})
+    rows.append({"type": "message", "message": {"role": "assistant", "content": [
+        {"type": "text", "text": "The browser is currently unavailable."},
+    ]}})
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+
 def _write_session(path: Path) -> None:
     lines = [
         {"type": "message", "message": {"role": "user", "content": [{"type": "text", "text": "go"}]}},
@@ -77,6 +112,37 @@ class TestStdoutJson:
     def test_non_json_returns_none(self) -> None:
         assert _stdout_json(["warning: something\n"]) is None
         assert _stdout_json([]) is None
+
+    def test_json_embedded_in_noise_parsed(self) -> None:
+        # OpenClaw mixes log lines with the result object (sometimes on stderr).
+        lines = [
+            "npm warn Unknown env config\n",
+            '{"other": 1} {"payloads": [{"text": "hi"}], "meta": {}}\n',
+            "trailing log\n",
+        ]
+        assert _stdout_json(lines)["payloads"][0]["text"] == "hi"
+
+    def test_json_without_result_keys_ignored(self) -> None:
+        assert _stdout_json(['{"done": true}\n']) is None
+
+
+class TestBuildCommand:
+    def test_agent_and_session_id_flags(self) -> None:
+        cmd = OpenClawAgent._build_command("prompt", "t1", 60, {})
+        assert cmd[cmd.index("--agent") + 1] == "main"
+        assert cmd[cmd.index("--session-id") + 1] == "bench-t1"
+        assert "--session-key" not in cmd
+        assert "--thinking" not in cmd
+
+    def test_thinking_passthrough(self) -> None:
+        cmd = OpenClawAgent._build_command("prompt", "t1", 60, {"thinking": "medium"})
+        assert cmd[cmd.index("--thinking") + 1] == "medium"
+
+    def test_thinking_normalized_from_reasoning_effort(self) -> None:
+        cmd = OpenClawAgent._build_command(
+            "prompt", "t1", 60, {"reasoning_effort": "Extra-High"}
+        )
+        assert cmd[cmd.index("--thinking") + 1] == "xhigh"
 
 
 class TestNormalizeSessionItems:
@@ -195,12 +261,41 @@ class TestOpenClawAgentRunTask:
         assert cfg["agents"]["defaults"]["model"]["primary"] == "bench/gpt-test"
         assert cfg["agents"]["defaults"]["workspace"] == str(tmp_path / ".openclaw-workspace")
         assert cfg["agents"]["list"][0]["tools"]["allow"] == ["browser", "read"]
-        assert cfg["models"]["providers"]["bench"]["timeoutSeconds"] == 300
+        # Without this, a browser call with no explicit target consults
+        # gateway node.list, which fails without gateway credentials.
+        assert cfg["gateway"]["nodes"]["browser"]["mode"] == "off"
+        # Current OpenClaw CLI rejects timeoutSeconds in the provider schema.
+        assert "timeoutSeconds" not in provider
+        assert provider["api"] == "openai-completions"
         # The api key written for the run must be scrubbed from the artifact.
         assert provider["apiKey"] == "***"
         # Without this compat flag OpenClaw never sends stream_options
         # include_usage to custom providers, so token usage is all zeros.
         assert provider["models"][0]["compat"] == {"supportsUsageInStreaming": True}
+
+    def test_provider_api_and_reasoning_from_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(), None))
+        config = {
+            **AGENT_CONFIG,
+            "api": "openai-responses",
+            "reasoning": True,
+            "supports_reasoning_effort": True,
+        }
+        agent.run_task(TASK_INFO, config, tmp_path)
+
+        cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
+        provider = cfg["models"]["providers"]["bench"]
+        model_def = provider["models"][0]
+        assert provider["api"] == "openai-responses"
+        assert model_def["api"] == "openai-responses"
+        assert model_def["reasoning"] is True
+        assert model_def["compat"] == {
+            "supportsUsageInStreaming": True,
+            "supportsReasoningEffort": True,
+        }
 
     def test_cdp_url_written_as_attach_profile(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -227,6 +322,13 @@ class TestOpenClawAgentRunTask:
         assert profile["cdpUrl"] == "wss://cdp.example/1"
         assert profile["attachOnly"] is True
         assert cfg["browser"]["defaultProfile"] == "bench"
+        # OpenClaw injects built-in "user" (attach local Chrome) and
+        # "openclaw" (managed local Chrome) profiles unless the config defines
+        # them; the model sometimes passes profile=user/openclaw explicitly,
+        # escaping the bench browser. Pin both names to the bench CDP.
+        for alias in ("user", "openclaw"):
+            assert cfg["browser"]["profiles"][alias]["cdpUrl"] == "wss://cdp.example/1"
+            assert cfg["browser"]["profiles"][alias]["attachOnly"] is True
         assert result.env_status == "success"
 
     def test_non_cdp_backend_fails_fast(
@@ -251,6 +353,60 @@ class TestOpenClawAgentRunTask:
         result = agent.run_task(TASK_INFO, config, tmp_path)
         assert result.env_status == "failed"
         assert "browser-use-cloud" in (result.error or "")
+
+    def test_result_json_recovered_from_stderr_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # OpenClaw sometimes emits the result JSON on stderr only; the adapter
+        # must recover it from the drained stderr.txt.
+        agent = OpenClawAgent()
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            (tmp_path / "stderr.txt").write_text(
+                "some log\n" + "".join(_result_stdout()), encoding="utf-8"
+            )
+            return 0, [], None
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "success"
+        assert result.answer == "The price is $42"
+
+    def test_final_answer_recovered_from_session_jsonl(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Some runs finish the turn and persist the assistant answer in the
+        # session file without ever emitting the --json payload.
+        agent = OpenClawAgent()
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            session_dir = tmp_path / ".openclaw-state" / "agents" / "main" / "sessions"
+            session_dir.mkdir(parents=True)
+            rows = [
+                {"type": "message", "message": {"role": "assistant", "content": [
+                    {"type": "toolCall", "id": "c1", "name": "browser",
+                     "arguments": {"action": "open"}},
+                ]}},
+                {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+                    "content": [{"type": "text", "text": "opened"}]}},
+                {"type": "message", "message": {"role": "assistant", "content": [
+                    {"type": "text", "text": "最终答案：测试成功"},
+                ], "usage": {"input": 11, "output": 7, "cacheRead": 3, "total": 21}}},
+            ]
+            (session_dir / "bench-t1.jsonl").write_text(
+                "\n".join(json.dumps(row) for row in rows), encoding="utf-8"
+            )
+            return 0, [], None
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "success"
+        assert result.agent_done == "done"
+        assert result.answer == "最终答案：测试成功"
+        usage = result.metrics.usage
+        assert usage is not None
+        assert usage.total_prompt_tokens == 14  # 11 + 3 cacheRead folded in
+        assert usage.total_completion_tokens == 7
 
     def test_no_result_json_is_error(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -318,6 +474,114 @@ class TestOpenClawAgentRunTask:
         assert "not found" in (result.error or "").lower()
 
 
+class TestGatewayTimeoutRetry:
+    def _fake_run_with_sessions(
+        self, tmp_path: Path, sessions: list[str], calls: list[list[str]]
+    ) -> Any:
+        """Build a fake _run_subprocess emitting one prepared session per call."""
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            calls.append(cmd)
+            attempt = len(calls)
+            session = tmp_path / f"session-attempt{attempt}.jsonl"
+            kind = sessions[attempt - 1]
+            if kind == "gateway_timeout":
+                _write_gateway_timeout_session(session)
+                answer = "The browser is currently unavailable."
+            elif kind == "late_gateway_timeout":
+                _write_gateway_timeout_session(session, extra_ok_calls=3)
+                answer = "Partial answer."
+            else:
+                _write_session(session)
+                answer = "The price is $42"
+            return 0, _result_stdout(session, answer=answer), None
+
+        return fake_run
+
+    def test_first_call_gateway_timeout_retries_once_and_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            self._fake_run_with_sessions(tmp_path, ["gateway_timeout", "ok"], calls),
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 2
+        assert result.env_status == "success"
+        assert result.agent_done == "done"
+        assert result.answer == "The price is $42"
+
+    def test_gateway_timeout_on_both_attempts_is_env_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = OpenClawAgent()
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            self._fake_run_with_sessions(
+                tmp_path, ["gateway_timeout", "gateway_timeout"], calls
+            ),
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 2  # exactly one retry
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "gateway" in (result.error or "").lower()
+
+    def test_late_gateway_timeout_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A timeout after several successful browser calls is not the
+        # first-call transient signature; keep the single attempt.
+        agent = OpenClawAgent()
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            agent, "_run_subprocess",
+            self._fake_run_with_sessions(tmp_path, ["late_gateway_timeout"], calls),
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert len(calls) == 1
+        assert result.env_status == "success"
+
+    def test_retry_opens_fresh_browser_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        from browseruse_bench.agents import openclaw as openclaw_module
+        from browseruse_bench.browsers.types import BrowserSessionContext
+
+        session_count = 0
+
+        @contextlib.contextmanager
+        def fake_session(browser_id: str, agent_name: str, agent_config: dict[str, Any]):
+            nonlocal session_count
+            session_count += 1
+            yield BrowserSessionContext(
+                backend_id=browser_id, transport="cdp",
+                cdp_url=f"wss://cdp.example/{session_count}",
+            )
+
+        monkeypatch.setattr(openclaw_module, "open_browser_session", fake_session)
+        agent = OpenClawAgent()
+        calls: list[list[str]] = []
+        seen_cdp_urls: list[str] = []
+        inner = self._fake_run_with_sessions(tmp_path, ["gateway_timeout", "ok"], calls)
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
+            seen_cdp_urls.append(cfg["browser"]["profiles"]["bench"]["cdpUrl"])
+            return inner(cmd, **kw)
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        config = {**AGENT_CONFIG, "browser_id": "lexmount"}
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+        assert result.env_status == "success"
+        assert seen_cdp_urls == ["wss://cdp.example/1", "wss://cdp.example/2"]
+
+
 class TestStopPredicate:
     def test_run_subprocess_stops_early_on_predicate(self, tmp_path: Path) -> None:
         # A process that prints JSON then sleeps forever must be terminated as
@@ -327,7 +591,8 @@ class TestStopPredicate:
         agent = OpenClawAgent()
         cmd = [
             "python3", "-u", "-c",
-            "import time, sys; print('{\"done\": true}'); sys.stdout.flush(); time.sleep(60)",
+            "import time, sys; print('{\"payloads\":[{\"text\":\"done\"}]}'); "
+            "sys.stdout.flush(); time.sleep(60)",
         ]
         t0 = time_module.monotonic()
         returncode, lines, error = agent._run_subprocess(
@@ -339,7 +604,7 @@ class TestStopPredicate:
         elapsed = time_module.monotonic() - t0
         assert returncode == 0
         assert error is None
-        assert _stdout_json(lines) == {"done": True}
+        assert _stdout_json(lines) == {"payloads": [{"text": "done"}]}
         assert elapsed < 15
 
 

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -490,6 +490,35 @@ class TestOpenClawAgentRunTask:
         assert "not found" in (result.error or "").lower()
 
 
+class TestCliVersionRecording:
+    def test_version_recorded_in_agent_metadata(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Compat problems (e.g. --session-key rejection in the 20260701 run)
+        # were observed on an unrecorded CLI version; every result must carry
+        # the version it ran against so failures stay attributable.
+        agent = OpenClawAgent()
+        monkeypatch.setattr(OpenClawAgent, "_cli_version", staticmethod(lambda: "2026.6.10 (test)"))
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, _result_stdout(), None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.agent_metadata["openclaw_cli_version"] == "2026.6.10 (test)"
+
+    def test_missing_executable_reports_unknown_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import subprocess
+
+        def raise_not_found(*a: Any, **kw: Any) -> None:
+            raise FileNotFoundError("openclaw not found")
+
+        monkeypatch.setattr(subprocess, "run", raise_not_found)
+        OpenClawAgent._cli_version.cache_clear()
+        try:
+            assert OpenClawAgent._cli_version() == "unknown"
+        finally:
+            OpenClawAgent._cli_version.cache_clear()
+
+
 class TestGatewayTimeoutRetry:
     """Outage-retry cases not covered by TestBrowserOutageRetry: the
     gateway-restart signature variant, and the fresh-browser-session

--- a/tests/browseruse_bench/test_run_watchdog.py
+++ b/tests/browseruse_bench/test_run_watchdog.py
@@ -1,0 +1,127 @@
+"""Tests for cli/run.py task-runner watchdog (lingering agent_runner recovery)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from browseruse_bench.cli import run as run_module
+from browseruse_bench.cli.run import (
+    _is_task_env_success_by_result_json,
+    _wait_for_task_runner,
+)
+
+
+def _write_result(
+    output_dir: Path,
+    task_id: str,
+    env_status: str = "success",
+    error: str | None = None,
+) -> Path:
+    task_dir = output_dir / "tasks" / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    result_file = task_dir / "result.json"
+    result_file.write_text(
+        json.dumps({"env_status": env_status, "agent_done": "done", "error": error}),
+        encoding="utf-8",
+    )
+    return result_file
+
+
+def _spawn_sleeper() -> subprocess.Popen:
+    # Own session/process group: _terminate_one signals the whole group, which
+    # must never be the test runner's own group.
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(120)"],
+        start_new_session=not sys.platform.startswith("win"),
+    )
+
+
+class TestIsTaskEnvSuccessByResultJson:
+    def test_success_result(self, tmp_path: Path) -> None:
+        _write_result(tmp_path, "t1")
+        assert _is_task_env_success_by_result_json("t1", tmp_path)
+
+    def test_failed_result(self, tmp_path: Path) -> None:
+        _write_result(tmp_path, "t1", env_status="failed")
+        assert not _is_task_env_success_by_result_json("t1", tmp_path)
+
+    def test_result_with_error_not_success(self, tmp_path: Path) -> None:
+        _write_result(tmp_path, "t1", error="boom")
+        assert not _is_task_env_success_by_result_json("t1", tmp_path)
+
+    def test_missing_result(self, tmp_path: Path) -> None:
+        assert not _is_task_env_success_by_result_json("t1", tmp_path)
+
+    def test_stale_result_rejected_by_newer_than(self, tmp_path: Path) -> None:
+        # A result.json left over from a previous run must not count for the
+        # current subprocess (it would let the watchdog kill a live re-run).
+        result_file = _write_result(tmp_path, "t1")
+        old = time.time() - 3600
+        os.utime(result_file, (old, old))
+        assert not _is_task_env_success_by_result_json("t1", tmp_path, newer_than=time.time() - 60)
+        assert _is_task_env_success_by_result_json("t1", tmp_path, newer_than=old - 60)
+
+
+class TestWaitForTaskRunner:
+    def test_normal_exit_passthrough(self, tmp_path: Path) -> None:
+        proc = subprocess.Popen([sys.executable, "-c", "print('done')"])
+        rc, killed = _wait_for_task_runner(
+            proc, "t1", tmp_path, task_timeout=30, prefix="Task t1"
+        )
+        assert rc == 0
+        assert killed is False
+
+    def test_lingering_runner_killed_after_result(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import threading
+
+        monkeypatch.setattr(run_module, "_TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS", 1)
+        proc = _spawn_sleeper()
+        # result.json lands while the runner is still alive (as in a real run).
+        timer = threading.Timer(1.0, _write_result, args=(tmp_path, "t1"))
+        timer.start()
+        t0 = time.monotonic()
+        rc, killed = _wait_for_task_runner(
+            proc, "t1", tmp_path, task_timeout=60, prefix="Task t1"
+        )
+        assert killed is True
+        assert time.monotonic() - t0 < 30
+        assert proc.poll() is not None
+
+    def test_stale_result_does_not_trigger_early_kill(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(run_module, "_TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS", 1)
+        monkeypatch.setattr(run_module, "_TASK_RUNNER_WATCHDOG_GRACE_SECONDS", 2)
+        result_file = _write_result(tmp_path, "t1")
+        old = time.time() - 3600
+        os.utime(result_file, (old, old))
+        proc = _spawn_sleeper()
+        rc, killed = _wait_for_task_runner(
+            proc, "t1", tmp_path, task_timeout=3, prefix="Task t1"
+        )
+        # The stale result must not count as completion; the runner is only
+        # reaped by the overall watchdog deadline.
+        assert killed is False
+        assert proc.poll() is not None
+
+    def test_watchdog_deadline_kills_runaway_runner(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(run_module, "_TASK_RUNNER_WATCHDOG_GRACE_SECONDS", 1)
+        proc = _spawn_sleeper()
+        t0 = time.monotonic()
+        rc, killed = _wait_for_task_runner(
+            proc, "t1", tmp_path, task_timeout=1, prefix="Task t1"
+        )
+        assert killed is False
+        assert time.monotonic() - t0 < 30
+        assert proc.poll() is not None

--- a/tests/browseruse_bench/test_run_watchdog.py
+++ b/tests/browseruse_bench/test_run_watchdog.py
@@ -125,3 +125,29 @@ class TestWaitForTaskRunner:
         assert killed is False
         assert time.monotonic() - t0 < 30
         assert proc.poll() is not None
+
+    def test_watchdog_deadline_covers_one_agent_level_retry(self) -> None:
+        # OpenClaw legitimately runs up to two full-timeout attempts
+        # (outage_retries=1); a single-attempt deadline would kill the retry.
+        assert run_module._watchdog_deadline_seconds(600) >= 2 * 600
+
+    def test_failed_terminal_result_also_reaps_lingering_runner(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A complete result.json reporting failure is just as terminal as a
+        # success; the runner must not be held until the hard deadline.
+        import threading
+
+        monkeypatch.setattr(run_module, "_TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS", 1)
+        proc = _spawn_sleeper()
+        timer = threading.Timer(
+            1.0, _write_result, args=(tmp_path, "t1"), kwargs={"env_status": "failed"}
+        )
+        timer.start()
+        t0 = time.monotonic()
+        rc, killed = _wait_for_task_runner(
+            proc, "t1", tmp_path, task_timeout=60, prefix="Task t1"
+        )
+        assert killed is True
+        assert time.monotonic() - t0 < 30
+        assert proc.poll() is not None


### PR DESCRIPTION
Merges the local patch that the 20260701 scored run (openclaw + gpt-5.5 + lexmount, bundle 20260703) actually ran with, reconciled on top of #78. #78 already landed the gateway node-dispatch off / pinned profiles / outage retry / port isolation pieces; this PR adds the parts it lacks.

## openclaw.py
- **CLI form — cross-version conservative choice, not a live bugfix**: `openclaw --dev agent --local --json --agent main --session-id bench-<id>` replaces `--session-key`, and provider `timeoutSeconds` is dropped. The bundle report claims the old form was rejected, but that was on an *unrecorded* CLI version (machine bot1); on the locally installed CLI (2026.6.10 aa69b12) **both forms work** (#78's smoke ran the old form green). The new form is the only one with green evidence on both known environments — bot1's 210-task scored run and local smokes — so it is the safer intersection. `--dev` keeps default ports away from a resident OpenClaw.app.
- **CLI version recording**: `openclaw --version` once per process, logged in run.log and stamped as `agent_metadata.openclaw_cli_version` on every result, so version-dependent compat failures stay attributable (the gap that made the report's claim uncheckable).
- **Provider config keys**: `api` (e.g. `openai-responses`), `reasoning`, `supports_reasoning_effort`, and `--thinking` passthrough with level normalization (`extra_high` → `xhigh`) — required to express the scored run's reasoning-effort configuration at all; not version-dependent.
- **Output recovery (dormant fallbacks)**: `_stdout_json` scans mixed log/JSON output, stderr is folded into the stop-predicate buffer, and `stdout.txt`/`stderr.txt` plus session-JSONL recovery kick in only when the `--json` payload never lands. Observed on bot1 only (long gpt-5.5 runs at volume); zero behavior change on healthy runs, mechanism unit-tested with synthetic inputs.
- Screenshot extraction from `details.media` result blocks.

## cli_agent.py
- `terminate_process_group` (SIGTERM → SIGKILL with grace knobs): "the CLI keeps running after the turn" is documented openclaw `--local` behavior (the reason stop_predicate exists); the old `terminate()` only killed the parent and could orphan `openclaw-agent`/browser helpers. Active on every run and validated locally (all smokes + two concurrency-10 batches + a unit test proving children are reaped). Also `collect_stderr_as_stdout` for CLIs that emit machine-readable output on stderr.

## cli/run.py
- Runner-level watchdog (dormant): reap an agent_runner that stays alive after its result.json already reports success, plus a hard deadline of task timeout + grace. Result files only count when written after the current subprocess started, so a stale result.json from a previous run cannot kill a live re-run. Env knobs: `BUBENCH_TASK_RUNNER_WATCHDOG_GRACE_SECONDS`, `BUBENCH_TASK_RUNNER_RESULT_EXIT_GRACE_SECONDS`. Excluded from the source patch: a one-off cursor resume hack (hardcoded run timestamp).

## Not needed from the patch
Usage accounting (bundle showed 671 prompt tokens for 39-step tasks) was already fixed on main (#74/#75); verified live: 13 usage entries / 419k prompt tokens on a single task.

## Verification
- TDD throughout; net-new tests for process-group termination, stderr recovery, session-JSONL recovery, watchdog (incl. stale-result guard), CLI flags, version recording. Full suite: 648 passed; the 2 failures are pre-existing environment issues (claude smoke .env leak, config_loader override), unrelated.
- Post-merge smoke per AGENTS.md, three green runs of `bubench run --agent openclaw --data LexBench-Browser --mode single` (gpt-5.4, lexmount): 9-12 steps of real browsing, correct answers, 73-76s wall-clock (runs 20260704_004649 / 20260704_004724 / 20260704_010405). The last one shows `OpenClaw CLI version: OpenClaw 2026.6.10 (aa69b12)` in run.log and the same string in result agent_metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)