### PR TITLE
feat(browser-use): capture raw LLM response for failed/unparseable calls in api_logs

### DIFF
--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -280,7 +280,14 @@ class _LLMFailureRecorder:
 
 
 def _record_raw_llm_responses(llm: Any, recorder: _LLMFailureRecorder) -> None:
-    """Stash each raw chat completion so failed parses keep their payload."""
+    """
+    Stash each raw chat completion so failed parses keep their payload.
+
+    Only OpenAI-compatible clients exposing chat.completions.create are covered
+    (the bench's primary gateway path). Azure responses-API mode, Anthropic, and
+    Google clients bypass this wrap; their failure records carry error and
+    timestamp but raw_response=None.
+    """
     original_get_client = llm.get_client
 
     def get_client_with_response_recording() -> Any:

--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -28,6 +28,7 @@ from browser_use import ChatGoogle as BrowserUseSDKChatGoogle
 from browser_use import ChatOpenAI as BrowserUseSDKChatOpenAI
 from browser_use.browser import session as browser_use_session_module
 from browser_use.browser.profile import ProxySettings as BrowserUseProxySettings
+from browser_use.llm.exceptions import ModelError as BrowserUseModelError
 from browser_use.llm.schema import SchemaOptimizer
 from pydantic import BaseModel as _PydanticBaseModel
 
@@ -238,6 +239,100 @@ def _enable_claude_thinking(llm: Any, reasoning_effort: str) -> None:
         return client
 
     llm.get_client = get_client_with_thinking  # type: ignore[method-assign]
+
+
+class _LLMFailureRecorder:
+    """
+    Keeps raw LLM completions for calls that fail browser-use parsing.
+
+    browser-use converts unparseable completions into ModelProviderError before
+    the agent sees the content, so the raw payload must be stashed at the HTTP
+    client layer and attached to the failure record here.
+    """
+
+    def __init__(self) -> None:
+        self._last_response: dict[str, Any] | None = None
+        self.failures: list[dict[str, Any]] = []
+
+    def begin_call(self) -> None:
+        self._last_response = None
+
+    def record_response(self, response: Any) -> None:
+        choices = getattr(response, "choices", None) or []
+        message = getattr(choices[0], "message", None) if choices else None
+        usage = getattr(response, "usage", None)
+        self._last_response = {
+            "raw_response": getattr(message, "content", None),
+            "usage": usage.model_dump() if hasattr(usage, "model_dump") else None,
+        }
+
+    def record_failure(self, error: Exception) -> None:
+        record: dict[str, Any] = {
+            "timestamp": time.time(),
+            "error": str(error),
+            "status_code": getattr(error, "status_code", None),
+            "raw_response": None,
+            "usage": None,
+        }
+        if self._last_response is not None:
+            record.update(self._last_response)
+        self.failures.append(record)
+
+
+def _record_raw_llm_responses(llm: Any, recorder: _LLMFailureRecorder) -> None:
+    """Stash each raw chat completion so failed parses keep their payload."""
+    original_get_client = llm.get_client
+
+    def get_client_with_response_recording() -> Any:
+        client = original_get_client()
+        completions = getattr(getattr(client, "chat", None), "completions", None)
+        if completions is None:
+            return client
+        original_create = completions.create
+
+        async def create_with_response_recording(*args: Any, **kwargs: Any) -> Any:
+            response = await original_create(*args, **kwargs)
+            recorder.record_response(response)
+            return response
+
+        completions.create = create_with_response_recording
+        return client
+
+    llm.get_client = get_client_with_response_recording
+
+
+def _capture_llm_failures(llm: Any, recorder: _LLMFailureRecorder) -> None:
+    """Wrap llm.ainvoke so provider/parse failures keep raw response context."""
+    if hasattr(llm, "get_client"):
+        _record_raw_llm_responses(llm, recorder)
+
+    original_ainvoke = llm.ainvoke
+
+    async def ainvoke_with_failure_capture(*args: Any, **kwargs: Any) -> Any:
+        recorder.begin_call()
+        try:
+            return await original_ainvoke(*args, **kwargs)
+        except BrowserUseModelError as exc:
+            recorder.record_failure(exc)
+            raise
+
+    llm.ainvoke = ainvoke_with_failure_capture
+
+
+def _match_step_llm_failures(
+    pending_failures: list[dict[str, Any]],
+    hist_item: Any,
+) -> list[dict[str, Any]]:
+    """Pop failures whose timestamps fall inside this history item's step window."""
+    metadata = getattr(hist_item, "metadata", None)
+    start = getattr(metadata, "step_start_time", None)
+    end = getattr(metadata, "step_end_time", None)
+    if start is None or end is None:
+        return []
+    matched = [failure for failure in pending_failures if start <= failure["timestamp"] <= end]
+    for failure in matched:
+        pending_failures.remove(failure)
+    return matched
 
 
 def _get_config_value(agent_config: dict[str, Any], *keys: str, default: Any = None) -> Any:
@@ -464,6 +559,8 @@ class BrowserUseAgent(BaseAgent):
         # Initialize LLM based on model type, this is a BU specific implementation, and different
         # models have different SDK preferences for utilizing the inference feature in agent scene.
         llm = self._create_llm(model_type, model_id, agent_config, config_info)
+        llm_recorder = _LLMFailureRecorder()
+        _capture_llm_failures(llm, llm_recorder)
 
         # Initialize Browser
         agent = None
@@ -557,6 +654,7 @@ class BrowserUseAgent(BaseAgent):
 
                     try:
                         api_logger = APICallLogger(api_logs_dir, task_id, model_id, system_prompt)
+                        pending_llm_failures = list(llm_recorder.failures)
                         for i, hist_item in enumerate(history.history, 1):
                             api_logger.log_step(
                                 step_number=i,
@@ -564,7 +662,9 @@ class BrowserUseAgent(BaseAgent):
                                 action_results=hist_item.result,
                                 state=hist_item.state,
                                 state_message=getattr(hist_item, "state_message", None),
+                                llm_failures=_match_step_llm_failures(pending_llm_failures, hist_item),
                             )
+                        api_logger.log_unmatched_llm_failures(pending_llm_failures)
                         api_logger.finalize(usage_data)
                     except Exception as exc:
                         logger.warning(f"Failed to generate API logs for task {task_id}: {exc}")

--- a/browseruse_bench/utils/api_logger.py
+++ b/browseruse_bench/utils/api_logger.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -61,6 +61,7 @@ class APICallLogger:
         action_results: list[Any] | None,
         state: Any | None,
         state_message: str | None,
+        llm_failures: list[dict[str, Any]] | None = None,
     ) -> None:
         """
         Log a single LLM API call step.
@@ -71,8 +72,10 @@ class APICallLogger:
             action_results: Results from executing the actions.
             state: Browser state information.
             state_message: Complete state message sent to LLM (contains browser_state, agent_history, etc.).
+            llm_failures: Failed LLM call records for this step (raw response text,
+                token usage, error) captured before the SDK discarded them.
         """
-        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        timestamp = datetime.now(UTC).isoformat(timespec="seconds")
 
         # Extract URL from state if available
         url = None
@@ -99,6 +102,7 @@ class APICallLogger:
             },
             "output": output_data,
             "action_results": results_data,
+            "llm_failures": llm_failures or [],
         }
 
         self.steps.append(step_data)
@@ -190,6 +194,48 @@ class APICallLogger:
             results.append(result_data)
 
         return results
+
+    def log_unmatched_llm_failures(self, failures: list[dict[str, Any]]) -> None:
+        """
+        Write failed LLM call records that could not be attributed to a step.
+
+        Args:
+            failures: Failure records (raw response text, usage, error) whose
+                timestamps fell outside every step window.
+        """
+        if not failures:
+            return
+
+        failures_file = self.api_logs_dir / "llm_failures_unmatched.json"
+        try:
+            failures_file.write_text(json.dumps(failures, ensure_ascii=False, indent=2))
+        except (OSError, TypeError) as exc:
+            logger.warning(f"Failed to write llm_failures_unmatched.json: {exc}")
+
+    @staticmethod
+    def _render_llm_failures(llm_failures: list[dict[str, Any]]) -> list[str]:
+        """Render failed LLM call records as summary.md lines."""
+        lines = ["### LLM Failures", ""]
+        for failure in llm_failures:
+            lines.append(f"- **Error**: {failure.get('error')}")
+            raw_response = failure.get("raw_response")
+            if not raw_response:
+                continue
+            lines.extend(
+                [
+                    "",
+                    "<details>",
+                    "<summary>Raw LLM response</summary>",
+                    "",
+                    "```",
+                    raw_response,
+                    "```",
+                    "",
+                    "</details>",
+                ]
+            )
+        lines.append("")
+        return lines
 
     def finalize(self, usage_data: dict[str, Any] | None = None) -> None:
         """
@@ -325,6 +371,11 @@ class APICallLogger:
                     if is_done:
                         lines.append(f"- **Done**: {is_done}")
                 lines.append("")
+
+            # === LLM FAILURES SECTION ===
+            llm_failures = step_data.get("llm_failures") or []
+            if llm_failures:
+                lines.extend(self._render_llm_failures(llm_failures))
 
             lines.append("---\n")
 

--- a/tests/browseruse_bench/test_api_logger.py
+++ b/tests/browseruse_bench/test_api_logger.py
@@ -1,0 +1,92 @@
+"""Tests for APICallLogger step logging of failed LLM calls."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from browseruse_bench.utils.api_logger import APICallLogger
+
+
+def _failure_record(**overrides: Any) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "timestamp": 1000.5,
+        "error": "Invalid JSON: trailing characters at line 2 column 1",
+        "status_code": 502,
+        "raw_response": '{"action": []}\n{"action": []}',
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    record.update(overrides)
+    return record
+
+
+def test_log_step_writes_llm_failures(tmp_path: Path) -> None:
+    api_logger = APICallLogger(tmp_path, "task-1", "gpt-test")
+    failure = _failure_record()
+
+    api_logger.log_step(
+        step_number=1,
+        model_output=None,
+        action_results=None,
+        state=None,
+        state_message=None,
+        llm_failures=[failure],
+    )
+
+    step_data = json.loads((tmp_path / "step_001.json").read_text())
+    assert step_data["output"] == {}
+    assert step_data["llm_failures"] == [failure]
+
+
+def test_log_step_defaults_to_empty_llm_failures(tmp_path: Path) -> None:
+    api_logger = APICallLogger(tmp_path, "task-1", "gpt-test")
+
+    api_logger.log_step(
+        step_number=1,
+        model_output=None,
+        action_results=None,
+        state=None,
+        state_message=None,
+    )
+
+    step_data = json.loads((tmp_path / "step_001.json").read_text())
+    assert step_data["llm_failures"] == []
+
+
+def test_finalize_summary_includes_llm_failures(tmp_path: Path) -> None:
+    api_logger = APICallLogger(tmp_path, "task-1", "gpt-test")
+    failure = _failure_record()
+
+    api_logger.log_step(
+        step_number=1,
+        model_output=None,
+        action_results=None,
+        state=None,
+        state_message=None,
+        llm_failures=[failure],
+    )
+    api_logger.finalize()
+
+    summary = (tmp_path / "summary.md").read_text()
+    assert "LLM Failures" in summary
+    assert failure["error"] in summary
+    assert failure["raw_response"] in summary
+
+
+def test_log_unmatched_llm_failures_writes_file(tmp_path: Path) -> None:
+    api_logger = APICallLogger(tmp_path, "task-1", "gpt-test")
+    failure = _failure_record()
+
+    api_logger.log_unmatched_llm_failures([failure])
+
+    data = json.loads((tmp_path / "llm_failures_unmatched.json").read_text())
+    assert data == [failure]
+
+
+def test_log_unmatched_llm_failures_skips_empty(tmp_path: Path) -> None:
+    api_logger = APICallLogger(tmp_path, "task-1", "gpt-test")
+
+    api_logger.log_unmatched_llm_failures([])
+
+    assert not (tmp_path / "llm_failures_unmatched.json").exists()

--- a/tests/browseruse_bench/test_browser_use_agent.py
+++ b/tests/browseruse_bench/test_browser_use_agent.py
@@ -3,17 +3,27 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from browser_use.llm.exceptions import ModelProviderError
 from pydantic import BaseModel, ValidationError
 
 from browseruse_bench.agents import browser_use as browser_use_module
 from browseruse_bench.agents.browser_use import BrowserUseAgent
 from browseruse_bench.browsers.types import BrowserSessionContext
+
+
+class _StubLLM:
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> None:
+        return None
 
 
 def test_run_task_uses_backend_manager_session_context(
@@ -406,7 +416,7 @@ def test_run_task_async_tolerates_temp_dir_cleanup_error(
     monkeypatch.setattr(
         BrowserUseAgent,
         "_create_llm",
-        lambda self, model_type, model_id, agent_config, config_info: object(),
+        lambda self, model_type, model_id, agent_config, config_info: _StubLLM(),
     )
     caplog.set_level("WARNING")
 
@@ -473,7 +483,7 @@ def test_run_task_async_maps_early_unfinished_history_to_error(
     monkeypatch.setattr(
         BrowserUseAgent,
         "_create_llm",
-        lambda self, model_type, model_id, agent_config, config_info: object(),
+        lambda self, model_type, model_id, agent_config, config_info: _StubLLM(),
     )
 
     result = asyncio.run(
@@ -541,7 +551,7 @@ def test_run_task_async_keeps_real_max_steps_status(
     monkeypatch.setattr(
         BrowserUseAgent,
         "_create_llm",
-        lambda self, model_type, model_id, agent_config, config_info: object(),
+        lambda self, model_type, model_id, agent_config, config_info: _StubLLM(),
     )
 
     result = asyncio.run(
@@ -623,3 +633,221 @@ def test_create_browser_instance_no_proxy_omits_kwarg(
     finally:
         if temp_dir is not None:
             temp_dir.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Raw LLM response capture for failed/unparseable calls
+# ---------------------------------------------------------------------------
+
+
+_RAW_LLM_TEXT = '{"action": []}\n{"trailing": true}'
+_PARSE_FAIL_MESSAGE = "Invalid JSON: trailing characters at line 2 column 1"
+
+
+class _FakeUsage:
+    def model_dump(self) -> dict[str, Any]:
+        return {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+
+
+def _fake_chat_completion(raw_text: str) -> Any:
+    message = SimpleNamespace(content=raw_text)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=_FakeUsage())
+
+
+class _OpenAIStyleLLM:
+    """ChatOpenAI-shaped fake: get_client() serves a raw completion, ainvoke fails to parse it."""
+
+    def __init__(self, raw_text: str | None = _RAW_LLM_TEXT, fail: bool = True) -> None:
+        self.raw_text = raw_text
+        self.fail = fail
+
+    def get_client(self) -> Any:
+        async def create(*args: Any, **kwargs: Any) -> Any:
+            return _fake_chat_completion(self.raw_text or "")
+
+        completions = SimpleNamespace(create=create)
+        return SimpleNamespace(chat=SimpleNamespace(completions=completions))
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> Any:
+        if self.raw_text is not None:
+            await self.get_client().chat.completions.create()
+        if self.fail:
+            raise ModelProviderError(message=_PARSE_FAIL_MESSAGE, model="gpt-test")
+        return "parsed"
+
+
+def test_capture_llm_failures_records_raw_response_and_usage() -> None:
+    llm = _OpenAIStyleLLM()
+    recorder = browser_use_module._LLMFailureRecorder()
+    browser_use_module._capture_llm_failures(llm, recorder)
+
+    with pytest.raises(ModelProviderError):
+        asyncio.run(llm.ainvoke([]))
+
+    assert len(recorder.failures) == 1
+    failure = recorder.failures[0]
+    assert failure["raw_response"] == _RAW_LLM_TEXT
+    assert failure["usage"] == {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+    assert failure["error"] == _PARSE_FAIL_MESSAGE
+    assert failure["status_code"] == 502
+    assert isinstance(failure["timestamp"], float)
+
+
+def test_capture_llm_failures_keeps_no_records_on_success() -> None:
+    llm = _OpenAIStyleLLM(fail=False)
+    recorder = browser_use_module._LLMFailureRecorder()
+    browser_use_module._capture_llm_failures(llm, recorder)
+
+    assert asyncio.run(llm.ainvoke([])) == "parsed"
+    assert recorder.failures == []
+
+
+def test_capture_llm_failures_clears_stale_raw_response() -> None:
+    llm = _OpenAIStyleLLM(fail=False)
+    recorder = browser_use_module._LLMFailureRecorder()
+    browser_use_module._capture_llm_failures(llm, recorder)
+
+    asyncio.run(llm.ainvoke([]))
+
+    # Second call raises before any completion arrives; the first call's raw
+    # response must not leak into this failure record.
+    llm.raw_text = None
+    llm.fail = True
+    with pytest.raises(ModelProviderError):
+        asyncio.run(llm.ainvoke([]))
+
+    assert len(recorder.failures) == 1
+    assert recorder.failures[0]["raw_response"] is None
+    assert recorder.failures[0]["usage"] is None
+
+
+def test_capture_llm_failures_supports_llm_without_get_client() -> None:
+    class NoClientLLM:
+        async def ainvoke(self, *args: Any, **kwargs: Any) -> Any:
+            raise ModelProviderError(message="provider down", model="other")
+
+    llm = NoClientLLM()
+    recorder = browser_use_module._LLMFailureRecorder()
+    browser_use_module._capture_llm_failures(llm, recorder)
+
+    with pytest.raises(ModelProviderError):
+        asyncio.run(llm.ainvoke([]))
+
+    assert recorder.failures[0]["error"] == "provider down"
+    assert recorder.failures[0]["raw_response"] is None
+
+
+def test_match_step_llm_failures_pops_only_step_window() -> None:
+    hist_item = SimpleNamespace(
+        metadata=SimpleNamespace(step_start_time=100.0, step_end_time=110.0)
+    )
+    pending = [
+        {"timestamp": 99.0, "error": "before"},
+        {"timestamp": 105.0, "error": "inside"},
+        {"timestamp": 111.0, "error": "after"},
+    ]
+
+    matched = browser_use_module._match_step_llm_failures(pending, hist_item)
+
+    assert [failure["error"] for failure in matched] == ["inside"]
+    assert [failure["error"] for failure in pending] == ["before", "after"]
+
+
+def test_match_step_llm_failures_without_metadata_returns_empty() -> None:
+    pending = [{"timestamp": 105.0, "error": "inside"}]
+
+    matched = browser_use_module._match_step_llm_failures(
+        pending,
+        SimpleNamespace(metadata=None),
+    )
+
+    assert matched == []
+    assert len(pending) == 1
+
+
+def test_run_task_async_writes_llm_failure_into_step_log(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeActionResult:
+        extracted_content = None
+        error = "Could not parse response"
+        is_done = False
+
+    class FakeHistory:
+        def __init__(self, start: float, end: float) -> None:
+            self.history = [
+                SimpleNamespace(
+                    model_output=None,
+                    result=[FakeActionResult()],
+                    state=None,
+                    state_message=None,
+                    metadata=SimpleNamespace(step_start_time=start, step_end_time=end),
+                )
+            ]
+
+        def extracted_content(self) -> list[str]:
+            return []
+
+        def number_of_steps(self) -> int:
+            return 1
+
+        def screenshots(self) -> list[str]:
+            return []
+
+        def errors(self) -> list[str | None]:
+            return ["Could not parse response"]
+
+        def is_done(self) -> bool:
+            return False
+
+        def final_result(self) -> str:
+            return ""
+
+    class FakeAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            self.llm = kwargs["llm"]
+            self.history: FakeHistory | None = None
+
+        async def run(self, max_steps: int) -> FakeHistory:
+            del max_steps
+            start = time.time()
+            with contextlib.suppress(ModelProviderError):
+                await self.llm.ainvoke([])
+            self.history = FakeHistory(start, time.time())
+            return self.history
+
+    class FakeBrowser:
+        async def stop(self) -> None:
+            return None
+
+    monkeypatch.setattr(browser_use_module, "Agent", FakeAgent)
+    monkeypatch.setattr(
+        BrowserUseAgent,
+        "_create_browser_instance",
+        staticmethod(lambda session_context: (FakeBrowser(), None)),
+    )
+    monkeypatch.setattr(
+        BrowserUseAgent,
+        "_create_llm",
+        lambda self, model_type, model_id, agent_config, config_info: _OpenAIStyleLLM(),
+    )
+
+    asyncio.run(
+        BrowserUseAgent()._run_task_async(
+            task_info={"task_id": "t-raw", "task_text": "search", "url": "https://example.com"},
+            task_workspace=tmp_path,
+            timeout=600,
+            flash_mode=False,
+            agent_config={"MODEL_TYPE": "OPENAI", "MODEL_ID": "gpt-test"},
+            session_context=BrowserSessionContext(backend_id="Chrome-Local", transport="local"),
+        )
+    )
+
+    step_data = json.loads((tmp_path / "api_logs" / "step_001.json").read_text())
+    assert len(step_data["llm_failures"]) == 1
+    failure = step_data["llm_failures"][0]
+    assert failure["raw_response"] == _RAW_LLM_TEXT
+    assert failure["usage"]["total_tokens"] == 10
+    assert failure["error"] == _PARSE_FAIL_MESSAGE
+    assert not (tmp_path / "api_logs" / "llm_failures_unmatched.json").exists()


### PR DESCRIPTION
## Problem

When an LLM response fails browser-use's AgentOutput pydantic validation, the SDK raises `ModelProviderError` inside `ainvoke` before the agent sees the content — the raw completion text and token usage are discarded. Per-step api_logs then record `output={}` with only a truncated pydantic error preview in `action_results[].error`. During the 2026-06-11 gateway incident (responses containing two concatenated JSON objects, "Invalid JSON: trailing characters"), this made root-cause analysis of ~685 failed calls across two runs impossible without the raw payload.

## Solution

- `_LLMFailureRecorder` stashes each raw chat completion (text + usage + status code) at the OpenAI client layer via the same `get_client` wrap pattern as the existing `_enable_claude_thinking` (the two wrappers compose). The stash resets at the start of every `ainvoke` call so a pre-HTTP failure cannot inherit a stale payload.
- `_capture_llm_failures` wraps `llm.ainvoke`; when browser-use raises `ModelError`, the stashed payload becomes a timestamped failure record and the exception re-raises unchanged.
- `_match_step_llm_failures` attributes failures to history steps by `StepMetadata` time windows; matched records are written into `step_XXX.json` under a new `llm_failures` key, leftovers into `llm_failures_unmatched.json`. `summary.md` renders an "LLM Failures" section with the raw response in a collapsible block.

Scope note (documented in the docstring): raw text is captured for OpenAI-compatible `chat.completions` clients — the bench's primary gateway path. Azure responses-API mode, Anthropic, and Google failures still get error/timestamp records, with `raw_response=None`.

## Review

High-effort multi-agent review (8 finder angles, adversarial verification): 19 candidates, 16 refuted with constructible evidence (wrapper composition, stale-reset test, sanctioned exception pattern, immaterial perf costs). 3 surviving findings: provider scope now documented (second commit); metadata-less steps route to the unmatched file by design; per-task memory growth judged immaterial.

## Testing

- 12 new targeted tests (TDD): raw-response + usage capture, stale-stash reset, non-OpenAI llm shapes, time-window matching, end-to-end `_run_task_async` → step-file assertion. Full suite: 659 passed; the only 2 failures are known pre-existing env-dependent ones (reproduce with this diff stashed).
- Smoke test (required): `bubench run --agent browser-use --data LexBench-Browser --mode single` — 77.1s, 1/1 success, gpt-5.4, 7 steps, 40,166 tokens, `✅ Task completed successfully`; real run's step files carry the new `llm_failures` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)