### PR TITLE
fix(openclaw): recover session data for timeout and empty-payload runs

### DIFF
--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -830,6 +830,12 @@ class OpenClawAgent(CLIAgent):
             answer = "\n".join(
                 str(p.get("text", "")) for p in payloads if isinstance(p, dict) and p.get("text")
             ).strip()
+        if not answer:
+            # Aborted runs can emit the --json payload with text="" while the
+            # real final answer only exists in the session JSONL.
+            recovered = self._session_result(task_workspace, session_id)
+            if recovered:
+                answer = str(recovered["payloads"][0].get("text") or "")
 
         if execution_error and "Timeout" in execution_error:
             logger.error("OpenClaw task %s timed out", task_id)
@@ -845,7 +851,7 @@ class OpenClawAgent(CLIAgent):
         if env_status == "failed" and not answer:
             answer = f"[Task Failed: {error_message or 'No result JSON from OpenClaw'}]"
 
-        items = self._session_items(result_obj, task_workspace)
+        items = self._session_items(result_obj, task_workspace, session_id)
         # Must run before write_api_logs: it pops inline base64 blobs off the
         # items so they never reach the api_logs artifacts.
         saved_screenshots = _collect_media_screenshots(items, trajectory_dir)
@@ -885,7 +891,9 @@ class OpenClawAgent(CLIAgent):
             model_id=model,
             agent_metadata=agent_metadata,
             metrics=AgentMetrics(
-                end_to_end_ms=duration_ms, steps=steps, usage=self._usage_from(result_obj)
+                end_to_end_ms=duration_ms,
+                steps=steps,
+                usage=self._usage_from(result_obj, task_workspace, session_id),
             ),
         )
 
@@ -969,19 +977,28 @@ class OpenClawAgent(CLIAgent):
         return Path(str(session_file)) if session_file else None
 
     @staticmethod
-    def _session_items(result_obj: dict[str, Any], task_workspace: Path) -> list[dict[str, Any]]:
+    def _session_items(
+        result_obj: dict[str, Any], task_workspace: Path, session_id: str = ""
+    ) -> list[dict[str, Any]]:
         session_file = OpenClawAgent._session_file_from(result_obj)
         if session_file is not None:
             return _normalize_session_items(session_file)
         agent_meta = OpenClawAgent._agent_meta(result_obj)
-        session_id = agent_meta.get("sessionId") if agent_meta else None
-        if not session_id:
+        # Timed-out runs killed mid tool-loop leave no result_obj at all; the
+        # caller-known session id still locates the on-disk session JSONL.
+        sid = (agent_meta.get("sessionId") if agent_meta else None) or session_id
+        if not sid:
             return []
-        return _normalize_session_items(_session_file_path(task_workspace, str(session_id)))
+        return _normalize_session_items(_session_file_path(task_workspace, str(sid)))
 
     @staticmethod
-    def _usage_from(result_obj: dict[str, Any]) -> AgentUsage | None:
-        totals = _collect_session_usage(OpenClawAgent._session_file_from(result_obj))
+    def _usage_from(
+        result_obj: dict[str, Any], task_workspace: Path, session_id: str = ""
+    ) -> AgentUsage | None:
+        session_file = OpenClawAgent._session_file_from(result_obj)
+        if session_file is None and session_id:
+            session_file = _session_file_path(task_workspace, session_id)
+        totals = _collect_session_usage(session_file)
         last_call: Any = None
         if not totals["entries"]:
             # lastCallUsage covers only the final LLM call; use it only when

--- a/browseruse_bench/agents/openclaw.py
+++ b/browseruse_bench/agents/openclaw.py
@@ -830,9 +830,12 @@ class OpenClawAgent(CLIAgent):
             answer = "\n".join(
                 str(p.get("text", "")) for p in payloads if isinstance(p, dict) and p.get("text")
             ).strip()
-        if not answer:
+        if result_obj and not answer and returncode in (0, None) and execution_error is None:
             # Aborted runs can emit the --json payload with text="" while the
-            # real final answer only exists in the session JSONL.
+            # real final answer only exists in the session JSONL. Recover it
+            # only for clean exits: on failed runs the "[Task Failed: ...]"
+            # sentinel must survive, and a recovered answer must never flip
+            # has_result for a crashed CLI.
             recovered = self._session_result(task_workspace, session_id)
             if recovered:
                 answer = str(recovered["payloads"][0].get("text") or "")
@@ -977,27 +980,41 @@ class OpenClawAgent(CLIAgent):
         return Path(str(session_file)) if session_file else None
 
     @staticmethod
+    def _resolve_session_file(
+        result_obj: dict[str, Any], task_workspace: Path, session_id: str
+    ) -> Path | None:
+        """Locate the session JSONL for a result.
+
+        Prefer the paths the CLI attested in agentMeta, then fall back to the
+        deterministic per-task layout (timed-out runs killed mid tool-loop
+        leave no result_obj at all). Candidates that do not exist on disk are
+        skipped rather than short-circuiting the fallback chain.
+        """
+        agent_meta = OpenClawAgent._agent_meta(result_obj) or {}
+        candidates: list[Path] = []
+        if agent_meta.get("sessionFile"):
+            candidates.append(Path(str(agent_meta["sessionFile"])))
+        if agent_meta.get("sessionId"):
+            candidates.append(_session_file_path(task_workspace, str(agent_meta["sessionId"])))
+        if session_id:
+            candidates.append(_session_file_path(task_workspace, session_id))
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate
+        return None
+
+    @staticmethod
     def _session_items(
-        result_obj: dict[str, Any], task_workspace: Path, session_id: str = ""
+        result_obj: dict[str, Any], task_workspace: Path, session_id: str
     ) -> list[dict[str, Any]]:
-        session_file = OpenClawAgent._session_file_from(result_obj)
-        if session_file is not None:
-            return _normalize_session_items(session_file)
-        agent_meta = OpenClawAgent._agent_meta(result_obj)
-        # Timed-out runs killed mid tool-loop leave no result_obj at all; the
-        # caller-known session id still locates the on-disk session JSONL.
-        sid = (agent_meta.get("sessionId") if agent_meta else None) or session_id
-        if not sid:
-            return []
-        return _normalize_session_items(_session_file_path(task_workspace, str(sid)))
+        session_file = OpenClawAgent._resolve_session_file(result_obj, task_workspace, session_id)
+        return _normalize_session_items(session_file) if session_file else []
 
     @staticmethod
     def _usage_from(
-        result_obj: dict[str, Any], task_workspace: Path, session_id: str = ""
+        result_obj: dict[str, Any], task_workspace: Path, session_id: str
     ) -> AgentUsage | None:
-        session_file = OpenClawAgent._session_file_from(result_obj)
-        if session_file is None and session_id:
-            session_file = _session_file_path(task_workspace, session_id)
+        session_file = OpenClawAgent._resolve_session_file(result_obj, task_workspace, session_id)
         totals = _collect_session_usage(session_file)
         last_call: Any = None
         if not totals["entries"]:

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -742,13 +742,13 @@ class TestStopPredicate:
 
 
 class TestUsageFromTotalOnly:
-    def test_total_only_last_call_usage_preserved(self) -> None:
+    def test_total_only_last_call_usage_preserved(self, tmp_path: Path) -> None:
         from browseruse_bench.agents.openclaw import OpenClawAgent
 
         result_obj = {
             "meta": {"agentMeta": {"lastCallUsage": {"total": 5000}}},
         }
-        usage = OpenClawAgent._usage_from(result_obj)
+        usage = OpenClawAgent._usage_from(result_obj, tmp_path)
         assert usage is not None
         assert usage.total_tokens == 5000
 
@@ -969,3 +969,103 @@ class TestOutageRetryHardening:
         agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
         cfg = json.loads((tmp_path / ".openclaw-state" / "openclaw.json").read_text())
         assert "ssrfPolicy" not in cfg["browser"]
+
+
+def _write_bench_session(task_workspace: Path, session_id: str, rows: list[dict[str, Any]]) -> Path:
+    """Write a session JSONL at OpenClaw's per-task state-dir layout."""
+    session_file = (
+        task_workspace / ".openclaw-state" / "agents" / "main" / "sessions"
+        / f"{session_id}.jsonl"
+    )
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    session_file.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+    return session_file
+
+
+class TestFinalizeResultSessionFallback:
+    """Timeout / empty-payload runs must still recover data from the session JSONL."""
+
+    def _finalize(
+        self,
+        tmp_path: Path,
+        stdout_lines: list[str],
+        returncode: int | None,
+        execution_error: str | None,
+    ) -> AgentResult:
+        trajectory_dir = tmp_path / "trajectory"
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+        agent = OpenClawAgent()
+        return agent._finalize_result(
+            task_id="t1",
+            model="gpt-test",
+            rules="rules",
+            stdout_lines=stdout_lines,
+            returncode=returncode,
+            execution_error=execution_error,
+            duration_ms=1000,
+            task_workspace=tmp_path,
+            trajectory_dir=trajectory_dir,
+            session_id="bench-t1",
+        )
+
+    def test_timeout_mid_tool_loop_exports_session_items(self, tmp_path: Path) -> None:
+        # Timed-out run killed mid tool-loop: no stdout JSON, and the session's
+        # last message is a toolCall so there is no terminal answer either.
+        # The trajectory data must still be exported from the session JSONL.
+        rows: list[dict[str, Any]] = [
+            {"type": "message", "message": {"role": "user", "content": [
+                {"type": "text", "text": "go"}]}},
+            {"type": "message", "message": {"role": "assistant",
+                "usage": {"input": 100, "output": 20, "cacheRead": 40, "cacheWrite": 0},
+                "content": [
+                    {"type": "toolCall", "id": "c1", "name": "browser",
+                     "arguments": {"action": "open", "url": "https://example.com"}},
+                ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+                "toolName": "browser", "content": [{"type": "text", "text": "opened"}]}},
+            {"type": "message", "message": {"role": "assistant",
+                "usage": {"input": 120, "output": 15, "cacheRead": 40, "cacheWrite": 0},
+                "content": [
+                    {"type": "toolCall", "id": "c2", "name": "browser",
+                     "arguments": {"action": "act", "kind": "click", "ref": "e1"}},
+                ]}},
+        ]
+        _write_bench_session(tmp_path, "bench-t1", rows)
+
+        result = self._finalize(
+            tmp_path, stdout_lines=[], returncode=None,
+            execution_error="Timeout: task exceeded 900s",
+        )
+
+        assert result.env_status == "success"
+        assert result.agent_done == "timeout"
+        assert result.metrics.steps == 2
+        assert list((tmp_path / "api_logs").glob("step_*.json"))
+        assert result.metrics.usage is not None
+        assert result.metrics.usage.entry_count == 2
+
+    def test_empty_payload_text_falls_back_to_session_answer(self, tmp_path: Path) -> None:
+        # The CLI sometimes emits the --json payload with text="" while the
+        # real final answer only exists as the session's terminal assistant
+        # message (observed on aborted runs). The answer must be recovered.
+        final_text = "Best-effort answer: blocked by captcha, no results visible."
+        rows: list[dict[str, Any]] = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "c1", "name": "browser",
+                 "arguments": {"action": "open", "url": "https://example.com"}},
+            ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+                "toolName": "browser", "content": [{"type": "text", "text": "opened"}]}},
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "text", "text": final_text}]}},
+        ]
+        session_file = _write_bench_session(tmp_path, "bench-t1", rows)
+
+        result = self._finalize(
+            tmp_path, stdout_lines=_result_stdout(session_file, answer=""),
+            returncode=0, execution_error=None,
+        )
+
+        assert result.answer == final_text
+        assert result.env_status == "success"
+        assert result.agent_done == "done"

--- a/tests/browseruse_bench/test_openclaw_agent.py
+++ b/tests/browseruse_bench/test_openclaw_agent.py
@@ -13,6 +13,7 @@ from browseruse_bench.agents.openclaw import (
     OpenClawAgent,
     _collect_media_screenshots,
     _normalize_session_items,
+    _session_file_path,
     _stdout_json,
 )
 from browseruse_bench.schemas import AgentResult
@@ -743,12 +744,10 @@ class TestStopPredicate:
 
 class TestUsageFromTotalOnly:
     def test_total_only_last_call_usage_preserved(self, tmp_path: Path) -> None:
-        from browseruse_bench.agents.openclaw import OpenClawAgent
-
         result_obj = {
             "meta": {"agentMeta": {"lastCallUsage": {"total": 5000}}},
         }
-        usage = OpenClawAgent._usage_from(result_obj, tmp_path)
+        usage = OpenClawAgent._usage_from(result_obj, tmp_path, "bench-t1")
         assert usage is not None
         assert usage.total_tokens == 5000
 
@@ -973,10 +972,7 @@ class TestOutageRetryHardening:
 
 def _write_bench_session(task_workspace: Path, session_id: str, rows: list[dict[str, Any]]) -> Path:
     """Write a session JSONL at OpenClaw's per-task state-dir layout."""
-    session_file = (
-        task_workspace / ".openclaw-state" / "agents" / "main" / "sessions"
-        / f"{session_id}.jsonl"
-    )
+    session_file = _session_file_path(task_workspace, session_id)
     session_file.parent.mkdir(parents=True, exist_ok=True)
     session_file.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
     return session_file
@@ -1043,6 +1039,66 @@ class TestFinalizeResultSessionFallback:
         assert list((tmp_path / "api_logs").glob("step_*.json"))
         assert result.metrics.usage is not None
         assert result.metrics.usage.entry_count == 2
+
+    def test_failed_run_keeps_task_failed_sentinel(self, tmp_path: Path) -> None:
+        # A run with a non-timeout execution_error is env-failed; the session's
+        # terminal answer must NOT replace the "[Task Failed: ...]" sentinel
+        # when the CLI's payload text was empty, otherwise the judge grades an
+        # answer on a hard-failed run.
+        rows: list[dict[str, Any]] = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "text", "text": "Interim note before the crash."}]}},
+        ]
+        _write_bench_session(tmp_path, "bench-t1", rows)
+
+        result = self._finalize(
+            tmp_path, stdout_lines=_result_stdout(answer=""), returncode=1,
+            execution_error="Process error: broken pipe",
+        )
+
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert result.answer.startswith("[Task Failed:")
+
+    def test_crashed_cli_with_empty_payload_stays_failed(self, tmp_path: Path) -> None:
+        # Nonzero exit without execution_error and an empty-text payload must
+        # keep the pre-recovery classification: the session's terminal answer
+        # must not flip has_result and mask the crash as (success, done).
+        rows: list[dict[str, Any]] = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "text", "text": "Interim note before the crash."}]}},
+        ]
+        _write_bench_session(tmp_path, "bench-t1", rows)
+
+        result = self._finalize(
+            tmp_path, stdout_lines=_result_stdout(answer=""), returncode=2,
+            execution_error=None,
+        )
+
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert result.answer.startswith("[Task Failed:")
+
+    def test_dangling_session_file_falls_back_to_caller_session_id(self, tmp_path: Path) -> None:
+        # An attested sessionFile that does not exist must not short-circuit
+        # item export when the caller-known session id locates the real JSONL.
+        rows: list[dict[str, Any]] = [
+            {"type": "message", "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "c1", "name": "browser",
+                 "arguments": {"action": "open", "url": "https://example.com"}},
+            ]}},
+            {"type": "message", "message": {"role": "toolResult", "toolCallId": "c1",
+                "toolName": "browser", "content": [{"type": "text", "text": "opened"}]}},
+        ]
+        _write_bench_session(tmp_path, "bench-t1", rows)
+        result_obj = {
+            "meta": {"agentMeta": {"sessionId": "bench-t1",
+                                   "sessionFile": str(tmp_path / "absent.jsonl")}},
+        }
+
+        items = OpenClawAgent._session_items(result_obj, tmp_path, "bench-t1")
+
+        assert len(items) == 1
 
     def test_empty_payload_text_falls_back_to_session_answer(self, tmp_path: Path) -> None:
         # The CLI sometimes emits the --json payload with text="" while the


### PR DESCRIPTION
## Problem

Two finalize-path bugs surfaced by the 20260704_015507 scoring run (100 tasks, gpt-5.5/lexmount), both from not treating the on-disk session JSONL as a fallback source:

1. **Timeout runs lost their whole trajectory.** Runs killed mid tool-loop produce no stdout JSON, and `_session_result` returns None when the session's last message is a toolCall, so `result_obj` was empty and `_session_items`/`_usage_from` had no sessionId to locate the JSONL. api_logs, screenshots, steps and usage were silently dropped — 4 timeout tasks in the scoring run lost 51–79 steps of trajectory each while the data sat on disk.
2. **Aborted runs scored real answers as empty.** The CLI can emit the `--json` payload with `text=""` while the actual final answer only exists as the session's terminal assistant message (task 82: a 364-char best-effort answer graded as empty).

## Fix

- `_resolve_session_file`: one shared resolver (attested sessionFile → attested sessionId → caller-known session_id, skipping candidates that do not exist on disk), used by both `_session_items` and `_usage_from`.
- `_finalize_result`: when the payload text is blank, recover the terminal session answer — guarded to clean exits (`result_obj` present, returncode 0/None, no execution_error) so env-failed runs keep the `[Task Failed: ...]` sentinel and a recovered answer can never flip `has_result` for a crashed CLI.

The second commit is the result of a full 8-angle code review of the first: the guard (confirmed finding: recovered answers on env-failed runs would reach the LLM judge, which never checks env_status), the unified resolver (precedence divergence + dangling-sessionFile short-circuit), and test hygiene.

## Testing

- TDD: 5 new tests written RED-first in `TestFinalizeResultSessionFallback` (timeout export, empty-payload recovery, failed-run sentinel, crashed-CLI classification, dangling-sessionFile fallback); 53/53 in the openclaw test file, 657 unit tests green (2 pre-existing failures verified unrelated by stash-rerun).
- Real-data replay: the scoring run's four zero-export timeout tasks recover 51–79 steps each; task 82's 364-char answer recovered.
- End-to-end smokes on lexmount + gpt-5.5 (per AGENTS.md): `--mode single` (task 5: success/done, 8 steps, 225-char answer, ~60s) and a forced-timeout run (`--id 63 --timeout 180`: agent_done=timeout with steps=17, api_logs=17, usage entries=17, screenshots=2 — previously all zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)