### PR TITLE
fix(logging): keep at most one console handler on the root logger

### DIFF
--- a/browseruse_bench/utils/logger.py
+++ b/browseruse_bench/utils/logger.py
@@ -16,6 +16,8 @@ _NOISY_THIRD_PARTY_LOGGERS = (
 
 _RUN_LOG_HANDLER_ATTR = "_run_log_file_handler"
 
+_CONSOLE_HANDLER_ATTR = "_browseruse_bench_console_handler"
+
 
 def _resolve_log_level(level_text: str, default_level: int) -> int:
     """Resolve a text log level into a logging constant."""
@@ -97,6 +99,30 @@ def add_file_handler(
     return handler
 
 
+def _attach_handlers_to_root(handlers: List[logging.Handler], level: int) -> None:
+    """Attach handlers to the root logger so propagating module-level loggers
+    are captured, keeping at most one console handler on root.
+
+    Every CLI submodule calls ``setup_logger`` at import time; without the
+    marker-based dedupe the root logger would accumulate one console handler
+    per call and print every propagated line that many times. The first
+    console handler to reach root owns the format and stream of propagated
+    output; later ``format_mode`` choices apply only to their named logger.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_has_console = any(
+        getattr(existing, _CONSOLE_HANDLER_ATTR, False)
+        for existing in root_logger.handlers
+    )
+    for handler in handlers:
+        is_console = getattr(handler, _CONSOLE_HANDLER_ATTR, False)
+        if is_console and root_has_console:
+            continue
+        root_logger.addHandler(handler)
+        root_has_console = root_has_console or is_console
+
+
 def setup_logger(
     name: str = __name__,
     log_dir: Optional[str] = None,
@@ -137,6 +163,7 @@ def setup_logger(
     if console_output:
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
+        setattr(console_handler, _CONSOLE_HANDLER_ATTR, True)
         logger.addHandler(console_handler)
         handlers.append(console_handler)
 
@@ -163,11 +190,7 @@ def setup_logger(
             logger.warning(f"[WARNING] Failed to setup file logging: {e}")
 
     if handlers:
-        root_logger = logging.getLogger()
-        root_logger.setLevel(level)
-        for handler in handlers:
-            if handler not in root_logger.handlers:
-                root_logger.addHandler(handler)
+        _attach_handlers_to_root(handlers, level)
 
     _configure_third_party_loggers()
 

--- a/tests/browseruse_bench/test_logger.py
+++ b/tests/browseruse_bench/test_logger.py
@@ -1,0 +1,100 @@
+"""Tests for browseruse_bench.utils.logger root-handler hygiene.
+
+Regression: setup_logger() used to attach a fresh console handler to the
+root logger on every call. Because every CLI submodule calls setup_logger
+at import time, the root logger accumulated ~10 console handlers and any
+propagating module-level logger printed each line ~10 times.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from browseruse_bench.utils.logger import (
+    _CONSOLE_HANDLER_ATTR,
+    _attach_handlers_to_root,
+    setup_logger,
+)
+
+_CLI_LOGGER_NAMES = ("bubench", "run", "eval", "skills", "submit", "leaderboard")
+
+# Loggers mutated by setup_logger during these tests: the CLI-style named
+# loggers, the propagation probe, and the third-party loggers whose levels
+# _configure_third_party_loggers adjusts.
+_TOUCHED_LOGGER_NAMES = _CLI_LOGGER_NAMES + (
+    "browseruse_bench.some_module",
+    "httpx",
+    "httpcore",
+    "openai",
+    "openai._base_client",
+)
+
+
+@pytest.fixture
+def clean_root_logger():
+    """Detach all root handlers for the test; restore root and every logger
+    the tests touch afterwards so no global logging state leaks."""
+    root = logging.getLogger()
+    saved_root = (root.handlers[:], root.level)
+    touched = [logging.getLogger(name) for name in _TOUCHED_LOGGER_NAMES]
+    saved = [(lg, lg.handlers[:], lg.level, lg.propagate) for lg in touched]
+    root.handlers[:] = []
+    yield root
+    root.handlers[:] = saved_root[0]
+    root.setLevel(saved_root[1])
+    for lg, handlers, level, propagate in saved:
+        lg.handlers[:] = handlers
+        lg.setLevel(level)
+        lg.propagate = propagate
+
+
+def _console_handlers(root: logging.Logger) -> list[logging.Handler]:
+    # Count only handlers created by setup_logger; pytest's logging plugin
+    # injects its own StreamHandler subclasses into root during tests.
+    return [h for h in root.handlers if getattr(h, _CONSOLE_HANDLER_ATTR, False)]
+
+
+def test_root_gets_at_most_one_console_handler(clean_root_logger):
+    """Repeated setup_logger calls (one per CLI submodule) must not stack
+    console handlers on the root logger."""
+    for name in _CLI_LOGGER_NAMES:
+        setup_logger(name)
+
+    assert len(_console_handlers(clean_root_logger)) == 1
+
+
+def test_attach_helper_enforces_invariant_within_one_call(clean_root_logger):
+    """Even a single handler list holding several marked console handlers
+    must yield exactly one console handler on root."""
+    marked = []
+    for _ in range(2):
+        handler = logging.StreamHandler()
+        setattr(handler, _CONSOLE_HANDLER_ATTR, True)
+        marked.append(handler)
+
+    _attach_handlers_to_root(marked, logging.INFO)
+
+    assert len(_console_handlers(clean_root_logger)) == 1
+
+
+def test_setup_logger_is_idempotent_for_same_name(clean_root_logger):
+    """Re-configuring the same logger must not leak extra root handlers."""
+    setup_logger("bubench")
+    setup_logger("bubench")
+
+    assert len(_console_handlers(clean_root_logger)) == 1
+
+
+def test_propagating_module_logger_emits_line_once(clean_root_logger, capsys):
+    """A module-level logger propagating to root must print each line once,
+    no matter how many CLI submodules configured their own loggers."""
+    for name in ("bubench", "run", "eval", "skills"):
+        setup_logger(name)
+
+    module_logger = logging.getLogger("browseruse_bench.some_module")
+    module_logger.info("unique-regression-marker")
+
+    captured = capsys.readouterr()
+    assert captured.out.count("unique-regression-marker") == 1


### PR DESCRIPTION
## Summary

`setup_logger()` attached its freshly created console handler to the root logger on every call; the `handler not in root_logger.handlers` check never deduped anything because each call creates new handler objects. Every CLI submodule calls `setup_logger` at import time and `cli/__init__.py` imports them all, so root accumulated ~10 console handlers and any propagating module-level logger (`logging.getLogger(__name__)`) printed each line ~10 times in the parent CLI process.

Fix: console handlers are tagged with a marker attribute (`_CONSOLE_HANDLER_ATTR`) and the new `_attach_handlers_to_root()` helper skips attaching a marked handler when root already holds one. The invariant is enforced both across calls and within a single handler list. File-handler attachment to root is unchanged.

## Contribution type

- [x] Bug fix

## Reproduction or validation

- Repro before fix: `uv run scripts/run.py --agent browser-use --data LexBench-Browser --mode first_n --count 5 --dry-run` printed module-level lines (`browseruse_bench.utils.data_loader`, `utils.task`) once per accumulated handler; after the fix each line appears exactly once (`sort | uniq -d` on the output is empty).
- `uv run pytest tests/browseruse_bench/test_logger.py -v` — 4 new regression tests, written TDD (behavioral test failed with the probe line printed 4x before the fix).
- `uv run pytest tests/` — 679 passed, 1 skipped; the 2 failures (`test_config_loader.py::test_resolve_agent_inline_config_uses_explicit_model_override`, claude-code smoke `.env`-leak) reproduce identically on `main` with the change stashed — pre-existing, not regressions.
- Real smoke run (logger.py is imported by the runner subprocess): `bubench run --agent browser-use --data LexBench-Browser --mode single` — 64.7s wall-clock, subprocess proof: `INFO [Agent] Starting a browser-use agent with version 0.13.3, with provider=openai and model=gpt-5.4` … `[SUCCESS] Task completed successfully`, summary `Total: 1 | Success: 1 | Failed: 0`.

## Self-review (mandatory)

- [x] I read every line of my diff and every change is intentional
- [x] The diff passes the hard rules in CONTRIBUTING.md (logger not print, specific exceptions, no hardcoded config, imports at top)
- [x] I ran a local `/code-review` and fixed or justified every finding
- [x] `uv run pytest tests/` passes and behavior changes have targeted tests
- [x] Agent-touching change: real smoke run evidence is included above
- [x] No secrets, cookies, or unredacted logs in the diff

## Notes for reviewers

Code-review findings and dispositions:
- Fixed: `_attach_handlers_to_root` now re-checks the console marker inside the loop, so the invariant holds even if one handler list carries several marked handlers (regression test added).
- Fixed: the test fixture restores the named loggers and third-party logger levels that `setup_logger` mutates, not just root, so no logging state leaks across tests.
- Documented, intentional: root's console format/stream is first-caller-wins; later `format_mode` choices (skills/login `plain`) apply only to their named logger. Before the fix, propagated lines printed ~10x in mixed formats, so this is strictly better, and named CLI loggers keep their own format via `propagate=False`.
- Out of scope, pre-existing, follow-up filed: file handlers from `setup_logger(log_dir=...)` still stack on root (run + login log files both receive all root-propagated lines) — unchanged behavior, tracked as a separate task.
- Not addressed by design: the dedupe is scoped to handlers this repo creates; a foreign root handler installed by an embedding process (e.g. `logging.basicConfig`) can still duplicate propagated lines. Same as before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)