### PR TITLE
fix(cli): stop bubench run --dry-run from claiming a run directory

### DIFF
--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -760,6 +760,40 @@ def configure_run_parser(parser: argparse.ArgumentParser, config: dict[str, Any]
     )
 
 
+def _resolve_run_output_dir(output_base: Path, args: argparse.Namespace) -> Path | None:
+    """Resolve the run output directory, claiming a fresh one when needed.
+
+    Dry runs must leave the experiments tree untouched — an empty timestamp
+    dir left behind would pollute find-latest and leaderboard scans — so no
+    directory is claimed and ``None`` is returned. Resuming an existing
+    ``--timestamp`` directory is read-only here, so it is still resolved
+    (and validated) for dry runs.
+    """
+    if args.timestamp:
+        timestamp = args.timestamp.strip()
+        if not re.match(r"^\d{8}_\d{6}$", timestamp):
+            raise SystemExit("[FAILED] --timestamp format must be YYYYMMDD_HHmmss")
+        output_dir = output_base / timestamp
+        if not output_dir.exists():
+            raise SystemExit(f"[FAILED] Specified timestamp directory does not exist: {output_dir}")
+        logger.info("Resuming/Running in existing timestamp directory: %s", timestamp)
+        return output_dir
+    if args.dry_run:
+        return None
+    return _claim_unique_run_dir(output_base)
+
+
+def _write_output_dir_marker(marker_path: str | None, output_dir: Path) -> None:
+    """Emit the resolved output dir for run-eval to bind to deterministically
+    (concurrency-safe: each caller passes its own marker file path)."""
+    if not marker_path:
+        return
+    try:
+        Path(marker_path).write_text(str(output_dir), encoding="utf-8")
+    except OSError as exc:
+        logger.error("Failed to write --write-output-dir marker: %s", exc)
+
+
 def _claim_unique_run_dir(output_base: Path, max_seconds: int = 600) -> Path:
     """Atomically create a fresh ``YYYYMMDD_HHMMSS`` run dir under *output_base*.
 
@@ -827,32 +861,18 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
         )
     output_base = REPO_ROOT / "experiments" / benchmark_name / args.split / agent_name / model_id
 
-    if args.timestamp:
-        timestamp = args.timestamp.strip()
-        if not re.match(r"^\d{8}_\d{6}$", timestamp):
-            raise SystemExit("[FAILED] --timestamp format must be YYYYMMDD_HHmmss")
-        output_dir = output_base / timestamp
-        if not output_dir.exists():
-            raise SystemExit(f"[FAILED] Specified timestamp directory does not exist: {output_dir}")
-        logger.info("Resuming/Running in existing timestamp directory: %s", timestamp)
-        output_dir.mkdir(parents=True, exist_ok=True)
-    else:
-        output_dir = _claim_unique_run_dir(output_base)
-        timestamp = output_dir.name
-
-    add_file_handler(logger, output_dir / "run.log", format_mode="plain")
-
-    # Emit the resolved output dir for run-eval to bind to deterministically
-    # (concurrency-safe: each caller passes its own marker file path).
-    write_output_dir = getattr(args, "write_output_dir", None)
-    if write_output_dir:
-        try:
-            Path(write_output_dir).write_text(str(output_dir), encoding="utf-8")
-        except OSError as exc:
-            logger.warning("Failed to write --write-output-dir marker: %s", exc)
+    # Dry runs claim no directory and write no run files (output_dir is None
+    # unless resuming an existing --timestamp directory).
+    output_dir = _resolve_run_output_dir(output_base, args)
+    if not args.dry_run:
+        add_file_handler(logger, output_dir / "run.log", format_mode="plain")
+    # The marker is emitted even on dry runs so run-eval stays on the
+    # authoritative marker binding path instead of its mtime fallback; the
+    # unclaimed output_base has no tasks/ subdir, so run-eval binds nothing.
+    _write_output_dir_marker(getattr(args, "write_output_dir", None), output_dir or output_base)
 
     logger.info("Running %s on %s", agent_name, benchmark_name)
-    logger.info("   Output: %s", output_dir)
+    logger.info("   Output: %s", output_dir or output_base)
     include_raw_machine_identifiers = bool(
         getattr(args, "include_raw_machine_identifiers", False)
         or str(os.getenv(INCLUDE_RAW_MACHINE_IDENTIFIERS_ENV_KEY) or "").strip().lower()
@@ -888,7 +908,9 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
     task_id = getattr(args, "id", None)
     tasks_to_run = filter_tasks(tasks, args.mode, args.count, args.task_ids, task_id)
 
-    if args.skip_completed:
+    # output_dir is None only on a fresh dry run, where nothing can be
+    # completed yet.
+    if args.skip_completed and output_dir is not None:
         tasks_to_run, skipped = filter_completed_tasks(
             tasks_to_run,
             output_dir,
@@ -937,8 +959,7 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
     venv_path = resolve_agent_venv_path(agent_config_dict)
     use_uv = check_uv_available()
     ensure_venv(venv_path, use_uv)
-    if not args.dry_run:
-        install_agent_dependencies(venv_path, extra_name, use_uv, install_targets)
+    install_agent_dependencies(venv_path, extra_name, use_uv, install_targets)
 
     # Prepare environment
     env = os.environ.copy()
@@ -1190,34 +1211,32 @@ def run_agent(agent_name: str, benchmark_name: str, config: dict[str, Any], args
         success_count,
         failed_count,
     )
-    # Skip manifest for dry runs: there is no real run to record and the
-    # tasks_success/failed counters would be misleadingly zero.
-    if not getattr(args, "dry_run", False):
-        try:
-            _write_run_manifest(
-                output_dir,
-                resolved_agent_config=agent_cfg,
-                run_context={
-                    "agent": agent_name,
-                    "benchmark": benchmark_name,
-                    "split": args.split,
-                    "model_id": model_id,
-                    "machine_id": machine_identity.get("machine_id"),
-                    "timestamp": timestamp,
-                    "model_name_override": getattr(args, "model_name", None),
-                    "browser_id_override": getattr(args, "browser_id", None),
-                    "mode": getattr(args, "mode", None),
-                    "task_ids": getattr(args, "task_ids", None),
-                    "task_id": getattr(args, "id", None),
-                    "count": getattr(args, "count", None),
-                    "region": getattr(args, "region", None),
-                    "concurrency": getattr(args, "concurrency", None),
-                    "agent_config_path": str(getattr(args, "agent_config", None) or ""),
-                },
-                machine_identity=machine_identity,
-            )
-        except (OSError, KeyError, AttributeError, TypeError) as exc:
-            logger.warning("Failed to finalize run manifest: %s", exc)
+    # Dry runs returned earlier, so this always records a real run.
+    try:
+        _write_run_manifest(
+            output_dir,
+            resolved_agent_config=agent_cfg,
+            run_context={
+                "agent": agent_name,
+                "benchmark": benchmark_name,
+                "split": args.split,
+                "model_id": model_id,
+                "machine_id": machine_identity.get("machine_id"),
+                "timestamp": output_dir.name,
+                "model_name_override": getattr(args, "model_name", None),
+                "browser_id_override": getattr(args, "browser_id", None),
+                "mode": getattr(args, "mode", None),
+                "task_ids": getattr(args, "task_ids", None),
+                "task_id": getattr(args, "id", None),
+                "count": getattr(args, "count", None),
+                "region": getattr(args, "region", None),
+                "concurrency": getattr(args, "concurrency", None),
+                "agent_config_path": str(getattr(args, "agent_config", None) or ""),
+            },
+            machine_identity=machine_identity,
+        )
+    except (OSError, KeyError, AttributeError, TypeError) as exc:
+        logger.warning("Failed to finalize run manifest: %s", exc)
     return 0 if failed_count == 0 else 1
 
 

--- a/tests/browseruse_bench/test_run_agent_dry_run.py
+++ b/tests/browseruse_bench/test_run_agent_dry_run.py
@@ -1,0 +1,97 @@
+"""Regression tests: `bubench run --dry-run` must leave the experiments tree untouched.
+
+_claim_unique_run_dir() used to run before the dry-run early return, so every
+dry run left an empty YYYYMMDD_HHMMSS directory behind that find-latest and
+leaderboard scans could pick up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from browseruse_bench.cli import run as run_module
+from browseruse_bench.cli.run import configure_run_parser, run_agent
+
+BENCHMARK = "FakeBench"
+AGENT = "dummy-agent"
+CONFIG = {"agents": {AGENT: {}}}
+
+
+@pytest.fixture
+def fake_repo_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    data_dir = tmp_path / "browseruse_bench" / "data" / BENCHMARK
+    data_dir.mkdir(parents=True)
+    (data_dir / "data_info.json").write_text(
+        json.dumps({"default_split": "All", "split": {"All": "task.jsonl"}}),
+        encoding="utf-8",
+    )
+    task = {"id": 1, "query": "open the page", "website": "https://example.com"}
+    (data_dir / "task.jsonl").write_text(json.dumps(task) + "\n", encoding="utf-8")
+    monkeypatch.setattr(run_module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_module,
+        "collect_machine_identity",
+        lambda *args, **kwargs: {"machine_id": "test-machine", "hostname": "test-host"},
+    )
+    return tmp_path
+
+
+def _run_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="bubench run")
+    configure_run_parser(parser, {})
+    args = parser.parse_args(argv)
+    args._inline_agent_config = {"model_id": "test-model"}
+    return args
+
+
+def test_dry_run_claims_no_run_directory(fake_repo_root: Path, tmp_path: Path) -> None:
+    marker = tmp_path / "outdir-marker"
+    args = _run_args(
+        [
+            "--agent", AGENT,
+            "--data", BENCHMARK,
+            "--mode", "first_n",
+            "--count", "1",
+            "--dry-run",
+            "--write-output-dir", str(marker),
+        ]
+    )
+
+    rc = run_agent(AGENT, BENCHMARK, CONFIG, args)
+
+    assert rc == 0
+    assert not (fake_repo_root / "experiments").exists()
+    # The marker is still emitted (run-eval relies on it to stay on the
+    # authoritative binding path), but points at the unclaimed output base,
+    # which run-eval's _read_marker never binds (no tasks/ subdir).
+    marker_content = Path(marker.read_text(encoding="utf-8"))
+    assert marker_content == (
+        fake_repo_root / "experiments" / BENCHMARK / "All" / AGENT / "test-model"
+    )
+    assert not marker_content.exists()
+
+
+def test_dry_run_with_timestamp_writes_nothing_to_existing_dir(fake_repo_root: Path) -> None:
+    existing = (
+        fake_repo_root / "experiments" / BENCHMARK / "All" / AGENT / "test-model" / "20260101_000000"
+    )
+    existing.mkdir(parents=True)
+    args = _run_args(
+        [
+            "--agent", AGENT,
+            "--data", BENCHMARK,
+            "--mode", "first_n",
+            "--count", "1",
+            "--dry-run",
+            "--timestamp", "20260101_000000",
+        ]
+    )
+
+    rc = run_agent(AGENT, BENCHMARK, CONFIG, args)
+
+    assert rc == 0
+    assert list(existing.iterdir()) == []


### PR DESCRIPTION
## Summary

`bubench run --dry-run` left an empty `YYYYMMDD_HHMMSS` directory under `experiments/{benchmark}/{split}/{agent}/{model_id}/` on every invocation, because `_claim_unique_run_dir()` in `browseruse_bench/cli/run.py` ran before the `args.dry_run` early return. These empty dirs pollute the experiments tree and can be picked up by find-latest / leaderboard scans. Dry-run resume (`--dry-run --timestamp ...`) additionally wrote `run.log` into the resumed directory.

Changes:

- Extract output-dir resolution into `_resolve_run_output_dir()`: dry runs claim no directory (returns `None`); an existing `--timestamp` directory is still resolved and validated read-only, so resume previews (including `--skip-completed` filtering) keep working.
- Gate the `run.log` file handler on non-dry runs.
- Keep emitting the `--write-output-dir` marker on dry runs, pointing at the unclaimed output base. The base has no `tasks/` subdir, so run-eval's `_read_marker` binds nothing — authoritatively, instead of falling back to the concurrency-unsafe mtime heuristic (which could have bound and reported a concurrent invocation's run dir).
- Extract `_write_output_dir_marker()` (explicit `marker_path` param, error-level log on failure per error-handling rules).
- Remove dead dry-run guards around `install_agent_dependencies` and `_write_run_manifest` (both unreachable after the early return), and the redundant `mkdir` after the `--timestamp` existence check.

## Contribution type

- [x] Bug fix

## Reproduction or validation

```bash
# regression tests (new): dry run claims no dir, writes no run.log, marker points at unclaimed base
uv run pytest tests/browseruse_bench/test_run_agent_dry_run.py -v

# full suite
uv run pytest tests/

# real CLI dry-run with before/after snapshot of experiments tree: zero new directories,
# marker contains .../experiments/LexBench-Browser/All/browser-use/gpt-5.4 (unclaimed)
uv run bubench run --agent browser-use --data LexBench-Browser --mode single --dry-run

# real smoke run (agent-touching change)
bubench run --agent browser-use --data LexBench-Browser --mode single
```

Smoke run evidence: wall-clock 2:47.78; subprocess did real work — `INFO [Agent] ✅ Task completed successfully`, outer summary `[SUMMARY] Total: 1 | Success: 1 | Failed: 0`; run dir `experiments/LexBench-Browser/All/browser-use/gpt-5.4/20260707_144958/` claimed with the same artifact layout as prior runs (`run.log`, `config_snapshot.json`, `tasks/`).

Full pytest: 644 passed / 2 failed — both failures are pre-existing and environment-conditional, reproduced on a clean tree via `git stash`: `test_config_loader::test_resolve_agent_inline_config_uses_explicit_model_override`, and `test_claude_code_agent` (known `.env`-leak un-skips a live-CLI test that hits the local proxy). Collection errors in `test_browsers.py` / `test_job_submission.py` / `test_sync_hf_dataset.py` are missing optional SDKs, also pre-existing.

## Self-review (mandatory)

- [x] I read every line of my diff and every change is intentional
- [x] The diff passes the hard rules in CONTRIBUTING.md (logger not print, specific exceptions, no hardcoded config, imports at top)
- [x] I ran a local `/code-review` and fixed or justified every finding
- [x] `uv run pytest tests/` passes and behavior changes have targeted tests
- [x] Agent-touching change: real smoke run evidence is included above
- [x] No secrets, cookies, or unredacted logs in the diff

`/code-review` findings fixed: dry runs dropping the run-eval marker (restored, see above); exception log level warning→error; derivable `timestamp` tuple return removed; dead manifest guard removed; marker helper takes explicit param; tests no longer trigger a live `socket.getfqdn()` DNS lookup. Justified, not fixed: the `^\d{8}_\d{6}$` timestamp regex is now the 4th inline copy in the codebase — pre-existing duplication, left for a follow-up to consolidate into one shared constant; the new tests intentionally use a real file-based fake repo root (rather than reusing `_patch_minimal_run_dependencies` from `test_run_dependency_sync.py`) so the regression is exercised through the real data-loading path; `output_dir: Path | None` threading (vs restructuring `run_agent`) keeps the change minimal — the None window is short and commented, and pyright is not CI-enforced.

## Notes for reviewers

Behavior deltas beyond the fix itself: on dry runs the `Output:` log line now prints the model_id base dir (no run dir exists), and the `--write-output-dir` marker contains the unclaimed base path instead of a claimed empty run dir — run-eval binding semantics are unchanged (binds nothing in both cases). `--dry-run --timestamp --skip-completed` still filters against the existing dir so resume previews stay accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)