### PR TITLE
fix(eval): make --force-reeval effective and stop double-counting resumed eval records

### DIFF
--- a/browseruse_bench/cli/eval.py
+++ b/browseruse_bench/cli/eval.py
@@ -16,6 +16,7 @@ from browseruse_bench.utils import (
     DataSource,
     add_eval_args,
     classify_failures_batch,
+    dedupe_records_keep_newest,
     find_latest_tasks_dir,
     get_env_var,
     handle_cli_errors,
@@ -55,12 +56,17 @@ def run_failure_classification(
     model: str,
     api_key: str,
     base_url: str,
-    skip_existing: bool = False,
+    skip_existing: bool = True,
     num_workers: int = 4,
     max_samples: int | None = None,
     temperature: float | None = None,
 ) -> int:
-    """Run failure classification on results file (post-evaluation)."""
+    """Run failure classification on results file (post-evaluation).
+
+    skip_existing defaults to True so resume evals do not re-classify records
+    that already carry a failure_category; use `bubench attribute --force` to
+    re-label everything.
+    """
     if not results_file.exists():
         logger.warning("Results file not found, skipping failure classification: %s", results_file)
         return 1
@@ -83,6 +89,14 @@ def run_failure_classification(
     if not eval_results:
         logger.warning("Evaluation results empty, skipping failure classification: %s", results_file)
         return 0
+
+    deduped = dedupe_records_keep_newest(eval_results)
+    if len(deduped) != len(eval_results):
+        logger.info(
+            "Deduplicated results before classification: %d -> %d records",
+            len(eval_results), len(deduped),
+        )
+        eval_results = deduped
 
     model_instance = load_evaluation_model(model, api_key, base_url, temperature=temperature)
     logger.info("Starting failure classification: %s records", len(eval_results))
@@ -383,6 +397,7 @@ def run_evaluation(
         split=args.split,
         data_source=getattr(args, "data_source", DataSource.LOCAL),
         mode=eval_mode,
+        force_reeval=bool(getattr(args, "force_reeval", False)),
         extra=extra,
     )
 
@@ -429,6 +444,7 @@ def run_evaluation(
         model_name,
         api_key,
         base_url,
+        skip_existing=True,
         temperature=temperature,
     ) if results_file else 0
 
@@ -481,7 +497,11 @@ def configure_eval_parser(parser: argparse.ArgumentParser, config: dict[str, Any
     parser.add_argument(
         "--force-reeval",
         action="store_true",
-        help="Rerun evaluation (default reuses existing results, only runs failure classification)",
+        help=(
+            "Archive existing eval results (timestamped .bak) and re-judge every task. "
+            "Default resumes: keeps existing records, evaluates missing tasks, and skips "
+            "already-classified failures (use `bubench attribute --force` to re-label those)."
+        ),
     )
     parser.add_argument(
         "--agent-config",

--- a/browseruse_bench/eval/base.py
+++ b/browseruse_bench/eval/base.py
@@ -5,6 +5,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Iterator, List, Optional, Set
 
@@ -13,6 +14,7 @@ import openai
 from browseruse_bench.eval.model import EvaluationModel, current_task_id
 from browseruse_bench.eval.summary import (
     aggregate_evaluation_costs,
+    dedupe_records_keep_newest,
     generate_evaluation_summary,
 )
 from browseruse_bench.schemas.eval_result import EvalResult
@@ -36,6 +38,7 @@ class EvaluatorArgs:
     split: str
     data_source: str
     mode: str
+    force_reeval: bool = False
     extra: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -120,6 +123,10 @@ class BaseEvaluator(ABC):
     def run(self) -> int:
         self.args.output_path.mkdir(parents=True, exist_ok=True)
         tasks = self.load_tasks()
+        # Archive only after load_tasks succeeded, so a startup failure (bad
+        # split, missing dataset) leaves the previous results untouched.
+        if self.args.force_reeval:
+            self._discard_existing_results()
         completed = self.list_completed_tasks()
         already = self._resume_skip_set()
         pending = [
@@ -129,21 +136,79 @@ class BaseEvaluator(ABC):
         logger.info("Evaluating %d tasks (skip %d already done)", len(pending), len(already))
         for result in self._run_iteration(pending, tasks):
             self._append_result(result)
-        # Hook runs before summary so subclasses (e.g. LexBench coverage backfill)
-        # can mutate the JSONL on disk; we re-read after the hook to pick up any
-        # records the hook added.
+        # Hook runs before the dedupe/summary pass so subclasses (e.g. LexBench
+        # coverage backfill) can mutate the JSONL on disk; _dedupe_results_file
+        # then re-reads the file, collapses duplicate task_ids (newest wins),
+        # and returns the records the summary is built from.
         records = self._load_all_records()
         self.post_eval_hook(records)
-        records = self._load_all_records()
+        records = self._dedupe_results_file()
         self._generate_summary(records)
         return 0
 
+    def _discard_existing_results(self) -> None:
+        """Archive the pre-reeval results file so the run starts from scratch.
+
+        The backup keeps a .bak suffix so it never matches the *_results.json
+        globs that leaderboard/visualization use to locate canonical results.
+        """
+        path = self.results_path()
+        if not path.exists():
+            return
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        backup = path.with_name(f"{path.name}.{stamp}.bak")
+        counter = 1
+        while backup.exists():
+            backup = path.with_name(f"{path.name}.{stamp}-{counter}.bak")
+            counter += 1
+        path.replace(backup)
+        logger.info("force-reeval: archived existing results file to %s", backup.name)
+
+    def _dedupe_results_file(self) -> List[Dict[str, Any]]:
+        """Collapse duplicate task_id records and return the deduped list.
+
+        Resume runs can legitimately re-judge a task that already has a line on
+        disk (e.g. a synthetic placeholder whose trajectory appeared later), and
+        _append_result then leaves both lines; without dedupe the summary and
+        every downstream reader would double-count that task. The file is only
+        rewritten when duplicates were dropped and every line parsed — with
+        unparseable lines present the rewrite would silently destroy them, so
+        dedupe then applies to the returned records only.
+        """
+        records, malformed = self._load_records_counting_malformed()
+        deduped = dedupe_records_keep_newest(records)
+        if len(deduped) == len(records):
+            return records
+        if malformed:
+            logger.warning(
+                "Results file %s has %d unparseable lines; skipped dedupe rewrite to preserve them",
+                self.results_path().name, malformed,
+            )
+            return deduped
+        self._write_records(deduped)
+        logger.info("Deduplicated results file: %d -> %d records", len(records), len(deduped))
+        return deduped
+
+    def _write_records(self, records: List[Dict[str, Any]]) -> None:
+        """Atomically replace the results JSONL with the given records."""
+        path = self.results_path()
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            for record in records:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        tmp_path.replace(path)
+
     def _load_all_records(self) -> List[Dict[str, Any]]:
         """Load every record currently appended to the results JSONL on disk."""
+        return self._load_records_counting_malformed()[0]
+
+    def _load_records_counting_malformed(self) -> tuple[List[Dict[str, Any]], int]:
+        """Load results records, also counting lines that failed to parse."""
         path = self.results_path()
         records: List[Dict[str, Any]] = []
+        malformed = 0
         if not path.exists():
-            return records
+            return records, malformed
         with open(path, encoding="utf-8") as fh:
             for line in fh:
                 line = line.strip()
@@ -152,10 +217,13 @@ class BaseEvaluator(ABC):
                 try:
                     record = json.loads(line)
                 except json.JSONDecodeError:
+                    malformed += 1
                     continue
                 if isinstance(record, dict):
                     records.append(record)
-        return records
+                else:
+                    malformed += 1
+        return records, malformed
 
     def _resume_skip_set(self) -> Set[str]:
         path = self.results_path()

--- a/browseruse_bench/eval/lexbench_browser/evaluator.py
+++ b/browseruse_bench/eval/lexbench_browser/evaluator.py
@@ -581,9 +581,7 @@ class LexBenchBrowserEvaluator(BaseEvaluator):
             synthetic = self._build_synthetic_failure(tid, tasks[tid])
             records_by_task_id[tid] = synthetic
         ordered = [records_by_task_id[tid] for tid in expected]
-        with open(self.results_path(), "w", encoding="utf-8") as fh:
-            for record in ordered:
-                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        self._write_records(ordered)
         logger.info("Backfilled %d synthetic failure records", len(missing))
 
     def _build_synthetic_failure(self, task_id: str, task_data: dict[str, Any]) -> dict[str, Any]:

--- a/browseruse_bench/eval/summary.py
+++ b/browseruse_bench/eval/summary.py
@@ -184,6 +184,25 @@ def _convert_json_to_jsonl(results_file: Path) -> Optional[Path]:
     return temp_path
 
 
+def dedupe_records_keep_newest(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collapse duplicate task_id records, keeping the newest occurrence.
+
+    Results JSONL files are append-only, so a later record for the same
+    task_id supersedes an earlier one (e.g. a synthetic placeholder that was
+    re-judged on resume). Order of first appearance is preserved; records
+    without a string task_id are kept unchanged after the deduped ones.
+    """
+    by_task_id: Dict[str, Dict[str, Any]] = {}
+    extras: List[Dict[str, Any]] = []
+    for record in records:
+        task_id = record.get("task_id")
+        if isinstance(task_id, str):
+            by_task_id[task_id] = record
+        else:
+            extras.append(record)
+    return list(by_task_id.values()) + extras
+
+
 @contextmanager
 def normalized_results_file(results_file: Path) -> Iterator[Path]:
     """Yield a path that is guaranteed to be JSONL-like, cleaning up temp files."""

--- a/browseruse_bench/utils/__init__.py
+++ b/browseruse_bench/utils/__init__.py
@@ -60,6 +60,7 @@ from browseruse_bench.eval.score import calculate_success, extract_score_from_re
 from browseruse_bench.eval.summary import (
     aggregate_evaluation_costs,
     calculate_evaluation_cost,
+    dedupe_records_keep_newest,
     normalized_results_file,
 )
 from browseruse_bench.utils.image_utils import (
@@ -197,6 +198,7 @@ __all__ = [
     "aggregate_evaluation_costs",
     "calculate_success",
     "find_latest_tasks_dir",
+    "dedupe_records_keep_newest",
     "normalized_results_file",
     # Failure classification
     "classify_failure_case",

--- a/tests/browseruse_bench/test_eval_base.py
+++ b/tests/browseruse_bench/test_eval_base.py
@@ -1,6 +1,7 @@
 """Tests for BaseEvaluator scaffolding."""
 from __future__ import annotations
 
+import json
 from dataclasses import fields, is_dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,7 @@ from browseruse_bench.schemas import (
     EvalDetails,
     EvalResult,
 )
+from browseruse_bench.utils.json_io import load_jsonl
 
 
 def test_evaluator_args_is_dataclass():
@@ -29,7 +31,7 @@ def test_evaluator_args_required_fields():
     assert expected.issubset(field_names)
 
 
-def _make_args(tmp_path: Path) -> EvaluatorArgs:
+def _make_args(tmp_path: Path, force_reeval: bool = False) -> EvaluatorArgs:
     traj = tmp_path / "tasks"
     traj.mkdir()
     out = tmp_path / "out"
@@ -47,6 +49,7 @@ def _make_args(tmp_path: Path) -> EvaluatorArgs:
         split="All",
         data_source="local",
         mode="fake_mode",
+        force_reeval=force_reeval,
     )
 
 
@@ -118,6 +121,133 @@ def test_run_resumes_already_evaluated(tmp_path):
     ev.run()
     assert "evaluate:t1" not in ev.calls
     assert "evaluate:t2" in ev.calls
+
+
+def test_force_reeval_discards_stale_results(tmp_path):
+    """--force-reeval must re-judge every task; no stale record may survive."""
+    args = _make_args(tmp_path, force_reeval=True)
+    _seed_trajectories(args, ("t1", "t2"))
+    out = args.output_path / "Fake_fake-model_results.json"
+    out.write_text(
+        '{"task_id": "t1", "predicted_label": 0, "stale": true}\n', encoding="utf-8"
+    )
+    tasks = {"t1": {"desc": "one"}, "t2": {"desc": "two"}}
+    ev = _FakeEvaluator(args, model=None, tasks=tasks)
+    assert ev.run() == 0
+    assert "evaluate:t1" in ev.calls
+    assert "evaluate:t2" in ev.calls
+    records = load_jsonl(out)
+    assert sorted(r["task_id"] for r in records) == ["t1", "t2"]
+    assert not any(r.get("stale") for r in records)
+    summary = json.loads(ev.summary_path().read_text(encoding="utf-8"))
+    assert summary["overall_statistics"]["evaluated_tasks"] == 2
+    assert summary["task_list"]["failed_task_ids"] == []
+
+
+def test_force_reeval_archives_old_results_as_backup(tmp_path):
+    """The pre-reeval file is renamed to a .bak sidecar, not destroyed.
+
+    The backup must not be picked up by the canonical results glob that
+    leaderboard/visualization use, or it would be double-counted.
+    """
+    args = _make_args(tmp_path, force_reeval=True)
+    _seed_trajectories(args, ("t1",))
+    out = args.output_path / "Fake_fake-model_results.json"
+    stale_line = '{"task_id": "t1", "predicted_label": 0, "stale": true}\n'
+    out.write_text(stale_line, encoding="utf-8")
+    ev = _FakeEvaluator(args, model=None, tasks={"t1": {"desc": "one"}})
+    assert ev.run() == 0
+    backups = list(args.output_path.glob("*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == stale_line
+    assert list(args.output_path.glob("*_results.json")) == [out]
+
+
+def test_force_reeval_keeps_results_when_load_tasks_fails(tmp_path):
+    """A force-reeval that fails during startup must not touch the results file."""
+    args = _make_args(tmp_path, force_reeval=True)
+    _seed_trajectories(args, ("t1",))
+    out = args.output_path / "Fake_fake-model_results.json"
+    stale_line = '{"task_id": "t1", "predicted_label": 1}\n'
+    out.write_text(stale_line, encoding="utf-8")
+
+    class _BrokenTasksEvaluator(_FakeEvaluator):
+        def load_tasks(self):
+            raise ValueError("bad split")
+
+    ev = _BrokenTasksEvaluator(args, model=None, tasks={})
+    with pytest.raises(ValueError):
+        ev.run()
+    assert out.read_text(encoding="utf-8") == stale_line
+    assert list(args.output_path.glob("*.bak")) == []
+
+
+def test_force_reeval_backup_names_do_not_collide(tmp_path, monkeypatch):
+    """Two archives within the same second must keep both backups."""
+    import browseruse_bench.eval.base as eval_base
+
+    fixed = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDatetime:
+        @staticmethod
+        def now(tz):
+            return fixed
+
+    monkeypatch.setattr(eval_base, "datetime", _FixedDatetime)
+    args = _make_args(tmp_path, force_reeval=True)
+    ev = _FakeEvaluator(args, model=None, tasks={})
+    out = ev.results_path()
+    for content in ("first", "second"):
+        out.write_text(content, encoding="utf-8")
+        ev._discard_existing_results()
+    backups = sorted(args.output_path.glob("*.bak"))
+    assert len(backups) == 2
+    assert {b.read_text(encoding="utf-8") for b in backups} == {"first", "second"}
+
+
+def test_summary_dedupes_duplicate_records_keeping_newest(tmp_path):
+    """Duplicate JSONL lines for one task_id must not inflate the summary."""
+    args = _make_args(tmp_path)
+    _seed_trajectories(args, ("t2",))
+    out = args.output_path / "Fake_fake-model_results.json"
+    out.write_text(
+        '{"task_id": "t1", "predicted_label": 0}\n'
+        '{"task_id": "t1", "predicted_label": 1}\n',
+        encoding="utf-8",
+    )
+    tasks = {"t1": {"desc": "one"}, "t2": {"desc": "two"}}
+    ev = _FakeEvaluator(args, model=None, tasks=tasks)
+    assert ev.run() == 0
+    records = load_jsonl(out)
+    assert [r["task_id"] for r in records] == ["t1", "t2"]
+    assert records[0]["predicted_label"] == 1
+    summary = json.loads(ev.summary_path().read_text(encoding="utf-8"))
+    assert summary["overall_statistics"]["evaluated_tasks"] == 2
+    assert summary["task_list"]["successful_task_ids"] == ["t1", "t2"]
+    assert summary["task_list"]["failed_task_ids"] == []
+
+
+def test_dedupe_preserves_file_with_malformed_lines(tmp_path):
+    """Unparseable lines block the rewrite but not the in-memory dedupe."""
+    args = _make_args(tmp_path)
+    _seed_trajectories(args, ("t2",))
+    out = args.output_path / "Fake_fake-model_results.json"
+    out.write_text(
+        '{"task_id": "t1", "predicted_label": 0}\n'
+        '{"task_id": "t1", "predicted_label": 1}{"broken": \n'
+        '{"task_id": "t1", "predicted_label": 1}\n',
+        encoding="utf-8",
+    )
+    tasks = {"t1": {"desc": "one"}, "t2": {"desc": "two"}}
+    ev = _FakeEvaluator(args, model=None, tasks=tasks)
+    assert ev.run() == 0
+    lines = [
+        line for line in out.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    assert len(lines) == 4  # 3 original lines (1 malformed kept) + appended t2
+    summary = json.loads(ev.summary_path().read_text(encoding="utf-8"))
+    assert summary["overall_statistics"]["evaluated_tasks"] == 2
+    assert summary["task_list"]["successful_task_ids"] == ["t1", "t2"]
 
 
 def test_run_skips_unknown_completed_dirs(tmp_path):

--- a/tests/browseruse_bench/test_eval_cli.py
+++ b/tests/browseruse_bench/test_eval_cli.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-import pytest
-
+import argparse
 import json
 
-from browseruse_bench.cli.eval import _parse_extra_args, refresh_summary_failure_stats
+import pytest
+
+from browseruse_bench.cli import eval as eval_cli
+from browseruse_bench.cli.eval import (
+    _parse_extra_args,
+    refresh_summary_failure_stats,
+    run_failure_classification,
+)
 
 
 def test_parse_eval_extra_args_coerces_private_options() -> None:
@@ -49,3 +55,108 @@ def test_refresh_summary_failure_stats_missing_summary_is_noop(tmp_path) -> None
     results.write_text(json.dumps({"task_id": "1", "predicted_label": 0}), encoding="utf-8")
 
     refresh_summary_failure_stats(results)
+
+
+def _make_fake_evaluator(out_dir, captured, results_body: str | None = None):
+    class _FakeEvaluator:
+        default_mode = "fake_mode"
+        uses_per_task_threshold = False
+
+        def __init__(self, evaluator_args, model):
+            captured["args"] = evaluator_args
+
+        def run(self):
+            if results_body is not None:
+                out_dir.mkdir(parents=True, exist_ok=True)
+                self.results_path().write_text(results_body, encoding="utf-8")
+            return 0
+
+        def results_path(self):
+            return out_dir / "results.json"
+
+        def summary_path(self):
+            return out_dir / "summary.json"
+
+    return _FakeEvaluator
+
+
+def _patch_eval_cli(monkeypatch, traj, evaluator_cls) -> None:
+    monkeypatch.setattr(eval_cli, "get_evaluator_class", lambda name: evaluator_cls)
+    monkeypatch.setattr(eval_cli, "load_data_info", lambda path: {})
+    monkeypatch.setattr(eval_cli, "resolve_split", lambda split, info: "All")
+    monkeypatch.setattr(eval_cli, "find_latest_tasks_dir", lambda base: traj)
+    monkeypatch.setattr(eval_cli, "load_evaluation_model", lambda *a, **kw: None)
+
+
+def _eval_args(**overrides) -> argparse.Namespace:
+    ns = argparse.Namespace(
+        model_id="model-x", split="All", timestamp=None, mode=None,
+        api_key="k", base_url="", model="judge", score_threshold=None,
+        num_worker=1, dry_run=False, force_reeval=False,
+        data_source="local", force_download=False, eval_strategy=None,
+    )
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_run_evaluation_passes_force_reeval_to_evaluator(tmp_path, monkeypatch) -> None:
+    traj = tmp_path / "run" / "tasks"
+    traj.mkdir(parents=True)
+    captured: dict = {}
+    evaluator_cls = _make_fake_evaluator(traj.parent / "tasks_eval_result", captured)
+    _patch_eval_cli(monkeypatch, traj, evaluator_cls)
+
+    args = _eval_args(force_reeval=True)
+    assert eval_cli.run_evaluation("agent-x", "Fake", {"eval": {}}, args, []) == 0
+    assert captured["args"].force_reeval is True
+
+
+def test_run_evaluation_skips_already_classified_failures(tmp_path, monkeypatch) -> None:
+    """A resume eval must not re-classify failures that already have a category."""
+    traj = tmp_path / "run" / "tasks"
+    traj.mkdir(parents=True)
+    captured: dict = {}
+    evaluator_cls = _make_fake_evaluator(
+        traj.parent / "tasks_eval_result",
+        captured,
+        results_body='{"task_id": "t1", "predicted_label": 0, "failure_category": "M2"}\n',
+    )
+    _patch_eval_cli(monkeypatch, traj, evaluator_cls)
+
+    def _fake_batch(eval_results, trajectories_dir, model, *, skip_existing, **kwargs):
+        captured["skip_existing"] = skip_existing
+        return eval_results
+
+    monkeypatch.setattr(eval_cli, "classify_failures_batch", _fake_batch)
+
+    assert eval_cli.run_evaluation("agent-x", "Fake", {"eval": {}}, _eval_args(), []) == 0
+    assert captured["skip_existing"] is True
+
+
+def test_run_failure_classification_dedupes_records(tmp_path, monkeypatch) -> None:
+    """Duplicate task_id lines are collapsed (newest wins) before classification."""
+    results = tmp_path / "task_m_per_task_eval_results.json"
+    results.write_text(
+        '{"task_id": "t1", "predicted_label": 0, "failure_category": "M2"}\n'
+        '{"task_id": "t1", "predicted_label": 1}\n',
+        encoding="utf-8",
+    )
+    captured: dict = {}
+
+    def _fake_batch(eval_results, trajectories_dir, model, *, skip_existing, **kwargs):
+        captured["records"] = eval_results
+        return eval_results
+
+    monkeypatch.setattr(eval_cli, "load_evaluation_model", lambda *a, **kw: None)
+    monkeypatch.setattr(eval_cli, "classify_failures_batch", _fake_batch)
+
+    assert run_failure_classification(results, tmp_path, "judge", "k", "") == 0
+    assert [r["task_id"] for r in captured["records"]] == ["t1"]
+    assert captured["records"][0]["predicted_label"] == 1
+    lines = [
+        line
+        for line in results.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(lines) == 1


### PR DESCRIPTION
## Summary

`bubench eval --force-reeval` was a parsed-but-unconsumed flag, and `BaseEvaluator.run()` aggregated every appended JSONL line into the summary. On resume, LexBench legitimately re-judges synthetic "not evaluated" placeholders, and `_append_result` left both lines — so summaries mixed stale records from earlier (possibly broken) eval rounds with the re-run. Observed 2026-07-07 on `experiments/LexBench-Browser/All/browser-use/gpt-5.4/20260707_113324`: `evaluated_tasks=39` for a 20-task run (19 duplicated task_ids, duplicated `failed_task_ids`), and task 21's stale broken record "won" because the re-run skipped it.

Fixes:

- **`--force-reeval` now works**: the flag flows through `EvaluatorArgs`; `run()` archives the existing results JSONL to a timestamped `.bak` (collision-safe; only after `load_tasks()` succeeds, so a startup failure leaves the previous results untouched) and re-judges every completed task. Per judge-model isolation is preserved — only the current filename is archived, and `.bak` matches none of the downstream `*_results.json` globs.
- **Dedupe before summary**: after `post_eval_hook`, duplicate `task_id` records collapse to the newest occurrence; the summary is built from the deduped set. The rewrite is atomic (tmp + replace, via a shared `_write_records` that the LexBench backfill now uses too) and is skipped when unparseable lines would otherwise be silently destroyed (dedupe then applies in memory only).
- **No repeated attribution cost**: `run_failure_classification` dedupes records first and now defaults to `skip_existing=True` (passed explicitly at the eval call site), so plain resume evals no longer re-classify every already-labeled failure on each invocation; `bubench attribute --force` remains the explicit re-label path. `--force-reeval` help text updated accordingly.

Replaying the new dedupe + summary on the contaminated production file: 39 lines -> 20 records, unique `failed_task_ids`, correct counts.

## Contribution type

- [ ] Agent adapter
- [ ] Browser backend
- [ ] Benchmark task or data
- [ ] Leaderboard/result submission
- [x] Evaluation or judge strategy
- [ ] Documentation/example
- [x] Bug fix

## Reproduction or validation

```bash
uv run pytest tests/browseruse_bench/ -q   # 666 passed; the only failure is the pre-existing
                                           # test_config_loader config.yaml-dependent case
                                           # (fails identically on main), plus 2 pre-existing
                                           # collection errors from uninstalled optional SDKs
                                           # (agentbay, lexbench_sdk)
```

New/updated targeted tests (all TDD, watched fail first): stale-JSONL force-reeval regression, `.bak` archiving + same-second collision, startup-failure leaves results untouched, dedupe-keep-newest via summary, malformed-line rewrite guard, CLI wiring for `force_reeval`, `skip_existing=True` forwarding, dedupe-before-classification.

No smoke run: this PR touches only the eval path (`cli/eval.py`, `eval/base.py`, `eval/summary.py`, LexBench evaluator write path) — no agent runtime/launch path is affected.

## Result artifacts

N/A (no result submission). `experiments/LexBench-Browser/All/browser-use/gpt-5.4/20260707_113324` still holds the contaminated pre-fix output; it needs a `bubench eval --force-reeval` re-run after this merges.

## Self-review (mandatory)

- [x] I read every line of my diff and every change is intentional
- [x] The diff passes the hard rules in CONTRIBUTING.md (logger not print, specific exceptions, no hardcoded config, imports at top)
- [x] I ran a local `/code-review` and fixed or justified every finding
- [x] `uv run pytest tests/` passes and behavior changes have targeted tests
- [x] Agent-touching change: real smoke run evidence is included above, or this PR does not touch any agent runtime path
- [x] No secrets, cookies, or unredacted logs in the diff

## Notes for reviewers

Local `/code-review` (8 finder angles) surfaced 16 unique findings; 14 fixed in this diff (archive-after-validate, atomic rewrite, dedupe-after-hook ordering, backup-name collisions, redundant file read, stale help text, implicit skip_existing, vacuous test assertion, stub-default masking, import ordering, JSONL reader/writer reuse, dedupe simplification, malformed-line guard, classification-path dedupe). Two findings rejected with rationale:

- *"force-reeval should also archive results files from other judge models"* — per-judge-model isolation is intended (each judge writes its own `*_eval_results.json`); cross-file glob merging in visualization is a pre-existing concern unchanged here.
- *"non-str task_id records escape dedupe"* — `EvalResult.task_id` is typed `str` and LexBench normalizes ids via `str()` at load; all writers go through `EvalResult`, matching the pre-existing `_resume_skip_set` convention.

Known limitations (unchanged semantics, follow-up candidates): a resume run killed mid-loop can leave duplicates on disk until the next completed eval heals them (write-time upsert would be a larger redesign), and `--force-reeval` against a hard-down judge model still republishes synthetic failures with exit 0 (pre-existing `run()` behavior; the `.bak` makes it recoverable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)