### PR TITLE
fix(logging): attach script logs at command execution time, not import time

### DIFF
--- a/browseruse_bench/cli/login.py
+++ b/browseruse_bench/cli/login.py
@@ -33,11 +33,17 @@ from browseruse_bench.browsers.login_contexts import (
     upsert_profile,
 )
 from browseruse_bench.browsers.providers.lexmount import _build_debug_url, normalize_profile_keys
-from browseruse_bench.utils import REPO_ROOT, handle_cli_errors, load_env_file, setup_logger
+from browseruse_bench.utils import (
+    REPO_ROOT,
+    add_script_log_handler,
+    handle_cli_errors,
+    load_env_file,
+    setup_logger,
+)
 
 load_env_file(REPO_ROOT / ".env")
 
-logger = setup_logger("login", log_dir="output/logs", format_mode="plain")
+logger = setup_logger("login", format_mode="plain")
 
 _ANSI_GREEN = "\033[32m"
 _ANSI_YELLOW = "\033[33m"
@@ -653,6 +659,9 @@ def _cmd_remove(args: argparse.Namespace, _config: dict[str, Any]) -> int:
 
 @handle_cli_errors
 def login_command(args: argparse.Namespace, _config: dict[str, Any]) -> int:
+    add_script_log_handler(
+        logger, REPO_ROOT / "output" / "logs", "login", format_mode="plain"
+    )
     action = getattr(args, "login_action", None)
     if action == "add":
         return _cmd_add(args, _config)

--- a/browseruse_bench/cli/run.py
+++ b/browseruse_bench/cli/run.py
@@ -35,6 +35,7 @@ from browseruse_bench.utils import (
     DataSource,
     add_common_task_args,
     add_file_handler,
+    add_script_log_handler,
     apply_skyvern_env,
     check_uv_available,
     ensure_venv,
@@ -73,7 +74,7 @@ CONFIG_PATH = REPO_ROOT / "config.yaml"
 load_env_file(REPO_ROOT / ".env")
 
 # Setup logger
-logger = setup_logger("run", log_dir="output/logs")
+logger = setup_logger("run")
 
 
 def resolve_lexmount_routing_for_task(
@@ -1254,6 +1255,7 @@ def _canonicalize_cli_browser_id(browser_id: str | None, source_cfg: dict[str, A
 
 def run_command(args: argparse.Namespace, config: dict[str, Any]) -> int:
     """Entry point for the run subcommand."""
+    add_script_log_handler(logger, REPO_ROOT / "output" / "logs", "run")
     logger.info("Starting run command")
     args.agent = normalize_agent_name(args.agent, config)
     source_cfg = config

--- a/browseruse_bench/utils/__init__.py
+++ b/browseruse_bench/utils/__init__.py
@@ -68,7 +68,11 @@ from browseruse_bench.utils.image_utils import (
     strip_base64_prefix,
 )
 from browseruse_bench.utils.json_io import load_task_file
-from browseruse_bench.utils.logger import add_file_handler, setup_logger
+from browseruse_bench.utils.logger import (
+    add_file_handler,
+    add_script_log_handler,
+    setup_logger,
+)
 from browseruse_bench.utils.parse_utils import find_key_recursive, load_json_records, safe_int
 from browseruse_bench.utils.prompt_loader import (
     load_prompt,
@@ -167,6 +171,7 @@ __all__ = [
     # Logger
     "setup_logger",
     "add_file_handler",
+    "add_script_log_handler",
     # Constants
     "IS_WINDOWS",
     "EXPERIMENTS_DIR",

--- a/browseruse_bench/utils/logger.py
+++ b/browseruse_bench/utils/logger.py
@@ -5,7 +5,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 _NOISY_THIRD_PARTY_LOGGERS = (
     "httpx",
@@ -14,7 +14,7 @@ _NOISY_THIRD_PARTY_LOGGERS = (
     "openai._base_client",
 )
 
-_RUN_LOG_HANDLER_ATTR = "_run_log_file_handler"
+_FILE_HANDLER_ATTR_TEMPLATE = "_{slot}_file_handler"
 
 _CONSOLE_HANDLER_ATTR = "_browseruse_bench_console_handler"
 
@@ -61,6 +61,7 @@ def add_file_handler(
     level: int = logging.INFO,
     format_mode: Optional[str] = None,
     also_root: bool = True,
+    slot: str = "run_log",
 ) -> logging.FileHandler:
     """Dynamically attach a file handler to an existing logger.
 
@@ -74,6 +75,9 @@ def add_file_handler(
         format_mode: Formatter mode (``"plain"`` or default structured).
         also_root: If True, also attach the handler to the root logger so
             that logs from all modules are captured.
+        slot: Replacement key; a later call with the same slot replaces the
+            previous handler, different slots coexist (e.g. the per-command
+            script log and the experiment run.log).
 
     Returns:
         The created ``FileHandler`` (caller can close it later if needed).
@@ -83,15 +87,16 @@ def add_file_handler(
     handler.setLevel(level)
     handler.setFormatter(_make_formatter(format_mode))
 
-    # Remove a previous run-log handler if one was attached
-    prev = getattr(logger_instance, _RUN_LOG_HANDLER_ATTR, None)
+    # Remove the previous handler occupying this slot, if any
+    slot_attr = _FILE_HANDLER_ATTR_TEMPLATE.format(slot=slot)
+    prev = getattr(logger_instance, slot_attr, None)
     if prev is not None:
         logger_instance.removeHandler(prev)
         logging.getLogger().removeHandler(prev)
         prev.close()
 
     logger_instance.addHandler(handler)
-    setattr(logger_instance, _RUN_LOG_HANDLER_ATTR, handler)
+    setattr(logger_instance, slot_attr, handler)
 
     if also_root:
         logging.getLogger().addHandler(handler)
@@ -99,43 +104,71 @@ def add_file_handler(
     return handler
 
 
-def _attach_handlers_to_root(handlers: List[logging.Handler], level: int) -> None:
-    """Attach handlers to the root logger so propagating module-level loggers
-    are captured, keeping at most one console handler on root.
+def add_script_log_handler(
+    logger_instance: logging.Logger,
+    log_dir: Path,
+    name: str,
+    *,
+    format_mode: Optional[str] = None,
+) -> Optional[logging.FileHandler]:
+    """Attach the per-command script log (``<log_dir>/<name>/<timestamp>.log``).
+
+    Called at command execution time so only the active command's script log
+    exists in the process; via the root attachment it captures the command's
+    own lines plus root-propagated module-level output. The script log is
+    auxiliary: if the location is unwritable, the command continues
+    console-only and this returns None.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = Path(log_dir) / name / f"{timestamp}.log"
+    try:
+        handler = add_file_handler(
+            logger_instance, log_file, format_mode=format_mode, slot="script_log"
+        )
+    except OSError as e:
+        logger_instance.warning(f"[WARNING] Failed to set up script log {log_file}: {e}")
+        return None
+    logger_instance.info(f"[INFO] Logging to file: {log_file}")
+    return handler
+
+
+def _attach_console_handler_to_root(handler: logging.Handler, level: int) -> None:
+    """Attach a console handler to the root logger so propagating module-level
+    loggers are captured, keeping at most one console handler on root.
 
     Every CLI submodule calls ``setup_logger`` at import time; without the
     marker-based dedupe the root logger would accumulate one console handler
     per call and print every propagated line that many times. The first
     console handler to reach root owns the format and stream of propagated
     output; later ``format_mode`` choices apply only to their named logger.
+    File handlers never attach here: root-wide file capture belongs to
+    ``add_file_handler``.
     """
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
-    root_has_console = any(
+    if any(
         getattr(existing, _CONSOLE_HANDLER_ATTR, False)
         for existing in root_logger.handlers
-    )
-    for handler in handlers:
-        is_console = getattr(handler, _CONSOLE_HANDLER_ATTR, False)
-        if is_console and root_has_console:
-            continue
-        root_logger.addHandler(handler)
-        root_has_console = root_has_console or is_console
+    ):
+        return
+    root_logger.addHandler(handler)
 
 
 def setup_logger(
     name: str = __name__,
-    log_dir: Optional[str] = None,
     level: int = logging.INFO,
     console_output: bool = True,
     format_mode: Optional[str] = None
 ) -> logging.Logger:
     """
-    Setup a logger with console and file handlers.
-    
+    Setup a named logger with a console handler.
+
+    File logging is an execution-time concern: use ``add_script_log_handler``
+    for the per-command script log and ``add_file_handler`` for the
+    experiment run.log.
+
     Args:
         name: Logger name
-        log_dir: Optional directory to save log files
         level: Logging level
         console_output: Whether to output to console
         format_mode: Optional formatter mode (e.g., "plain" for message-only logs)
@@ -143,54 +176,17 @@ def setup_logger(
     logger = logging.getLogger(name)
     logger.setLevel(level)
     logger.propagate = False
-    
+
     # Remove existing handlers to avoid duplicates
     if logger.handlers:
         logger.handlers.clear()
 
-    formatter = _make_formatter(format_mode)
-
-    handlers: List[logging.Handler] = []
-
-    env_announce = os.getenv("BROWSERUSE_BENCH_LOG_ANNOUNCE", "").strip().lower()
-    if env_announce in {"0", "false", "no", "off"}:
-        announce_log_file = False
-    elif env_announce in {"1", "true", "yes", "on"}:
-        announce_log_file = True
-    else:
-        announce_log_file = "skills" not in sys.argv
-
     if console_output:
         console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setFormatter(formatter)
+        console_handler.setFormatter(_make_formatter(format_mode))
         setattr(console_handler, _CONSOLE_HANDLER_ATTR, True)
         logger.addHandler(console_handler)
-        handlers.append(console_handler)
-
-    if log_dir:
-        try:
-            # Create log directory with subdirectory for each logger
-            log_path = Path(log_dir) / name
-            log_path.mkdir(parents=True, exist_ok=True)
-            
-            # Create log file with timestamp
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            log_file = log_path / f"{timestamp}.log"
-            
-            file_handler = logging.FileHandler(log_file, encoding="utf-8")
-            file_handler.setFormatter(formatter)
-            logger.addHandler(file_handler)
-            handlers.append(file_handler)
-            
-            # If console output is enabled, print where the log file is
-            if console_output and announce_log_file:
-                logger.info(f"[INFO] Logging to file: {log_file}")
-                
-        except (OSError, ValueError) as e:
-            logger.warning(f"[WARNING] Failed to setup file logging: {e}")
-
-    if handlers:
-        _attach_handlers_to_root(handlers, level)
+        _attach_console_handler_to_root(console_handler, level)
 
     _configure_third_party_loggers()
 

--- a/tests/browseruse_bench/test_logger.py
+++ b/tests/browseruse_bench/test_logger.py
@@ -1,9 +1,13 @@
-"""Tests for browseruse_bench.utils.logger root-handler hygiene.
+"""Tests for browseruse_bench.utils.logger handler hygiene.
 
-Regression: setup_logger() used to attach a fresh console handler to the
-root logger on every call. Because every CLI submodule calls setup_logger
-at import time, the root logger accumulated ~10 console handlers and any
-propagating module-level logger printed each line ~10 times.
+Regression history: setup_logger() used to attach a fresh console handler and
+its script-log file handler to the root logger on every call. Every CLI
+submodule calls setup_logger at import time, so root accumulated ~10 console
+handlers (each propagated line printed that many times) and one script-log
+file per CLI module (each file receiving every other command's output).
+Console handlers are now deduped on root via a marker attribute, and file
+handlers are attached only at command execution time via add_file_handler /
+add_script_log_handler.
 """
 
 from __future__ import annotations
@@ -14,14 +18,23 @@ import pytest
 
 from browseruse_bench.utils.logger import (
     _CONSOLE_HANDLER_ATTR,
-    _attach_handlers_to_root,
+    add_file_handler,
+    add_script_log_handler,
     setup_logger,
 )
 
-_CLI_LOGGER_NAMES = ("bubench", "run", "eval", "skills", "submit", "leaderboard")
+_CLI_LOGGER_NAMES = (
+    "bubench",
+    "run",
+    "eval",
+    "skills",
+    "submit",
+    "leaderboard",
+    "login",
+)
 
-# Loggers mutated by setup_logger during these tests: the CLI-style named
-# loggers, the propagation probe, and the third-party loggers whose levels
+# Loggers mutated during these tests: the CLI-style named loggers, the
+# propagation probe, and the third-party loggers whose levels
 # _configure_third_party_loggers adjusts.
 _TOUCHED_LOGGER_NAMES = _CLI_LOGGER_NAMES + (
     "browseruse_bench.some_module",
@@ -31,23 +44,60 @@ _TOUCHED_LOGGER_NAMES = _CLI_LOGGER_NAMES + (
     "openai._base_client",
 )
 
+_FILE_HANDLER_SLOT_ATTRS = ("_run_log_file_handler", "_script_log_file_handler")
+
+
+def _close_new_file_handlers(
+    loggers: list[logging.Logger], saved_ids: set[int]
+) -> None:
+    """Close file handlers created during a test so no fd leaks."""
+    current = [handler for lg in loggers for handler in lg.handlers]
+    for handler in current:
+        if id(handler) not in saved_ids and isinstance(handler, logging.FileHandler):
+            handler.close()
+
+
+_MISSING = object()
+
+
+def _save_slot_attrs(lg: logging.Logger) -> dict[str, object]:
+    return {
+        attr: getattr(lg, attr, _MISSING) for attr in _FILE_HANDLER_SLOT_ATTRS
+    }
+
+
+def _restore_slot_attrs(lg: logging.Logger, attrs: dict[str, object]) -> None:
+    for attr, value in attrs.items():
+        if value is not _MISSING:
+            setattr(lg, attr, value)
+        elif hasattr(lg, attr):
+            delattr(lg, attr)
+
 
 @pytest.fixture
 def clean_root_logger():
     """Detach all root handlers for the test; restore root and every logger
     the tests touch afterwards so no global logging state leaks."""
     root = logging.getLogger()
-    saved_root = (root.handlers[:], root.level)
     touched = [logging.getLogger(name) for name in _TOUCHED_LOGGER_NAMES]
-    saved = [(lg, lg.handlers[:], lg.level, lg.propagate) for lg in touched]
+    saved_root = (root.handlers[:], root.level)
+    saved = [
+        (lg, lg.handlers[:], lg.level, lg.propagate, _save_slot_attrs(lg))
+        for lg in touched
+    ]
+    saved_ids = {id(handler) for handler in saved_root[0]}
+    for _, handlers, _, _, _ in saved:
+        saved_ids.update(id(handler) for handler in handlers)
     root.handlers[:] = []
     yield root
+    _close_new_file_handlers([root, *touched], saved_ids)
     root.handlers[:] = saved_root[0]
     root.setLevel(saved_root[1])
-    for lg, handlers, level, propagate in saved:
+    for lg, handlers, level, propagate, slot_attrs in saved:
         lg.handlers[:] = handlers
         lg.setLevel(level)
         lg.propagate = propagate
+        _restore_slot_attrs(lg, slot_attrs)
 
 
 def _console_handlers(root: logging.Logger) -> list[logging.Handler]:
@@ -56,25 +106,15 @@ def _console_handlers(root: logging.Logger) -> list[logging.Handler]:
     return [h for h in root.handlers if getattr(h, _CONSOLE_HANDLER_ATTR, False)]
 
 
+def _file_handlers(lg: logging.Logger) -> list[logging.Handler]:
+    return [h for h in lg.handlers if isinstance(h, logging.FileHandler)]
+
+
 def test_root_gets_at_most_one_console_handler(clean_root_logger):
     """Repeated setup_logger calls (one per CLI submodule) must not stack
     console handlers on the root logger."""
     for name in _CLI_LOGGER_NAMES:
         setup_logger(name)
-
-    assert len(_console_handlers(clean_root_logger)) == 1
-
-
-def test_attach_helper_enforces_invariant_within_one_call(clean_root_logger):
-    """Even a single handler list holding several marked console handlers
-    must yield exactly one console handler on root."""
-    marked = []
-    for _ in range(2):
-        handler = logging.StreamHandler()
-        setattr(handler, _CONSOLE_HANDLER_ATTR, True)
-        marked.append(handler)
-
-    _attach_handlers_to_root(marked, logging.INFO)
 
     assert len(_console_handlers(clean_root_logger)) == 1
 
@@ -98,3 +138,68 @@ def test_propagating_module_logger_emits_line_once(clean_root_logger, capsys):
 
     captured = capsys.readouterr()
     assert captured.out.count("unique-regression-marker") == 1
+
+
+def test_setup_logger_never_attaches_file_handlers(clean_root_logger):
+    """Import-time setup_logger must not create or attach file handlers;
+    files are an execution-time concern (add_file_handler)."""
+    logger = setup_logger("run")
+
+    assert not _file_handlers(logger)
+    assert not _file_handlers(clean_root_logger)
+
+
+def test_script_log_captures_root_propagated_lines(clean_root_logger, tmp_path):
+    """The active command's script log must receive both the command logger's
+    own lines and root-propagated module-level lines."""
+    logger = setup_logger("run")
+    handler = add_script_log_handler(logger, tmp_path, "run")
+
+    logging.getLogger("browseruse_bench.some_module").info("propagated-line")
+    logger.info("own-line")
+    handler.flush()
+
+    content = next((tmp_path / "run").iterdir()).read_text()
+    assert "propagated-line" in content
+    assert "own-line" in content
+
+
+def test_script_log_and_run_log_slots_replace_independently(
+    clean_root_logger, tmp_path
+):
+    """Re-attaching the script log must replace only the script-log slot;
+    the experiment run.log handler stays open and attached."""
+    logger = setup_logger("run")
+    first_script = add_script_log_handler(logger, tmp_path, "run")
+    run_log = add_file_handler(logger, tmp_path / "run.log")
+
+    second_script = add_script_log_handler(logger, tmp_path, "run")
+
+    assert first_script.stream is None or first_script.stream.closed
+    assert run_log.stream is not None and not run_log.stream.closed
+    assert second_script in clean_root_logger.handlers
+    assert run_log in clean_root_logger.handlers
+
+
+def test_script_log_failure_degrades_to_console_only(clean_root_logger, tmp_path):
+    """An unwritable script-log location must not abort the command: the
+    helper warns and returns None, console logging keeps working."""
+    logger = setup_logger("run")
+    (tmp_path / "run").write_text("blocks the log directory")
+
+    handler = add_script_log_handler(logger, tmp_path, "run")
+
+    assert handler is None
+    assert not _file_handlers(logger)
+
+
+def test_add_file_handler_still_captures_root_traffic(clean_root_logger, tmp_path):
+    """Execution-time run.log capture via add_file_handler(also_root=True)
+    must keep receiving root-propagated module lines."""
+    logger = setup_logger("run")
+    handler = add_file_handler(logger, tmp_path / "run.log")
+
+    logging.getLogger("browseruse_bench.some_module").info("captured-line")
+    handler.flush()
+
+    assert "captured-line" in (tmp_path / "run.log").read_text()


### PR DESCRIPTION
## Summary

Follow-up to #91 (console-handler dedupe): the file-handler half of the same accumulation bug. `setup_logger(log_dir=...)` attached each CLI module's script-log `FileHandler` to the root logger at import time. Because `cli/__init__.py` imports `run.py` and `login.py`, **every** bubench invocation created both `output/logs/run/<ts>.log` and `output/logs/login/<ts>.log` and wrote every root-propagated line into both unrelated files; re-configuration also leaked the superseded handler's fd.

Fix (at the mechanism level rather than another marker special case):
- `setup_logger` configures the console handler only; it never creates file handlers.
- New `add_script_log_handler` attaches the per-command script log inside `run_command` / `login_command`, so only the **active** command's script log exists — no cross-contamination, and it still captures root-propagated module output (now also on `--dry-run` and during the pre-run window, which the import-time design lost).
- `add_file_handler` gains a `slot` parameter (default `"run_log"` keeps the existing replace semantics) so the script log and the experiment `run.log` replace independently.
- An unwritable script-log location degrades to console-only with a warning instead of aborting the command (matches old behavior).

## Contribution type

- [x] Bug fix

## Reproduction or validation

- `uv run pytest tests/browseruse_bench/test_logger.py -v` — 8 tests, written TDD (each new behavior watched fail first).
- Dry-run validation: `uv run scripts/run.py --agent browser-use --data LexBench-Browser --mode first_n --count 5 --dry-run` — run's script log contains its own lines **plus** `browseruse_bench.utils.data_loader` / `utils.task` propagated lines; no login log file is created (count unchanged before/after).
- `uv run pytest tests/` — 686 passed, 1 skipped; same 2 pre-existing failures as `main` (config_loader model-override, claude-code `.env`-leak smoke), verified unrelated in #91.
- Real smoke run: `bubench run --agent browser-use --data LexBench-Browser --mode single` — 106.0s wall-clock, `INFO [Agent] Starting a browser-use agent with version 0.13.3, with provider=openai and model=gpt-5.4` … `[SUCCESS] Task completed successfully`, `Total: 1 | Success: 1 | Failed: 0`.

## Self-review (mandatory)

- [x] I read every line of my diff and every change is intentional
- [x] The diff passes the hard rules in CONTRIBUTING.md (logger not print, specific exceptions, no hardcoded config, imports at top)
- [x] I ran a local `/code-review` and fixed or justified every finding
- [x] `uv run pytest tests/` passes and behavior changes have targeted tests
- [x] Agent-touching change: real smoke run evidence is included above
- [x] No secrets, cookies, or unredacted logs in the diff

## Notes for reviewers

Code-review findings and dispositions (7 finder passes across two rounds):
- Fixed: an earlier draft kept `log_dir` in `setup_logger` with named-logger-only attachment; review showed that silently dropped root-propagated provider lines from `bubench login`'s script log (login does all its work via module loggers) and lost run's pre-attach/dry-run window — hence the execution-time design.
- Fixed: an earlier draft closed superseded file handlers inside `setup_logger`, which could close the `run.log` handler owned by `add_file_handler`; ownership is now unambiguous (each helper closes only its own slot).
- Fixed: script-log setup failure no longer aborts the command (degrades to console-only with a warning; regression test included).
- Fixed: test fixture saves/restores slot attributes and named-logger/third-party state, and closes test-created file handlers on teardown.
- Justified: `BROWSERUSE_BENCH_LOG_ANNOUNCE` removed — no in-repo/doc references; its purpose (suppressing the announce when unrelated CLI modules import at load time) is structurally gone since the announce now fires only for the executing command.
- Justified: script-log filenames keep second-resolution timestamps (unchanged naming); two command invocations in the same process within one second would append to one file — same as the pre-existing scheme, not newly reachable in any shipped flow.
- Behavior note: `output/logs` is now anchored at `REPO_ROOT` instead of the current working directory, per the config-path rule in docs_4_codeagent/imports-runtime-config.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)