### PR TITLE
Add Grok 4.5 Responses API support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@
 OPENAI_API_KEY=your-openai-api-key-here        # OpenAI API key
 # OPENAI_BASE_URL=https://api.openai.com/v1    # Optional: custom / OpenAI-compatible gateway
 
+### xAI API (Grok, OpenAI-compatible Responses API)
+# XAI_API_KEY=your-xai-api-key-here
+
 ### OpenAI-compatible gateway (Skyvern, and any agent using openai_compatible_*)
 # OPENAI_COMPATIBLE_API_KEY=your-gateway-api-key
 # OPENAI_COMPATIBLE_API_BASE=https://your-gateway.example.com/v1
@@ -33,4 +36,3 @@ BROWSER_USE_API_KEY=your-browser-use-api-key   # Browser Use service key
 
 ### HuggingFace (Optional)
 # HF_ENDPOINT=https://hf-mirror.com          # Use mirror for faster downloads in China
-

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ vim .env
 |----------|-------------|---------|----------|
 | `OPENAI_API_KEY` | API key for agents and evaluation | [platform.openai.com](https://platform.openai.com/api-keys) | ✅ |
 | `OPENAI_BASE_URL` | Custom API base URL (e.g. LiteLLM proxy) | — | Optional |
+| `XAI_API_KEY` | xAI Grok API key for `models.grok-4.5` | [console.x.ai](https://console.x.ai/) | When using Grok |
 | `LEXMOUNT_API_KEY` + `LEXMOUNT_PROJECT_ID` | Lexmount cloud browser | [browser.lexmount.cn](https://browser.lexmount.cn/) | When using lexmount |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser | [browser-use.com](https://www.browser-use.com/) | When using browser-use-cloud |
 | `AGENTBAY_API_KEY` | AgentBay cloud browser | [agentbay.ai](https://agentbay.ai/) | When using agentbay |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -136,6 +136,7 @@ vim .env
 | ------------------------------------------ | ------------------------------ | ----------------------------------------------------------- | ------------------- |
 | `OPENAI_API_KEY`                           | Agent 与评估用 API Key             | [platform.openai.com](https://platform.openai.com/api-keys) | ✅                   |
 | `OPENAI_BASE_URL`                          | 自定义 API Base URL（如 LiteLLM 代理） | —                                                           | 可选                  |
+| `XAI_API_KEY`                              | `models.grok-4.5` 使用的 xAI Grok API Key | [console.x.ai](https://console.x.ai/)                       | 使用 Grok 时          |
 | `LEXMOUNT_API_KEY` + `LEXMOUNT_PROJECT_ID` | lexmount 云端浏览器                 | [browser.lexmount.cn](https://browser.lexmount.cn/)         | 使用 lexmount 时       |
 | `BROWSER_USE_API_KEY`                      | Browser Use 云端浏览器              | [browser-use.com](https://www.browser-use.com/)             | 使用 browser-use-cloud 时 |
 | `AGENTBAY_API_KEY`                         | AgentBay 云端浏览器                 | [agentbay.ai](https://agentbay.ai/)                         | 使用 agentbay 时       |

--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -15,6 +15,7 @@ import tempfile
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -29,7 +30,10 @@ from browser_use import ChatOpenAI as BrowserUseSDKChatOpenAI
 from browser_use.browser import session as browser_use_session_module
 from browser_use.browser.profile import ProxySettings as BrowserUseProxySettings
 from browser_use.llm.exceptions import ModelError as BrowserUseModelError
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.openai.responses_serializer import ResponsesAPIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 from pydantic import BaseModel as _PydanticBaseModel
 
 from browseruse_bench.agents.base import BaseAgent
@@ -183,6 +187,7 @@ def _patch_agent_output_json_parsers(agent: Any) -> None:
 
 _PATCHED_SCHEMA_OPTIMIZER_ATTR = "_browseruse_bench_strip_numeric_bounds_patched"
 _VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high")
+_NON_IDENTIFIER_CHARS_RE = re.compile(r"[^a-zA-Z0-9_-]+")
 
 
 def _is_claude_model(model_id: str | None) -> bool:
@@ -324,6 +329,158 @@ def _capture_llm_failures(llm: Any, recorder: _LLMFailureRecorder) -> None:
             raise
 
     llm.ainvoke = ainvoke_with_failure_capture
+
+
+@dataclass
+class _BrowserUseResponsesLLM:
+    """browser-use LLM adapter for OpenAI-compatible Responses API endpoints."""
+
+    model: str
+    api_key: str | None = None
+    base_url: str | None = None
+    temperature: float | None = None
+    max_output_tokens: int | None = None
+    add_schema_to_system_prompt: bool = True
+
+    @property
+    def provider(self) -> str:
+        return "openai"
+
+    @property
+    def name(self) -> str:
+        return self.model
+
+    @property
+    def model_name(self) -> str:
+        return self.model
+
+    def get_client(self) -> Any:
+        from openai import AsyncOpenAI
+
+        client_kwargs: dict[str, Any] = {}
+        if self.api_key:
+            client_kwargs["api_key"] = self.api_key
+        if self.base_url:
+            client_kwargs["base_url"] = self.base_url
+        return AsyncOpenAI(**client_kwargs)
+
+    def _model_params(self) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if self.temperature is not None:
+            params["temperature"] = self.temperature
+        if self.max_output_tokens is not None:
+            params["max_output_tokens"] = self.max_output_tokens
+        return params
+
+    @staticmethod
+    def _schema_name(output_format: type[Any]) -> str:
+        raw_name = getattr(output_format, "__name__", "agent_output")
+        name = _NON_IDENTIFIER_CHARS_RE.sub("_", raw_name).strip("_")
+        return name[:64] or "agent_output"
+
+    @classmethod
+    def _text_format(cls, output_format: type[Any]) -> dict[str, Any]:
+        return {
+            "format": {
+                "type": "json_schema",
+                "name": cls._schema_name(output_format),
+                "schema": SchemaOptimizer.create_optimized_json_schema(output_format),
+                "strict": True,
+            }
+        }
+
+    @staticmethod
+    def _with_schema_prompt(messages: list[Any], output_format: type[Any]) -> list[Any]:
+        schema = SchemaOptimizer.create_optimized_json_schema(output_format)
+        instruction = (
+            "Return only valid JSON matching this schema. Do not wrap it in markdown.\n"
+            f"<json_schema>\n{json.dumps(schema, ensure_ascii=False)}\n</json_schema>"
+        )
+        serialized = ResponsesAPIMessageSerializer.serialize_messages(messages)
+        if serialized and serialized[0].get("role") == "system":
+            content = serialized[0].get("content")
+            if isinstance(content, str):
+                serialized[0]["content"] = f"{content}\n\n{instruction}"
+            elif isinstance(content, list):
+                serialized[0]["content"] = [
+                    *content,
+                    {"type": "input_text", "text": f"\n\n{instruction}"},
+                ]
+            else:
+                serialized.insert(0, {"role": "system", "content": instruction})
+            return serialized
+        return [{"role": "system", "content": instruction}, *serialized]
+
+    @staticmethod
+    def _usage(response: Any) -> ChatInvokeUsage | None:
+        raw_usage = getattr(response, "usage", None)
+        if raw_usage is None:
+            return None
+        input_tokens = int(getattr(raw_usage, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(raw_usage, "output_tokens", 0) or 0)
+        cached_tokens = None
+        input_details = getattr(raw_usage, "input_tokens_details", None)
+        if input_details is not None:
+            cached = getattr(input_details, "cached_tokens", None)
+            cached_tokens = int(cached) if cached is not None else None
+        return ChatInvokeUsage(
+            prompt_tokens=input_tokens,
+            prompt_cached_tokens=cached_tokens,
+            prompt_cache_creation_tokens=None,
+            prompt_image_tokens=None,
+            completion_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+        )
+
+    async def ainvoke(
+        self,
+        messages: list[Any],
+        output_format: type[Any] | None = None,
+        **kwargs: Any,
+    ) -> ChatInvokeCompletion[Any]:
+        from openai import APIConnectionError, APIStatusError, RateLimitError
+
+        del kwargs
+        if output_format is None:
+            responses_input = ResponsesAPIMessageSerializer.serialize_messages(messages)
+            model_params = self._model_params()
+        else:
+            responses_input = self._with_schema_prompt(messages, output_format)
+            model_params = {
+                **self._model_params(),
+                "text": self._text_format(output_format),
+            }
+
+        try:
+            response = await self.get_client().responses.create(
+                model=self.model,
+                input=responses_input,
+                **model_params,
+            )
+        except RateLimitError as exc:
+            raise ModelRateLimitError(message=exc.message, model=self.name) from exc
+        except APIConnectionError as exc:
+            raise ModelProviderError(message=str(exc), model=self.name) from exc
+        except APIStatusError as exc:
+            raise ModelProviderError(
+                message=exc.message,
+                status_code=exc.status_code,
+                model=self.name,
+            ) from exc
+
+        text = getattr(response, "output_text", "") or ""
+        usage = self._usage(response)
+        if output_format is None:
+            return ChatInvokeCompletion(completion=text, usage=usage, stop_reason=None)
+
+        parsed = _validate_json_candidates(output_format, _iter_json_candidates(text))
+        if parsed is None:
+            raise ModelProviderError(
+                message="Responses API model returned no valid structured output",
+                status_code=500,
+                model=self.name,
+            )
+        return ChatInvokeCompletion(completion=parsed, usage=usage, stop_reason=None)
 
 
 def _match_step_llm_failures(
@@ -783,8 +940,12 @@ class BrowserUseAgent(BaseAgent):
             config_info["claude_schema_numeric_bounds_stripped"] = True
 
         llm_class = provider_classes[model_type]
-        kwargs = provider_builders[model_type](model_id, agent_config, config_info)
-        llm = llm_class(**kwargs)
+        if model_type == "OPENAI" and agent_config.get("model_api_style") == "responses":
+            kwargs = self._build_openai_responses_kwargs(model_id, agent_config, config_info)
+            llm = _BrowserUseResponsesLLM(**kwargs)
+        else:
+            kwargs = provider_builders[model_type](model_id, agent_config, config_info)
+            llm = llm_class(**kwargs)
 
         if is_claude and model_type in ("OPENAI", "AZURE"):
             thinking_enabled = _get_config_value(
@@ -864,6 +1025,36 @@ class BrowserUseAgent(BaseAgent):
         if agent_config.get("remove_defaults_from_schema"):
             openai_kwargs["remove_defaults_from_schema"] = True
         return openai_kwargs
+
+    @staticmethod
+    def _build_openai_responses_kwargs(
+        model_id: str,
+        agent_config: dict[str, Any],
+        config_info: dict[str, Any],
+    ) -> dict[str, Any]:
+        responses_kwargs: dict[str, Any] = {
+            "model": model_id,
+            "api_key": (
+                agent_config.get("api_key")
+                or os.getenv("XAI_API_KEY")
+                or os.getenv("GROK_API_KEY")
+                or os.getenv("OPENAI_API_KEY")
+            ),
+            "base_url": agent_config.get("base_url") or os.getenv("OPENAI_BASE_URL"),
+            "add_schema_to_system_prompt": True,
+        }
+        config_info["model_api_style"] = "responses"
+        config_info["add_schema_prompt"] = True
+        if "temperature" in agent_config:
+            responses_kwargs["temperature"] = agent_config["temperature"]
+            config_info["temperature"] = agent_config["temperature"]
+        if agent_config.get("max_tokens") is not None:
+            responses_kwargs["max_output_tokens"] = agent_config["max_tokens"]
+            config_info["max_tokens"] = agent_config["max_tokens"]
+        elif agent_config.get("max_completion_tokens") is not None:
+            responses_kwargs["max_output_tokens"] = agent_config["max_completion_tokens"]
+            config_info["max_completion_tokens"] = agent_config["max_completion_tokens"]
+        return responses_kwargs
 
     @staticmethod
     def _build_azure_kwargs(

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -120,6 +120,20 @@ models:
     dont_force_structured_output: false
     add_schema_to_system_prompt: true
 
+  # xAI Grok via the OpenAI-compatible Responses API.
+  # Use the API root as base_url; Responses clients append /responses themselves.
+  grok-4.5:
+    model_type: OPENAI
+    model_provider: openai
+    model_id: grok-4.5
+    api_key: $XAI_API_KEY
+    base_url: https://api.x.ai/v1
+    model_api_style: responses
+    api: openai-responses
+    frequency_penalty: null
+    dont_force_structured_output: true
+    add_schema_to_system_prompt: true
+
   openrouter:
     model_type: OPENROUTER
     model_id: openai/gpt-5.4

--- a/configs/pricing/model_pricing.yaml
+++ b/configs/pricing/model_pricing.yaml
@@ -85,6 +85,14 @@ dmx-claude-sonnet-4-6:
   cache_read_input_cost_per_million_tokens: 0.3
 
 # =====================================================================
+# xAI Grok (USD list price, docs.x.ai/developers/pricing)
+# =====================================================================
+grok-4.5:
+  input_cost_per_million_tokens: 2.0
+  output_cost_per_million_tokens: 6.0
+  cache_read_input_cost_per_million_tokens: 0.5
+
+# =====================================================================
 # Google Gemini (USD list price, ai.google.dev/gemini-api/docs/pricing)
 # Base tier (<=200K prompt); cache_read ~= 10% of input.
 # =====================================================================

--- a/docs/en/quickstart.mdx
+++ b/docs/en/quickstart.mdx
@@ -55,6 +55,9 @@ icon: "rocket"
     OPENAI_API_KEY=your-openai-api-key-here
     # OPENAI_BASE_URL=https://api.openai.com/v1    # Optional: custom / OpenAI-compatible gateway
 
+    ### xAI API (Grok, OpenAI-compatible Responses API)
+    # XAI_API_KEY=your-xai-api-key-here
+
     ### OpenAI-compatible gateway (Skyvern, and any agent using openai_compatible_*)
     # OPENAI_COMPATIBLE_API_KEY=your-gateway-api-key
     # OPENAI_COMPATIBLE_API_BASE=https://your-gateway.example.com/v1
@@ -102,6 +105,13 @@ icon: "rocket"
         model_id: gpt-5.4
         api_key: $OPENAI_API_KEY
         base_url: $OPENAI_BASE_URL
+      grok-4.5:
+        model_type: OPENAI
+        model_id: grok-4.5
+        api_key: $XAI_API_KEY
+        base_url: https://api.x.ai/v1  # API root; do not include /responses
+        model_api_style: responses
+        api: openai-responses
       browser-use:
         model_type: BROWSER_USE
         model_id: bu-2-0

--- a/docs/zh/quickstart.mdx
+++ b/docs/zh/quickstart.mdx
@@ -55,6 +55,9 @@ icon: "rocket"
     OPENAI_API_KEY=your-openai-api-key-here
     # OPENAI_BASE_URL=https://api.openai.com/v1    # 可选：自定义 / OpenAI 兼容网关
 
+    ### xAI API（Grok，OpenAI-compatible Responses API）
+    # XAI_API_KEY=your-xai-api-key-here
+
     ### OpenAI 兼容网关（Skyvern 及使用 openai_compatible_* 的 Agent）
     # OPENAI_COMPATIBLE_API_KEY=your-gateway-api-key
     # OPENAI_COMPATIBLE_API_BASE=https://your-gateway.example.com/v1
@@ -102,6 +105,13 @@ icon: "rocket"
         model_id: gpt-5.4
         api_key: $OPENAI_API_KEY
         base_url: $OPENAI_BASE_URL
+      grok-4.5:
+        model_type: OPENAI
+        model_id: grok-4.5
+        api_key: $XAI_API_KEY
+        base_url: https://api.x.ai/v1  # API root；不要包含 /responses
+        model_api_style: responses
+        api: openai-responses
       browser-use:
         model_type: BROWSER_USE
         model_id: bu-2-0

--- a/tests/browseruse_bench/test_browser_use_agent.py
+++ b/tests/browseruse_bench/test_browser_use_agent.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import SystemMessage, UserMessage
 from pydantic import BaseModel, ValidationError
 
 from browseruse_bench.agents import browser_use as browser_use_module
@@ -353,6 +354,95 @@ def test_create_llm_enables_claude_schema_and_thinking(
     assert captured["kwargs"]["model"] == "openrouter/claude-opus-4.8"
     assert config_info["claude_schema_numeric_bounds_stripped"] is True
     assert config_info["claude_reasoning_effort"] == "medium"
+
+
+def test_create_llm_uses_responses_adapter_for_responses_api_style() -> None:
+    config_info: dict[str, Any] = {}
+
+    llm = BrowserUseAgent()._create_llm(
+        "OPENAI",
+        "grok-4.5",
+        {
+            "api_key": "xai-key",
+            "base_url": "https://api.x.ai/v1",
+            "model_api_style": "responses",
+            "max_tokens": 1234,
+        },
+        config_info,
+    )
+
+    assert isinstance(llm, browser_use_module._BrowserUseResponsesLLM)
+    assert llm.model == "grok-4.5"
+    assert llm.api_key == "xai-key"
+    assert llm.base_url == "https://api.x.ai/v1"
+    assert llm.max_output_tokens == 1234
+    assert config_info["model_api_style"] == "responses"
+
+
+def test_responses_adapter_parses_structured_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeResponses:
+        async def create(self, **kwargs: Any) -> Any:
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                output_text='{"memory": "ok", "action": [{"done": {"text": "done"}}]}',
+                usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            )
+
+    class FakeClient:
+        responses = FakeResponses()
+
+    llm = browser_use_module._BrowserUseResponsesLLM(
+        model="grok-4.5",
+        api_key="xai-key",
+        base_url="https://api.x.ai/v1",
+        max_output_tokens=100,
+    )
+    monkeypatch.setattr(llm, "get_client", lambda: FakeClient())
+
+    result = asyncio.run(
+        llm.ainvoke(
+            [SystemMessage(content="system"), UserMessage(content="task")],
+            output_format=_OutputForParserTest,
+        )
+    )
+
+    assert result.completion.memory == "ok"
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 5
+    assert captured["kwargs"]["model"] == "grok-4.5"
+    assert captured["kwargs"]["max_output_tokens"] == 100
+    assert captured["kwargs"]["text"]["format"]["type"] == "json_schema"
+    assert captured["kwargs"]["text"]["format"]["name"] == "OutputForParserTest"
+    assert captured["kwargs"]["text"]["format"]["strict"] is True
+    assert captured["kwargs"]["text"]["format"]["schema"]["type"] == "object"
+
+
+def test_responses_adapter_does_not_force_text_format_without_output_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeResponses:
+        async def create(self, **kwargs: Any) -> Any:
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                output_text="plain text",
+                usage=SimpleNamespace(input_tokens=3, output_tokens=2),
+            )
+
+    class FakeClient:
+        responses = FakeResponses()
+
+    llm = browser_use_module._BrowserUseResponsesLLM(model="grok-4.5")
+    monkeypatch.setattr(llm, "get_client", lambda: FakeClient())
+
+    result = asyncio.run(llm.ainvoke([UserMessage(content="task")]))
+
+    assert result.completion == "plain text"
+    assert "text" not in captured["kwargs"]
 
 
 def test_create_browser_instance_rejects_cloud_transport_for_unknown_backend() -> None:


### PR DESCRIPTION
## Summary
- Add a browser-use Responses API adapter for OpenAI-compatible endpoints such as xAI Grok.
- Add the grok-4.5 model config, XAI_API_KEY docs, and custom pricing entry.
- Cover the adapter path with unit tests for model creation, structured output parsing, and plain-text responses.

## Validation
- uv run pytest tests/browseruse_bench/test_browser_use_agent.py
- uv run pytest tests/browseruse_bench/test_browser_use_agent.py tests/scripts/test_agent_runner.py
- uv run ruff check browseruse_bench/agents/browser_use.py tests/browseruse_bench/test_browser_use_agent.py
- git diff --check
- Real smoke: uv run bubench run --agent browser-use --data LexBench-Browser --split All --mode single --model-name grok-4.5 --timeout 1200
  - Output: experiments/LexBench-Browser/All/browser-use/grok-4.5/20260709_202919
  - Result: Total: 1 | Success: 1 | Failed: 0