### PR TITLE
fix(browser-use): honor local launch configuration

### DIFF
--- a/browseruse_bench/agents/browser_use.py
+++ b/browseruse_bench/agents/browser_use.py
@@ -656,9 +656,12 @@ class BrowserUseAgent(BaseAgent):
             temp_dir_obj = tempfile.TemporaryDirectory(prefix="browseruse-tmp-user-data-")
             user_data_dir = Path(temp_dir_obj.name)
             local_browser_kwargs: dict[str, Any] = {
-                "headless": False,
+                "headless": bool(session_context.metadata.get("headless", False)),
                 "user_data_dir": user_data_dir,
             }
+            executable_path = str(session_context.metadata.get("executable_path") or "").strip()
+            if executable_path:
+                local_browser_kwargs["executable_path"] = executable_path
             proxy_meta = session_context.metadata.get("local_proxy")
             if proxy_meta:
                 local_browser_kwargs["proxy"] = BrowserUseProxySettings(

--- a/browseruse_bench/browsers/providers/local.py
+++ b/browseruse_bench/browsers/providers/local.py
@@ -10,6 +10,12 @@ _logger = logging.getLogger(__name__)
 _warned_agents: set[str] = set()
 
 
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in ("false", "0", "no", "off")
+
+
 def warn_if_local_proxy_unsupported(agent_config: Dict[str, Any], agent_name: str) -> None:
     """One-shot warning for agents whose local-Chrome launch path can't honour
     `local_proxy_*`.
@@ -71,6 +77,11 @@ class LocalBackend(BrowserBackend):
 
     def open(self, agent_name: str, agent_config: Dict[str, Any]) -> BrowserSessionContext:
         metadata: Dict[str, Any] = {}
+        if agent_config.get("headless") not in (None, ""):
+            metadata["headless"] = _coerce_bool(agent_config["headless"])
+        executable_path = str(agent_config.get("local_executable_path") or "").strip()
+        if executable_path:
+            metadata["executable_path"] = executable_path
         proxy = _extract_local_proxy(agent_config)
         if proxy is not None:
             metadata["local_proxy"] = proxy

--- a/tests/browseruse_bench/test_browser_use_agent.py
+++ b/tests/browseruse_bench/test_browser_use_agent.py
@@ -725,6 +725,31 @@ def test_create_browser_instance_no_proxy_omits_kwarg(
             temp_dir.cleanup()
 
 
+def test_create_browser_instance_uses_local_headless_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeBrowser:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(browser_use_module, "Browser", FakeBrowser)
+
+    ctx = BrowserSessionContext(
+        backend_id="local",
+        transport="local",
+        metadata={"headless": True, "executable_path": "/opt/chrome"},
+    )
+    _, temp_dir = BrowserUseAgent._create_browser_instance(session_context=ctx)
+    try:
+        assert captured["headless"] is True
+        assert captured["executable_path"] == "/opt/chrome"
+    finally:
+        if temp_dir is not None:
+            temp_dir.cleanup()
+
+
 # ---------------------------------------------------------------------------
 # Raw LLM response capture for failed/unparseable calls
 # ---------------------------------------------------------------------------

--- a/tests/browseruse_bench/test_browsers.py
+++ b/tests/browseruse_bench/test_browsers.py
@@ -272,6 +272,26 @@ def test_local_backend_empty_proxy_server_treated_as_no_proxy() -> None:
     assert "local_proxy" not in ctx.metadata
 
 
+def test_local_backend_passes_explicit_headless_setting() -> None:
+    backend = LocalBackend("local")
+
+    enabled = backend.open(agent_name="browser-use", agent_config={"headless": True})
+    disabled = backend.open(agent_name="browser-use", agent_config={"headless": "false"})
+
+    assert enabled.metadata["headless"] is True
+    assert disabled.metadata["headless"] is False
+
+
+def test_local_backend_passes_explicit_executable_path() -> None:
+    backend = LocalBackend("local")
+    ctx = backend.open(
+        agent_name="browser-use",
+        agent_config={"local_executable_path": "/opt/chrome"},
+    )
+
+    assert ctx.metadata["executable_path"] == "/opt/chrome"
+
+
 def test_local_backend_server_only() -> None:
     backend = LocalBackend("local")
     ctx = backend.open(


### PR DESCRIPTION
## What changed
- propagate the local backend's explicit `headless` setting into browser-use
- allow experiments to select a concrete local Chrome executable
- add focused coverage for both settings

## Why
The local LexBench comparison ignored `headless: true` and browser-use selected an older cached Playwright Chromium that stayed alive without exposing CDP on macOS. This made the local baseline fail before the first model step.

## Validation
- 53 targeted tests passed
- Ruff passed for the touched modules (with the repository's existing typing-rule ignores)
- real LexBench task 6 completed on macOS system Chrome in 9 steps
- stepwise judge passed the task with 74/100
