### PR TITLE
feat(agents): add hermes agent + eval api_key fix + opt-in browser_vision

### DIFF
--- a/browseruse_bench/agents/__init__.py
+++ b/browseruse_bench/agents/__init__.py
@@ -44,6 +44,11 @@ except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.openclaw: %s", exc)
 
 try:
+    from browseruse_bench.agents import hermes  # noqa: F401
+except ImportError as exc:
+    logger.warning("Skipping optional agent module browseruse_bench.agents.hermes: %s", exc)
+
+try:
     from browseruse_bench.agents import browser_use  # noqa: F401
 except ImportError as exc:
     logger.warning("Skipping optional agent module browseruse_bench.agents.browser_use: %s", exc)

--- a/browseruse_bench/agents/hermes.py
+++ b/browseruse_bench/agents/hermes.py
@@ -1,0 +1,513 @@
+"""
+HermesAgent - Browser automation using the Hermes Agent CLI (Nous Research).
+
+This agent executes tasks by invoking `hermes -z <prompt>` (oneshot mode: one
+non-interactive agent conversation, no gateway, exits when done). Browsing
+uses Hermes's built-in `browser` toolset attached to an external CDP endpoint
+via the BROWSER_CDP_URL env var, or Hermes's own managed local browser for
+self-launch backends. Each task gets an isolated HERMES_HOME state directory;
+the provider API key is delivered via an env var and never written to disk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import sqlite3
+import subprocess
+import time
+from datetime import UTC, datetime
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from browseruse_bench.agents.cli_agent import CLIAgent
+from browseruse_bench.agents.playwright_mcp import (
+    SELF_LAUNCH_BROWSER_IDS,
+    STEP_ITEM_TYPES,
+    extract_actions,
+    write_api_logs,
+)
+from browseruse_bench.agents.registry import register_agent
+from browseruse_bench.browsers import open_browser_session
+from browseruse_bench.browsers.providers.local import warn_if_local_proxy_unsupported
+from browseruse_bench.schemas import AgentMetrics, AgentResult, AgentUsage
+from browseruse_bench.utils.parse_utils import safe_int
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RULES = (
+    "You are a browser automation agent. "
+    "You MUST use ONLY the browser_* tools for ALL browser interactions."
+    "\n\nTask completion rules:\n"
+    "- If you can see enough information to answer the task from the current page (e.g., "
+    "ratings, names, prices visible in search results), provide your answer IMMEDIATELY "
+    "without clicking into individual items to get more detail.\n"
+    "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
+    "go back to the previous page and use the data already collected to answer.\n"
+    "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+    "- Read pages with browser_snapshot. Do NOT use browser_vision or browser_get_images: "
+    "no vision model is available in this environment, image analysis always fails."
+)
+
+# The name of the env var carrying the bench provider API key into the Hermes
+# subprocess; referenced as key_env in the per-task config.yaml so the secret
+# never touches disk.
+_API_KEY_ENV = "HERMES_BENCH_API_KEY"
+
+# Hermes auto-detects extra providers (auxiliary vision/web-extract models,
+# fallback chains) from well-known env vars, which would route calls outside
+# the bench provider. The bench provider is delivered via the per-task
+# config.yaml + _API_KEY_ENV only, so scrub the whole families. HERMES_* is
+# scrubbed to drop operator overrides (HERMES_INFERENCE_MODEL, ...); BROWSER_*
+# to drop a stale BROWSER_CDP_URL before the per-task one is set.
+_SCRUB_ENV_PREFIXES = (
+    "ANTHROPIC_",
+    "OPENAI_",
+    "OPENROUTER_",
+    "GOOGLE_",
+    "GEMINI_",
+    "NOUS_",
+    "OLLAMA_",
+    "HERMES_",
+    "BROWSER_",
+)
+
+_SCREENSHOTS_SUBDIR = Path("cache") / "screenshots"
+
+
+def _subprocess_env(state_dir: Path, cdp_url: str | None, api_key: str) -> dict[str, str]:
+    """Build the Hermes subprocess env: scrubbed, isolated, CDP-attached."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.endswith("_API_KEY") and not key.startswith(_SCRUB_ENV_PREFIXES)
+    }
+    env["HERMES_HOME"] = str(state_dir)
+    env[_API_KEY_ENV] = api_key
+    if cdp_url:
+        env["BROWSER_CDP_URL"] = cdp_url
+    return env
+
+
+def _state_config(model: str, base_url: str, agent_config: dict[str, Any]) -> dict[str, Any]:
+    """Build the per-task HERMES_HOME/config.yaml content."""
+    agent_section: dict[str, Any] = {"verbose": False}
+    reasoning_effort = agent_config.get("reasoning_effort")
+    if reasoning_effort:
+        agent_section["reasoning_effort"] = str(reasoning_effort)
+    return {
+        "model": {"default": model, "provider": "bench"},
+        "providers": {"bench": {"base_url": base_url, "key_env": _API_KEY_ENV}},
+        "agent": agent_section,
+    }
+
+
+def _write_state_config(
+    state_dir: Path, model: str, base_url: str, agent_config: dict[str, Any]
+) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    config = _state_config(model, base_url, agent_config)
+    (state_dir / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+
+
+def _read_usage_report(path: Path) -> dict[str, Any] | None:
+    """Read the JSON usage report written by `hermes -z --usage-file`."""
+    if not path.is_file():
+        return None
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read Hermes usage report %s: %s", path, exc)
+        return None
+    return report if isinstance(report, dict) else None
+
+
+def _usage_from_report(report: dict[str, Any] | None) -> AgentUsage | None:
+    """Map the oneshot usage report to AgentUsage.
+
+    Hermes normalizes every wire format to DISJOINT buckets: its
+    ``input_tokens`` EXCLUDES ``cache_read_tokens``/``cache_write_tokens``
+    (see hermes-agent ``agent/usage_pricing.py``). Fold the cache counters
+    into the prompt count to match the AgentUsage convention.
+    """
+    if not report:
+        return None
+    input_tokens = safe_int(report.get("input_tokens"))
+    cache_read = safe_int(report.get("cache_read_tokens"))
+    cache_write = safe_int(report.get("cache_write_tokens"))
+    completion = safe_int(report.get("output_tokens"))
+    if input_tokens + cache_read + cache_write + completion == 0:
+        return None
+    return AgentUsage(
+        total_prompt_tokens=input_tokens + cache_read + cache_write,
+        total_prompt_cached_tokens=cache_read,
+        total_prompt_cache_creation_tokens=cache_write,
+        total_completion_tokens=completion,
+        entry_count=safe_int(report.get("api_calls")),
+    )
+
+
+def _fold_tool_calls(
+    raw: str, items: list[dict[str, Any]], by_call_id: dict[str, dict[str, Any]]
+) -> None:
+    """Append one assistant message's tool calls to *items* in the shared shape."""
+    try:
+        calls = json.loads(raw)
+    except json.JSONDecodeError:
+        return
+    if not isinstance(calls, list):
+        return
+    for call in calls:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function") if isinstance(call.get("function"), dict) else {}
+        item = {
+            "type": "mcp_tool_call",
+            "tool": str(function.get("name") or ""),
+            "arguments": _parse_arguments(function.get("arguments")),
+            "status": "in_progress",
+        }
+        items.append(item)
+        by_call_id[str(call.get("call_id") or call.get("id") or "")] = item
+
+
+def _parse_arguments(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _fold_rows(rows: list[tuple[Any, ...]]) -> list[dict[str, Any]]:
+    """Normalize (role, content, tool_call_id, tool_calls) rows to step items."""
+    items: list[dict[str, Any]] = []
+    by_call_id: dict[str, dict[str, Any]] = {}
+    for role, content, tool_call_id, tool_calls in rows:
+        if role == "assistant" and tool_calls:
+            _fold_tool_calls(str(tool_calls), items, by_call_id)
+            continue
+        if role != "tool":
+            continue
+        item = by_call_id.get(str(tool_call_id or ""))
+        if item is None:
+            continue
+        item["status"] = "completed"
+        item["result"] = {"content": [{"type": "text", "text": str(content or "")}]}
+    return items
+
+
+def _session_items(state_dir: Path, session_id: str | None) -> list[dict[str, Any]]:
+    """Read tool calls for *session_id* from the per-task SQLite session store.
+
+    Falls back to the newest session in the store when *session_id* is unknown
+    (e.g. the run timed out before the usage report was written) — the store
+    is per-task, so at most one oneshot session exists.
+    """
+    db_path = state_dir / "state.db"
+    if not db_path.is_file():
+        return []
+    try:
+        with sqlite3.connect(db_path) as conn:
+            resolved = session_id or _latest_session_id(conn)
+            if not resolved:
+                return []
+            rows = conn.execute(
+                "SELECT role, content, tool_call_id, tool_calls FROM messages "
+                "WHERE session_id = ? ORDER BY id",
+                (resolved,),
+            ).fetchall()
+    except sqlite3.Error as exc:
+        logger.warning("Failed to read Hermes session store %s: %s", db_path, exc)
+        return []
+    return _fold_rows(rows)
+
+
+def _latest_session_id(conn: sqlite3.Connection) -> str | None:
+    row = conn.execute("SELECT id FROM sessions ORDER BY rowid DESC LIMIT 1").fetchone()
+    return str(row[0]) if row else None
+
+
+def _screenshots_by_mtime(source_dir: Path) -> list[Path]:
+    """Stat once per file; a file vanishing between glob and stat is skipped."""
+    stamped: list[tuple[float, Path]] = []
+    for path in source_dir.glob("*.png"):
+        try:
+            stamped.append((path.stat().st_mtime, path))
+        except OSError as exc:
+            logger.warning("Skipping unreadable screenshot %s: %s", path, exc)
+    return [path for _, path in sorted(stamped)]
+
+
+def _collect_screenshots(state_dir: Path, trajectory_dir: Path) -> list[str]:
+    """Copy browser screenshots from the Hermes cache into trajectory/."""
+    source_dir = state_dir / _SCREENSHOTS_SUBDIR
+    if not source_dir.is_dir():
+        return []
+    sources = _screenshots_by_mtime(source_dir)
+    if not sources:
+        return []
+    try:
+        trajectory_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("Failed to create trajectory dir %s: %s", trajectory_dir, exc)
+        return []
+    saved: list[str] = []
+    for source in sources:
+        fname = f"screenshot-{len(saved) + 1}.png"
+        try:
+            shutil.copyfile(source, trajectory_dir / fname)
+            saved.append(fname)
+        except OSError as exc:
+            logger.warning("Failed to copy screenshot %s: %s", source, exc)
+    return saved
+
+
+@cache
+def _hermes_cli_version() -> str:
+    """One `hermes --version` per process; behavior is version-dependent, so
+    every result must record which CLI it ran against."""
+    try:
+        proc = subprocess.run(
+            ["hermes", "--version"], capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("Could not determine Hermes CLI version: %s", exc)
+        return "unknown"
+    lines = (proc.stdout or proc.stderr or "").strip().splitlines()
+    return lines[0].strip() if lines else "unknown"
+
+
+@register_agent
+class HermesAgent(CLIAgent):
+    """
+    Browser automation agent using the Hermes Agent CLI.
+
+    Hermes is invoked as an external process via `hermes -z` (oneshot mode)
+    with HERMES_HOME pointed at a per-task directory (the operator's ~/.hermes
+    is never touched). The `browser` toolset drives either an external CDP
+    endpoint (BROWSER_CDP_URL) or Hermes's managed local browser.
+    Install first: curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+    """
+
+    name = "hermes"
+
+    def run_task(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+    ) -> AgentResult | dict[str, Any]:
+        """Execute a browser automation task using the Hermes CLI."""
+        cli_version = self._cli_version()
+        logger.info("Hermes CLI version: %s", cli_version)
+        browser_id = str(agent_config.get("browser_id") or "")
+        if browser_id in SELF_LAUNCH_BROWSER_IDS:
+            warn_if_local_proxy_unsupported(agent_config, self.name)
+            result = self._execute(task_info, agent_config, task_workspace, cdp_url=None)
+        else:
+            result = self._run_with_browser_session(task_info, agent_config, task_workspace)
+        if isinstance(result, AgentResult):
+            result.agent_metadata["hermes_cli_version"] = cli_version
+        return result
+
+    # Class attribute so tests can patch/clear the process-wide cache.
+    _cli_version = staticmethod(_hermes_cli_version)
+
+    def _run_with_browser_session(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+    ) -> AgentResult:
+        browser_id = str(agent_config.get("browser_id") or "")
+        with open_browser_session(
+            browser_id=browser_id,
+            agent_name=self.name,
+            agent_config=agent_config,
+        ) as session_context:
+            cdp_url = session_context.cdp_url if session_context.transport == "cdp" else None
+            if not cdp_url:
+                return self._unsupported_backend_result(
+                    task_info["task_id"], browser_id, session_context.transport
+                )
+            return self._execute(task_info, agent_config, task_workspace, cdp_url=cdp_url)
+
+    def _unsupported_backend_result(
+        self, task_id: str, browser_id: str, transport: str
+    ) -> AgentResult:
+        """Fail fast instead of silently launching a managed local browser."""
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status="failed",  # type: ignore[arg-type]
+            agent_done="error",  # type: ignore[arg-type]
+            error=(
+                f"Browser backend '{browser_id}' (transport={transport}) provides no CDP "
+                "endpoint, so the hermes agent cannot attach its browser toolset to it. "
+                "Use a CDP-capable backend (e.g. lexmount, cdp) or browser_id=local."
+            ),
+            metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+        )
+
+    def _execute(
+        self,
+        task_info: dict[str, Any],
+        agent_config: dict[str, Any],
+        task_workspace: Path,
+        cdp_url: str | None,
+    ) -> AgentResult:
+        task_id = task_info["task_id"]
+        prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
+        rules = agent_config.get("system_prompt") or _DEFAULT_RULES
+        model = str(agent_config.get("model_id") or agent_config.get("model", ""))
+        timeout = self.get_timeout(agent_config, 600)
+
+        state_dir = task_workspace / ".hermes-state"
+        _write_state_config(state_dir, model, str(agent_config.get("base_url", "")), agent_config)
+        usage_file = task_workspace / "hermes_usage.json"
+        cmd = self._build_command(f"{rules}\n\n{prompt}", usage_file, agent_config)
+        env = _subprocess_env(state_dir, cdp_url, str(agent_config.get("api_key", "")))
+
+        logger.info("Executing Hermes for task %s (model=%s, timeout=%ds)", task_id, model, timeout)
+        t_start = time.monotonic()
+        try:
+            returncode, stdout_lines, execution_error = self._run_subprocess(
+                cmd,
+                timeout=timeout,
+                task_workspace=task_workspace,
+                cwd=task_workspace,
+                env=env,
+                # Hermes spawns helper processes (browser supervisor, node);
+                # kill the whole group on timeout so they cannot keep the
+                # benchmark runner alive.
+                terminate_process_group=True,
+            )
+        except FileNotFoundError:
+            return self._missing_cli_result(task_id)
+        duration_ms = int((time.monotonic() - t_start) * 1000)
+
+        return self._finalize_result(
+            task_id=task_id,
+            model=model,
+            rules=rules,
+            stdout_lines=stdout_lines,
+            returncode=returncode,
+            execution_error=execution_error,
+            duration_ms=duration_ms,
+            task_workspace=task_workspace,
+            state_dir=state_dir,
+            usage_file=usage_file,
+        )
+
+    @staticmethod
+    def _missing_cli_result(task_id: str) -> AgentResult:
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status="failed",  # type: ignore[arg-type]
+            agent_done="error",  # type: ignore[arg-type]
+            error=(
+                "Executable 'hermes' not found. Please install Hermes Agent: "
+                "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
+            ),
+            metrics=AgentMetrics(end_to_end_ms=0, steps=0),
+        )
+
+    @staticmethod
+    def _build_command(
+        full_prompt: str, usage_file: Path, agent_config: dict[str, Any]
+    ) -> list[str]:
+        toolsets = str(agent_config.get("toolsets") or "browser")
+        return [
+            "hermes",
+            "-z", full_prompt,
+            "--usage-file", str(usage_file),
+            "-t", toolsets,
+        ]
+
+    def _resolve_status(
+        self,
+        returncode: int,
+        execution_error: str | None,
+        report: dict[str, Any] | None,
+        answer: str,
+    ) -> tuple[str, str, str | None]:
+        """Map exit conditions plus the usage report to (env_status, agent_done, error)."""
+        env_status, agent_done = self._map_exit_status(
+            returncode, execution_error, has_result=bool(answer)
+        )
+        error_message = execution_error
+        if agent_done != "timeout" and report is not None and report.get("failed"):
+            env_status, agent_done = "failed", "error"
+            error_message = error_message or str(
+                report.get("failure") or "Hermes reported a failed run"
+            )
+        if env_status == "failed" and not error_message:
+            # A crashed CLI (non-zero exit, nothing on stdout, no report) must
+            # still leave a diagnostic on the result.
+            error_message = f"Hermes exited with code {returncode} and produced no output"
+        return env_status, agent_done, error_message
+
+    def _finalize_result(
+        self,
+        task_id: str,
+        model: str,
+        rules: str,
+        stdout_lines: list[str],
+        returncode: int,
+        execution_error: str | None,
+        duration_ms: int,
+        task_workspace: Path,
+        state_dir: Path,
+        usage_file: Path,
+    ) -> AgentResult:
+        answer = "".join(stdout_lines).strip()
+        report = _read_usage_report(usage_file)
+        if execution_error and "Timeout" in execution_error:
+            logger.error("Hermes task %s timed out", task_id)
+        env_status, agent_done, error_message = self._resolve_status(
+            returncode, execution_error, report, answer
+        )
+        if env_status == "failed" and not answer:
+            answer = f"[Task Failed: {error_message}]"
+
+        session_id = str(report.get("session_id") or "") if report else None
+        items = _session_items(state_dir, session_id)
+        trajectory_dir = task_workspace / "trajectory"
+        saved_screenshots = _collect_screenshots(state_dir, trajectory_dir)
+        steps = sum(1 for item in items if item.get("type") in STEP_ITEM_TYPES)
+        if items:
+            try:
+                write_api_logs(task_id, model, rules, items, task_workspace / "api_logs")
+            except (OSError, TypeError, ValueError) as exc:
+                logger.warning("Failed to generate api_logs for task %s: %s", task_id, exc)
+
+        return AgentResult(
+            task_id=task_id,
+            timestamp=datetime.now(UTC),
+            env_status=env_status,  # type: ignore[arg-type]
+            agent_done=agent_done,  # type: ignore[arg-type]
+            answer=answer,
+            error=error_message if env_status == "failed" else None,
+            action_history=extract_actions(items),
+            screenshots=saved_screenshots,
+            model_id=model,
+            agent_metadata={},
+            metrics=AgentMetrics(
+                end_to_end_ms=duration_ms,
+                steps=steps,
+                usage=_usage_from_report(report),
+            ),
+        )

--- a/browseruse_bench/agents/hermes.py
+++ b/browseruse_bench/agents/hermes.py
@@ -40,7 +40,8 @@ from browseruse_bench.utils.parse_utils import safe_int
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_RULES = (
+# Shared rule prefix for every run; the final reading rule differs by mode.
+_RULES_PREFIX = (
     "You are a browser automation agent. "
     "You MUST use ONLY the browser_* tools for ALL browser interactions."
     "\n\nTask completion rules:\n"
@@ -50,6 +51,9 @@ _DEFAULT_RULES = (
     "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
     "go back to the previous page and use the data already collected to answer.\n"
     "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+)
+
+_DEFAULT_RULES = _RULES_PREFIX + (
     "- Read pages with browser_snapshot. Do NOT use browser_vision or browser_get_images: "
     "no vision model is available in this environment, image analysis always fails."
 )
@@ -58,16 +62,7 @@ _DEFAULT_RULES = (
 # (Hermes auxiliary auto mode resolves to the main provider first), so it works
 # whenever that model is multimodal. Vision is evidence capture on top of
 # snapshot-driven reading, not a replacement for it.
-_VISION_RULES = (
-    "You are a browser automation agent. "
-    "You MUST use ONLY the browser_* tools for ALL browser interactions."
-    "\n\nTask completion rules:\n"
-    "- If you can see enough information to answer the task from the current page (e.g., "
-    "ratings, names, prices visible in search results), provide your answer IMMEDIATELY "
-    "without clicking into individual items to get more detail.\n"
-    "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
-    "go back to the previous page and use the data already collected to answer.\n"
-    "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+_VISION_RULES = _RULES_PREFIX + (
     "- Read pages with browser_snapshot as your primary tool. Additionally, call "
     "browser_vision once on each page that contains evidence for your final answer, so "
     "the run keeps a visual record. Trust browser_snapshot text over the vision summary "
@@ -86,6 +81,7 @@ def _rules_for(agent_config: dict[str, Any]) -> str:
     if explicit:
         return str(explicit)
     return _VISION_RULES if agent_config.get("use_vision") else _DEFAULT_RULES
+
 
 # The name of the env var carrying the bench provider API key into the Hermes
 # subprocess; referenced as key_env in the per-task config.yaml so the secret
@@ -139,10 +135,10 @@ def _state_config(model: str, base_url: str, agent_config: dict[str, Any]) -> di
         "agent": agent_section,
     }
     if agent_config.get("use_vision"):
-        temperature = float(
-            agent_config.get("vision_temperature", _DEFAULT_VISION_TEMPERATURE)
-        )
-        config["auxiliary"] = {"vision": {"temperature": temperature}}
+        # `or` (not the .get default) so an explicit null/empty in config falls
+        # back instead of crashing float(None).
+        raw_temperature = agent_config.get("vision_temperature") or _DEFAULT_VISION_TEMPERATURE
+        config["auxiliary"] = {"vision": {"temperature": float(raw_temperature)}}
     return config
 
 

--- a/browseruse_bench/agents/hermes.py
+++ b/browseruse_bench/agents/hermes.py
@@ -54,6 +54,39 @@ _DEFAULT_RULES = (
     "no vision model is available in this environment, image analysis always fails."
 )
 
+# Rules for use_vision runs: browser_vision routes to the main bench model
+# (Hermes auxiliary auto mode resolves to the main provider first), so it works
+# whenever that model is multimodal. Vision is evidence capture on top of
+# snapshot-driven reading, not a replacement for it.
+_VISION_RULES = (
+    "You are a browser automation agent. "
+    "You MUST use ONLY the browser_* tools for ALL browser interactions."
+    "\n\nTask completion rules:\n"
+    "- If you can see enough information to answer the task from the current page (e.g., "
+    "ratings, names, prices visible in search results), provide your answer IMMEDIATELY "
+    "without clicking into individual items to get more detail.\n"
+    "- If you encounter a CAPTCHA, verification page, login wall, or access restriction: "
+    "go back to the previous page and use the data already collected to answer.\n"
+    "- Do NOT get stuck retrying the same blocked action. One retry max, then fall back.\n"
+    "- Read pages with browser_snapshot as your primary tool. Additionally, call "
+    "browser_vision once on each page that contains evidence for your final answer, so "
+    "the run keeps a visual record. Trust browser_snapshot text over the vision summary "
+    "when they disagree."
+)
+
+# gpt-5-family models on the gateway reject any temperature other than 1, while
+# Hermes's browser_vision defaults to temperature=0.1; vision runs therefore
+# pin auxiliary.vision.temperature (config key vision_temperature to override).
+_DEFAULT_VISION_TEMPERATURE = 1.0
+
+
+def _rules_for(agent_config: dict[str, Any]) -> str:
+    """Pick the system rules for a run: explicit config wins, then vision mode."""
+    explicit = agent_config.get("system_prompt")
+    if explicit:
+        return str(explicit)
+    return _VISION_RULES if agent_config.get("use_vision") else _DEFAULT_RULES
+
 # The name of the env var carrying the bench provider API key into the Hermes
 # subprocess; referenced as key_env in the per-task config.yaml so the secret
 # never touches disk.
@@ -100,11 +133,17 @@ def _state_config(model: str, base_url: str, agent_config: dict[str, Any]) -> di
     reasoning_effort = agent_config.get("reasoning_effort")
     if reasoning_effort:
         agent_section["reasoning_effort"] = str(reasoning_effort)
-    return {
+    config: dict[str, Any] = {
         "model": {"default": model, "provider": "bench"},
         "providers": {"bench": {"base_url": base_url, "key_env": _API_KEY_ENV}},
         "agent": agent_section,
     }
+    if agent_config.get("use_vision"):
+        temperature = float(
+            agent_config.get("vision_temperature", _DEFAULT_VISION_TEMPERATURE)
+        )
+        config["auxiliary"] = {"vision": {"temperature": temperature}}
+    return config
 
 
 def _write_state_config(
@@ -370,7 +409,7 @@ class HermesAgent(CLIAgent):
     ) -> AgentResult:
         task_id = task_info["task_id"]
         prompt = task_info.get("prompt") or self.build_task_prompt(task_info)
-        rules = agent_config.get("system_prompt") or _DEFAULT_RULES
+        rules = _rules_for(agent_config)
         model = str(agent_config.get("model_id") or agent_config.get("model", ""))
         timeout = self.get_timeout(agent_config, 600)
 

--- a/browseruse_bench/cli/eval.py
+++ b/browseruse_bench/cli/eval.py
@@ -512,9 +512,12 @@ def configure_eval_parser(parser: argparse.ArgumentParser, config: dict[str, Any
             "config.yaml). Its `eval` section overrides the defaults from root config.yaml."
         ),
     )
+    # api_key default must stay empty: an env-derived default would count as an
+    # explicit --api-key and override config.yaml eval.api_key in the resolution
+    # chain. OPENAI_API_KEY remains the last-resort fallback at resolution time.
     parser.set_defaults(
         model="",
-        api_key=get_env_var("OPENAI_API_KEY", ""),
+        api_key="",
         base_url="",
     )
 

--- a/browseruse_bench/skills/custom-agent-creator/SKILL.md
+++ b/browseruse_bench/skills/custom-agent-creator/SKILL.md
@@ -102,6 +102,14 @@ description: "Create and integrate new modular agents for browseruse-bench (Base
 - Keep provider-specific session create/delete logic in `browseruse_bench/browsers/providers/*.py`; do not duplicate this in agent modules.
 - In agent code, branch by `session_context.transport` (`local` / `cdp` / `cloud_native`) instead of hardcoding provider SDK logic.
 - History handling: decode base64 screenshots to `trajectory/`, collect basic actions, steps, end-to-end ms; keep result dict small.
+- Trajectory screenshots are an expected artifact, not an optional extra: `AgentResult.screenshots`
+  must list the files saved under `trajectory/`. If the agent framework can capture screenshots,
+  make the default rules ask for at least one after reaching the main page and one after finding
+  the answer (see the openclaw/hermes default rules). If capturing is deliberately disabled — for
+  example the only screenshot path also triggers a vision-model call the bench model cannot serve
+  (hermes `browser_vision`) — record that trade-off in the agent module's default rules or a module
+  comment so a run with zero screenshots is explainable, and still keep the collection code path
+  working for the day it is re-enabled.
 - For provider semantics, routing, workspace, and missing-file edge cases, follow the guidance in
   `SDK Integration Pitfalls` below instead of repeating those rules in the generated agent.
 - Error handling: catch specific expected failures (`asyncio.TimeoutError`, `TimeoutError`, `ValueError`, `RuntimeError`), set `status`/`error`; no bare `except`.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -174,6 +174,15 @@ models:
     # reasoning: true                # mark the model as a reasoning model
     # supports_reasoning_effort: true
     # thinking: medium               # OpenClaw --thinking level (off|minimal|low|medium|high|xhigh)
+  # Hermes Agent CLI model. Only supported by the hermes agent; the agent
+  # writes a per-task Hermes provider config from these values
+  # (OpenAI-compatible endpoints work, e.g. a LiteLLM proxy).
+  hermes:
+    model_type: OPENAI
+    model_id: gpt-5.4
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    # reasoning_effort: medium       # forwarded to agent.reasoning_effort in the per-task config
 browsers:
   lexmount:
     browser_id: lexmount
@@ -276,6 +285,10 @@ agents:
   openclaw:
     active_model: openclaw
     timeout: 600
+  hermes:
+    active_model: hermes
+    timeout: 600
+    # toolsets: browser              # Hermes toolsets enabled for the run (comma-separated)
   deepbrowse:
     use_vision: auto
     max_steps: 50

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -289,6 +289,10 @@ agents:
     active_model: hermes
     timeout: 600
     # toolsets: browser              # Hermes toolsets enabled for the run (comma-separated)
+    # use_vision: true               # allow browser_vision (needs a multimodal bench model);
+    #                                # captures screenshots as trajectory evidence
+    # vision_temperature: 1          # auxiliary.vision.temperature for use_vision runs
+    #                                # (gpt-5-family gateways only accept temperature=1)
   deepbrowse:
     use_vision: auto
     max_steps: 50

--- a/configs/agent_registry.yaml
+++ b/configs/agent_registry.yaml
@@ -76,6 +76,17 @@ openclaw:
     - WebVoyager
     - Odysseys
 
+hermes:
+  path: browseruse_bench/agents
+  entrypoint: browseruse_bench/runner/agent_runner.py
+  venv: .venv
+  supported_benchmarks:
+    - Online-Mind2Web
+    - BrowseComp
+    - LexBench-Browser
+    - WebVoyager
+    - Odysseys
+
 deepbrowse:
   path: browseruse_bench/agents
   entrypoint: browseruse_bench/runner/agent_runner.py

--- a/tests/browseruse_bench/test_eval_cli.py
+++ b/tests/browseruse_bench/test_eval_cli.py
@@ -160,3 +160,19 @@ def test_run_failure_classification_dedupes_records(tmp_path, monkeypatch) -> No
         if line.strip()
     ]
     assert len(lines) == 1
+
+
+def test_api_key_default_does_not_shadow_config_eval_key(monkeypatch) -> None:
+    """An OPENAI_API_KEY in the environment must not become an implicit
+    --api-key default: that would win over config.yaml eval.api_key in the
+    resolution chain (args.api_key or eval_cfg or env fallback)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-stale-env-key")
+    parser = argparse.ArgumentParser()
+    eval_cli.configure_eval_parser(parser, {})
+    args = parser.parse_args(["--agent", "hermes", "--data", "LexBench-Browser"])
+
+    assert args.api_key == ""
+
+    eval_cfg = {"api_key": "sk-config-key"}
+    resolved = args.api_key or eval_cfg.get("api_key") or "sk-stale-env-key"
+    assert resolved == "sk-config-key"

--- a/tests/browseruse_bench/test_hermes_agent.py
+++ b/tests/browseruse_bench/test_hermes_agent.py
@@ -1,0 +1,335 @@
+"""Tests for HermesAgent: session-store normalization, usage mapping, run_task."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from browseruse_bench.agents.hermes import (
+    _API_KEY_ENV,
+    HermesAgent,
+    _collect_screenshots,
+    _session_items,
+    _state_config,
+    _subprocess_env,
+    _usage_from_report,
+)
+from browseruse_bench.schemas import AgentResult
+
+TASK_INFO: dict[str, Any] = {
+    "task_id": "t1",
+    "task_text": "Go to example.com",
+    "url": "https://example.com",
+}
+
+AGENT_CONFIG: dict[str, Any] = {
+    "model_id": "gpt-test",
+    "api_key": "sk-test",
+    "base_url": "https://llm.example/v1",
+    "timeout": 10,
+}
+
+USAGE_REPORT: dict[str, Any] = {
+    "input_tokens": 1000,
+    "output_tokens": 50,
+    "cache_read_tokens": 400,
+    "cache_write_tokens": 100,
+    "total_tokens": 1050,
+    "api_calls": 3,
+    "model": "gpt-test",
+    "session_id": "sess-1",
+    "completed": True,
+    "failed": False,
+}
+
+
+def _write_state_db(state_dir: Path, session_id: str = "sess-1") -> None:
+    """Create a minimal Hermes state.db with one browsing session."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(state_dir / "state.db") as conn:
+        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        conn.execute(
+            "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "session_id TEXT, role TEXT, content TEXT, tool_call_id TEXT, tool_calls TEXT)"
+        )
+        conn.execute("INSERT INTO sessions (id) VALUES (?)", (session_id,))
+        tool_calls = json.dumps([
+            {
+                "id": "c1",
+                "call_id": "c1",
+                "type": "function",
+                "function": {
+                    "name": "browser_navigate",
+                    "arguments": json.dumps({"url": "https://example.com"}),
+                },
+            }
+        ])
+        rows = [
+            (session_id, "user", "go", None, None),
+            (session_id, "assistant", None, None, tool_calls),
+            (session_id, "tool", "opened example.com", "c1", None),
+            (session_id, "assistant", "done", None, None),
+        ]
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, tool_call_id, tool_calls) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _prepare_success_artifacts(task_workspace: Path) -> None:
+    """Simulate the artifacts a successful `hermes -z` run leaves behind."""
+    (task_workspace / "hermes_usage.json").write_text(json.dumps(USAGE_REPORT), encoding="utf-8")
+    _write_state_db(task_workspace / ".hermes-state")
+
+
+class TestSessionItems:
+    def test_tool_calls_folded_to_items(self, tmp_path: Path) -> None:
+        _write_state_db(tmp_path)
+        items = _session_items(tmp_path, "sess-1")
+        assert len(items) == 1
+        assert items[0]["type"] == "mcp_tool_call"
+        assert items[0]["tool"] == "browser_navigate"
+        assert items[0]["arguments"] == {"url": "https://example.com"}
+        assert items[0]["status"] == "completed"
+        assert items[0]["result"]["content"][0]["text"] == "opened example.com"
+
+    def test_missing_db_returns_empty(self, tmp_path: Path) -> None:
+        assert _session_items(tmp_path, "sess-1") == []
+
+    def test_unknown_session_falls_back_to_latest(self, tmp_path: Path) -> None:
+        # Timed-out runs never produce a usage report; the store is per-task,
+        # so the newest (only) session is the right fallback.
+        _write_state_db(tmp_path)
+        items = _session_items(tmp_path, None)
+        assert len(items) == 1
+        assert items[0]["tool"] == "browser_navigate"
+
+    def test_malformed_tool_calls_skipped(self, tmp_path: Path) -> None:
+        tmp_path.mkdir(exist_ok=True)
+        with sqlite3.connect(tmp_path / "state.db") as conn:
+            conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+            conn.execute(
+                "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "session_id TEXT, role TEXT, content TEXT, tool_call_id TEXT, tool_calls TEXT)"
+            )
+            conn.execute("INSERT INTO sessions (id) VALUES ('s')")
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, tool_call_id, tool_calls) "
+                "VALUES ('s', 'assistant', NULL, NULL, 'not-json')"
+            )
+        assert _session_items(tmp_path, "s") == []
+
+
+class TestUsageFromReport:
+    def test_disjoint_buckets_folded_into_prompt(self) -> None:
+        # Hermes reports DISJOINT buckets (input excludes cache reads/writes);
+        # AgentUsage wants prompt INCLUDING cached.
+        usage = _usage_from_report(USAGE_REPORT)
+        assert usage is not None
+        assert usage.total_prompt_tokens == 1500
+        assert usage.total_prompt_cached_tokens == 400
+        assert usage.total_prompt_cache_creation_tokens == 100
+        assert usage.total_completion_tokens == 50
+        assert usage.entry_count == 3
+
+    def test_empty_report_returns_none(self) -> None:
+        assert _usage_from_report(None) is None
+        assert _usage_from_report({"input_tokens": 0, "output_tokens": 0}) is None
+
+
+class TestStateConfig:
+    def test_provider_uses_key_env_not_secret(self) -> None:
+        config = _state_config("gpt-test", "https://llm.example/v1", AGENT_CONFIG)
+        assert config["model"] == {"default": "gpt-test", "provider": "bench"}
+        assert config["providers"]["bench"]["base_url"] == "https://llm.example/v1"
+        assert config["providers"]["bench"]["key_env"] == _API_KEY_ENV
+        assert "sk-test" not in yaml.safe_dump(config)
+
+    def test_reasoning_effort_forwarded(self) -> None:
+        config = _state_config("m", "u", {"reasoning_effort": "high"})
+        assert config["agent"]["reasoning_effort"] == "high"
+
+
+class TestSubprocessEnv:
+    def test_scrubs_provider_and_hermes_vars(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-leak")
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://leak.local")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-leak")
+        monkeypatch.setenv("HERMES_INFERENCE_MODEL", "operator-model")
+        monkeypatch.setenv("HERMES_HOME", "/operator/.hermes")
+        monkeypatch.setenv("BROWSER_CDP_URL", "http://stale:9222")
+        monkeypatch.setenv("BENCH_HARMLESS_VAR", "keep-me")
+        env = _subprocess_env(tmp_path, "http://127.0.0.1:9222", "sk-bench")
+        assert "OPENAI_API_KEY" not in env
+        assert "OPENAI_BASE_URL" not in env
+        assert "OPENROUTER_API_KEY" not in env
+        assert "HERMES_INFERENCE_MODEL" not in env
+        assert env["BENCH_HARMLESS_VAR"] == "keep-me"
+        assert env["HERMES_HOME"] == str(tmp_path)
+        assert env[_API_KEY_ENV] == "sk-bench"
+        assert env["BROWSER_CDP_URL"] == "http://127.0.0.1:9222"
+
+    def test_no_cdp_env_for_self_launch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("BROWSER_CDP_URL", "http://stale:9222")
+        env = _subprocess_env(tmp_path, None, "sk-bench")
+        assert "BROWSER_CDP_URL" not in env
+
+
+class TestCollectScreenshots:
+    def test_copies_pngs_in_mtime_order(self, tmp_path: Path) -> None:
+        shots_dir = tmp_path / "state" / "cache" / "screenshots"
+        shots_dir.mkdir(parents=True)
+        (shots_dir / "browser_screenshot_b.png").write_bytes(b"one")
+        (shots_dir / "browser_screenshot_a.png").write_bytes(b"two")
+        os.utime(shots_dir / "browser_screenshot_b.png", (1, 1))
+        os.utime(shots_dir / "browser_screenshot_a.png", (2, 2))
+        trajectory = tmp_path / "trajectory"
+        assert _collect_screenshots(tmp_path / "state", trajectory) == [
+            "screenshot-1.png",
+            "screenshot-2.png",
+        ]
+        assert (trajectory / "screenshot-1.png").read_bytes() == b"one"
+
+    def test_no_screenshots_dir(self, tmp_path: Path) -> None:
+        assert _collect_screenshots(tmp_path, tmp_path / "trajectory") == []
+
+
+class TestHermesAgentRunTask:
+    def _agent(self, monkeypatch: pytest.MonkeyPatch) -> HermesAgent:
+        agent = HermesAgent()
+        monkeypatch.setattr(agent, "_cli_version", lambda: "Hermes Agent v0.0-test")
+        return agent
+
+    def test_successful_run_returns_answer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = self._agent(monkeypatch)
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            _prepare_success_artifacts(tmp_path)
+            return 0, ["The price is $42\n"], None
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert isinstance(result, AgentResult)
+        assert result.env_status == "success"
+        assert result.agent_done == "done"
+        assert result.answer == "The price is $42"
+        assert result.action_history == ["Navigate to https://example.com"]
+        assert result.metrics.steps == 1
+        assert result.metrics.usage.total_prompt_tokens == 1500
+        assert result.agent_metadata["hermes_cli_version"] == "Hermes Agent v0.0-test"
+        assert (tmp_path / "api_logs" / "system_prompt.txt").is_file()
+
+    def test_state_config_written_without_secret(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = self._agent(monkeypatch)
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (0, ["ok\n"], None))
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        written = (tmp_path / ".hermes-state" / "config.yaml").read_text(encoding="utf-8")
+        assert "sk-test" not in written
+        assert _API_KEY_ENV in written
+
+    def test_command_shape(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        agent = self._agent(monkeypatch)
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            captured["cmd"] = cmd
+            captured["env"] = kw.get("env")
+            return 0, ["ok\n"], None
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        cmd = captured["cmd"]
+        assert cmd[0] == "hermes"
+        assert cmd[1] == "-z"
+        assert "Go to example.com" in cmd[2]
+        assert cmd[cmd.index("-t") + 1] == "browser"
+        assert captured["env"][_API_KEY_ENV] == "sk-test"
+
+    def test_failed_report_maps_to_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = self._agent(monkeypatch)
+
+        def fake_run(cmd: list[str], **kw: Any) -> tuple[int, list[str], None]:
+            report = dict(USAGE_REPORT, completed=False, failed=True, failure="boom")
+            (tmp_path / "hermes_usage.json").write_text(json.dumps(report), encoding="utf-8")
+            return 0, [], None
+
+        monkeypatch.setattr(agent, "_run_subprocess", fake_run)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert result.error == "boom"
+        assert result.answer.startswith("[Task Failed:")
+
+    def test_crash_without_output_keeps_diagnostic(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Non-zero exit, nothing on stdout, no usage report: the result must
+        # still carry an error message, not error=None.
+        agent = self._agent(monkeypatch)
+        monkeypatch.setattr(agent, "_run_subprocess", lambda *a, **kw: (1, [], None))
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert result.agent_done == "error"
+        assert "exited with code 1" in result.error
+        assert result.answer.startswith("[Task Failed:")
+
+    def test_timeout_preserved(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        agent = self._agent(monkeypatch)
+        monkeypatch.setattr(
+            agent, "_run_subprocess", lambda *a, **kw: (-1, [], "Timeout after 10 seconds")
+        )
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "success"
+        assert result.agent_done == "timeout"
+
+    def test_missing_executable(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        agent = self._agent(monkeypatch)
+
+        def raise_not_found(*a: Any, **kw: Any) -> None:
+            raise FileNotFoundError("hermes")
+
+        monkeypatch.setattr(agent, "_run_subprocess", raise_not_found)
+        result = agent.run_task(TASK_INFO, AGENT_CONFIG, tmp_path)
+        assert result.env_status == "failed"
+        assert "install" in result.error.lower()
+
+    def test_non_cdp_backend_fails_fast(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent = self._agent(monkeypatch)
+
+        class FakeSession:
+            transport = "playwright"
+            cdp_url = None
+
+            def __enter__(self) -> FakeSession:
+                return self
+
+            def __exit__(self, *exc: Any) -> None:
+                return None
+
+        monkeypatch.setattr(
+            "browseruse_bench.agents.hermes.open_browser_session",
+            lambda **kw: FakeSession(),
+        )
+        config = dict(AGENT_CONFIG, browser_id="browser-use-cloud")
+        result = agent.run_task(TASK_INFO, config, tmp_path)
+        assert result.env_status == "failed"
+        assert "no CDP" in result.error

--- a/tests/browseruse_bench/test_hermes_agent.py
+++ b/tests/browseruse_bench/test_hermes_agent.py
@@ -15,6 +15,7 @@ from browseruse_bench.agents.hermes import (
     _API_KEY_ENV,
     HermesAgent,
     _collect_screenshots,
+    _rules_for,
     _session_items,
     _state_config,
     _subprocess_env,
@@ -155,6 +156,32 @@ class TestStateConfig:
     def test_reasoning_effort_forwarded(self) -> None:
         config = _state_config("m", "u", {"reasoning_effort": "high"})
         assert config["agent"]["reasoning_effort"] == "high"
+
+    def test_no_auxiliary_section_without_use_vision(self) -> None:
+        config = _state_config("m", "u", AGENT_CONFIG)
+        assert "auxiliary" not in config
+
+    def test_use_vision_pins_vision_temperature(self) -> None:
+        config = _state_config("m", "u", {"use_vision": True})
+        assert config["auxiliary"]["vision"]["temperature"] == 1.0
+
+    def test_vision_temperature_override(self) -> None:
+        config = _state_config("m", "u", {"use_vision": True, "vision_temperature": 0.3})
+        assert config["auxiliary"]["vision"]["temperature"] == 0.3
+
+
+class TestRulesSelection:
+    def test_default_rules_forbid_vision(self) -> None:
+        rules = _rules_for({})
+        assert "Do NOT use browser_vision" in rules
+
+    def test_use_vision_switches_to_vision_rules(self) -> None:
+        rules = _rules_for({"use_vision": True})
+        assert "browser_vision" in rules
+        assert "Do NOT use browser_vision" not in rules
+
+    def test_explicit_system_prompt_wins(self) -> None:
+        assert _rules_for({"use_vision": True, "system_prompt": "custom"}) == "custom"
 
 
 class TestSubprocessEnv:

--- a/tests/browseruse_bench/test_hermes_agent.py
+++ b/tests/browseruse_bench/test_hermes_agent.py
@@ -169,6 +169,12 @@ class TestStateConfig:
         config = _state_config("m", "u", {"use_vision": True, "vision_temperature": 0.3})
         assert config["auxiliary"]["vision"]["temperature"] == 0.3
 
+    def test_null_vision_temperature_falls_back(self) -> None:
+        # An explicit null in config.yaml (key present, value None) must fall
+        # back to the default, not crash float(None).
+        config = _state_config("m", "u", {"use_vision": True, "vision_temperature": None})
+        assert config["auxiliary"]["vision"]["temperature"] == 1.0
+
 
 class TestRulesSelection:
     def test_default_rules_forbid_vision(self) -> None:


### PR DESCRIPTION
## Summary

Integrate Nous Research's **Hermes Agent CLI** as a bench agent (oneshot `hermes -z` mode, following the openclaw CLI-subprocess pattern), plus two fixes surfaced while validating it end-to-end.

**Commits:**
1. `feat(agents): add hermes agent` — the adapter, tests, config + registry entries.
2. `docs(custom-agent-creator)` — make trajectory screenshots an explicit integration requirement (surfaced by hermes's zero-screenshot baseline runs).
3. `fix(eval): stop env OPENAI_API_KEY from shadowing config eval.api_key` — `configure_eval_parser` set the `--api-key` argparse default to the `OPENAI_API_KEY` env value, so a stale key in `.env` counted as an explicit CLI override and silently won over `config.yaml eval.api_key`. Every judge call then 401'd and the evaluator backfilled synthetic failures — a `0/N` that never ran a judge. Default is now empty; env stays as the documented last-resort fallback. This aligns `eval` with the `attribute` command, which already used `default=None`.
4. `feat(hermes): opt-in browser_vision via use_vision config` — the original "no vision model" premise was stale: Hermes auxiliary auto-mode routes `browser_vision` to the main bench provider, and gpt-5.4 is multimodal. The real blocker was Hermes's hardcoded vision `temperature=0.1` vs the gpt-5-family `temperature=1`-only contract. `agents.hermes.use_vision: true` switches the run rules and pins `auxiliary.vision.temperature` (default 1, override via `vision_temperature`). Default (vision off) unchanged.
5. `refactor(hermes)` — self-review cleanup: dedupe the shared rule prefix, harden `vision_temperature` against an explicit `null`.

## Contribution type

- [x] Agent adapter
- [x] Evaluation or judge strategy
- [x] Bug fix

## Reproduction or validation

```bash
# Baseline smoke (single, non-login task)
bubench run --agent hermes --data LexBench-Browser --split lexmount --mode single
#   -> task 5, lexmount backend, 28.9s, real subprocess work:
#      "Executing Hermes for task 5 (model=gpt-5.4, timeout=600s)" -> "Task completed successfully"

# 5-task batch, baseline + real gpt-5.4 judge eval
bubench run  --agent hermes --data LexBench-Browser --split lexmount --mode first_n --count 5   # 5/5 completed
bubench eval --agent hermes --data LexBench-Browser --split lexmount --model-id gpt-5.4 --force-reeval  # judge 1/5

# 5-task batch with use_vision on
bubench run  --agent hermes ... (use_vision: true)   # 5/5, 2-3 browser_vision calls + 2-3 screenshots per task
bubench eval --agent hermes ...                      # judge 2/5; all 5 tasks scored higher than baseline
```

**Answer-provenance audit** (guarding against "fast = fabricated"): every factual claim in the baseline answers (video titles, recipe names, page counts, ratings) was found verbatim in the `role=tool` browser_snapshot payloads in `state.db` — no hallucinated answers. The short wall-clock is a shallow-strategy artifact (the default rules tell the agent to answer from the results page without drilling into detail pages), which the judge correctly penalizes.

## Self-review (mandatory)

- [x] I read every line of my diff and every change is intentional
- [x] The diff passes the hard rules in CONTRIBUTING.md (logger not print, specific exceptions, no hardcoded config, imports at top)
- [x] I ran a local `/code-review` and fixed or justified every finding
- [x] `uv run pytest tests/` passes and behavior changes have targeted tests
- [x] Agent-touching change: real smoke run evidence is included above
- [x] No secrets, cookies, or unredacted logs in the diff

`/code-review` (high) found two items, both fixed in commit 5: the `_DEFAULT_RULES`/`_VISION_RULES` prose duplication (extracted `_RULES_PREFIX`) and a `float(None)` crash on an explicit-null `vision_temperature` (switched to `or` fallback + regression test). Structural concerns raised by the finders (agent_metadata assignment on all result paths, exit-status contract, venv/registry wiring, cross-command impact of the eval default change) were traced and confirmed safe.

Test note: 3 pre-existing failures in the full suite (`test_claude_code_agent` .env-leak smoke, `test_config_loader`, `test_logger`) reproduce on a clean `main` checkout and are unrelated to this PR. The two `test_browser*` collection errors are the `agentbay` optional-SDK-not-installed case.

## Notes for reviewers

- **Optional dependency**: hermes is a separately-installed CLI (`curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`), so it has no `pyproject` extra and runs in the base `.venv` (registry `venv: .venv`), same as openclaw/codex/cursor.
- **Verified against Hermes Agent v0.18.0**; the CLI is version-dependent, so `agent_metadata.hermes_cli_version` records the exact version per run.
- `use_vision` is **off by default** and adds ~50-70s wall clock per task (2-3 vision calls); the A/B above is n=5, so treat the +1 pass-rate and score deltas as directional, not conclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
