### PR TITLE
fix(codex): disable built-in image_generation tool (unbreaks gpt-5.x gateway)

### DIFF
--- a/browseruse_bench/agents/codex.py
+++ b/browseruse_bench/agents/codex.py
@@ -276,6 +276,11 @@ class CodexAgent(CLIAgent):
             "-c", 'mcp_servers.playwright.default_tools_approval_mode="approve"',
             "-c", f"mcp_servers.playwright.startup_timeout_sec={mcp_startup_timeout}",
             "-c", f"mcp_servers.playwright.tool_timeout_sec={mcp_tool_timeout}",
+            # Codex advertises a built-in image_generation tool by default; the
+            # bench gateway's Azure gpt-5.x deployment rejects it (400
+            # "imagegen deployment must be provided ...") on turn 1, before any
+            # browsing. Browser tasks never generate images, so disable it.
+            "-c", "features.image_generation=false",
         ]
         # codex ignores OPENAI_BASE_URL; to route it at a custom (proxy)
         # endpoint, register a model provider under a fixed, non-reserved id

--- a/tests/browseruse_bench/test_codex_agent.py
+++ b/tests/browseruse_bench/test_codex_agent.py
@@ -254,6 +254,9 @@ class TestCodexAgentRunTask:
         assert "--cdp-endpoint" not in joined
         # No base_url => default codex provider (api.openai.com / auth.json).
         assert "model_provider=" not in joined
+        # Codex's built-in image_generation tool is rejected by the gateway's
+        # Azure gpt-5.x deployment on turn 1; browser tasks never need it.
+        assert "features.image_generation=false" in joined
 
     def test_base_url_registers_responses_provider(self, tmp_path: Path) -> None:
         # codex ignores OPENAI_BASE_URL; base_url must be wired via a model


### PR DESCRIPTION
## Summary

Unbreak the codex agent on the bench gateway by disabling Codex CLI's built-in `image_generation` tool. This started as "add vision to codex/cursor" and ended with a concrete finding: **codex vision was already wired — the only blocker was an unrelated pre-existing breakage.**

Codex CLI 0.142.5 advertises a built-in `image_generation` tool by default. The gateway's Azure gpt-5.x deployment rejects it on turn 1, before any browsing:

```
litellm.BadRequestError: Azure_aiException - imagegen deployment must be provided
through header: x-ms-oai-image-generation-deployment
(image_generation_user_error, param: tools, Model Group=gpt-5.5)
```

Every codex run failed at ~10s with exit 1. Browser tasks never generate images, so this disables the feature via `-c features.image_generation=false` (`--ignore-user-config` means a `config.toml` toggle would not apply).

## Contribution type

- [x] Bug fix
- [x] Agent adapter

## Reproduction or validation

```bash
bubench run --agent codex --data LexBench-Browser --split lexmount --mode single
# before: FAILED at 9.8s — imagegen 400
# after:  task 5, 85.0s, SUCCESS, real subprocess work, correct answer
```

**Vision finding (why no `use_vision` flag is needed for codex):** With codex running again, its vision path is already complete. Playwright MCP returns `browser_take_screenshot` as a real image content block (334KB PNG in the event stream), Codex CLI forwards it to gpt-5.5, and the model reasons over the pixels. Verified **causally** on the baidu-image task (task 7):

- codex answer describes image *pixels*: "白色布偶猫坐在桌边，毛发蓬松整洁", "布偶猫和花束合照，下面还有几张同组美容照缩略图", "右侧还有一张背部/尾部护理效果图".
- The `browser_snapshot` **text** result for that page carried only the page title + search box — no per-image alt text.
- Each visual keyword appears exactly once in the whole event stream (only in the answer, not in any tool result), so it can only have come from the screenshot.

Screenshots already reach the model, so codex needs no vision toggle — just this fix.

## Self-review (mandatory)

- [x] I read every line of my diff and every change is intentional
- [x] The diff passes the hard rules in CONTRIBUTING.md (logger not print, specific exceptions, no hardcoded config, imports at top)
- [x] I ran a local `/code-review` and fixed or justified every finding
- [x] `uv run pytest tests/` passes and behavior changes have targeted tests (`test_command_includes_mcp_overrides` asserts the flag)
- [x] Agent-touching change: real smoke run evidence included above
- [x] No secrets, cookies, or unredacted logs in the diff

Diff is a single `-c` flag plus a test assertion. Pre-existing full-suite failures (`test_claude_code_agent` .env-leak smoke, `test_config_loader`, `test_logger`) are unrelated and reproduce on clean `main`.

## Notes for reviewers

- Built on latest `main` (includes hermes PR #101). Independent of it — only touches codex.
- Verified against **codex-cli 0.142.5**, model gpt-5.5 via the gateway.
- **cursor** was in scope too but is blocked externally: `ActionRequiredError: Free plans can only use Auto` — the CURSOR_API_KEY is a Free-plan key that cannot select the named gpt-5.2 model, so cursor vision could not be probed. Not a code issue; left for when a paid Cursor plan is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
