### PR TITLE
fix(browser-use): pin OOPIF session timeout fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
 
 # Agent-specific dependencies (use --extra to select)
 browser-use = [
-    "browser-use>=0.12.6",
+    "browser-use @ git+https://github.com/254808127/browser-use.git@b174da3fcd1c6483fbae9746cbc686fb97b502a5",
     "wuying-agentbay-sdk>=0.15.0",
 ]
 


### PR DESCRIPTION
## Summary

- Pin the `browser-use` optional dependency to an immutable commit containing the SessionManager attach/detach race fix and the OOPIF lookup fix.
- Avoid reinstalling the released `0.13.4` implementation that can fan out frame-tree and metadata CDP requests over stale targets and hit the 30-second watchdog limit.
- Keep the Bench change to dependency selection only; no adapter or watchdog behavior is patched here.

The pinned commit is [`b174da3f`](https://github.com/254808127/browser-use/commit/b174da3fcd1c6483fbae9746cbc686fb97b502a5). Its race-fix parent is under upstream review in [browser-use/browser-use#5223](https://github.com/browser-use/browser-use/pull/5223).

## Contribution type

- [ ] Agent adapter
- [ ] Browser backend
- [ ] Benchmark task or data
- [ ] Leaderboard/result submission
- [ ] Evaluation or judge strategy
- [ ] Documentation/example
- [x] Bug fix

## Reproduction or validation

Dependency resolution:

```text
browser-use==0.13.4 (from git+https://github.com/254808127/browser-use.git@b174da3fcd1c6483fbae9746cbc686fb97b502a5)
```

Targeted dependency-sync tests:

```bash
uv run pytest tests/browseruse_bench/test_run_dependency_sync.py
```

```text
3 passed
```

Full suite:

```bash
uv run pytest tests/
```

```text
814 passed, 1 skipped, 3 failed
```

The same three failures reproduce on a detached, unmodified worktree at base commit `a20a356`: the configured Claude smoke model is unavailable, the `qwen-plus` fixture is absent from `config.example.yaml`, and the logger test expects stdout while the implementation emits to stderr. The branch introduces no additional test failures.

Real regression run:

```bash
uv run bubench run --agent browser-use --data LexBench-Browser --split All --mode by_id --id 3012 --model-name grok-4.5 --timeout 1200 --concurrency 1
```

Redacted evidence:

```text
[INFO] Installing dependencies: .[browser-use]
[INFO] Starting a browser-use agent with version 0.13.4
[SUCCESS] Task completed successfully
[TIMING] Task wall-clock time: 838.2s
[SUMMARY] Total: 1 | Success: 1 | Failed: 0
```

The original failure signatures were absent: `TIMEOUT HERE=0`, `AgentFocusChangedEvent` timeout `=0`, and `Client is not started=0`. The agent reached its configured 40-step limit and saved 18 of 20 requested records; the remaining two were a model step-budget outcome, not a watchdog interruption.

## Result artifacts

Not a result submission. Runtime logs are not attached because they contain provider session URLs; the relevant redacted lines are included above.

## Self-review (mandatory)

See [Mandatory Self-Review](https://github.com/lexmount/browseruse-agent-bench/blob/main/CONTRIBUTING.md#mandatory-self-review-before-every-pr).

- [x] I read every line of my diff and every change is intentional
      / 我逐行读完了自己的 diff,每处改动都是有意为之
- [x] The diff passes the hard rules in CONTRIBUTING.md (logger not print, specific exceptions,
      no hardcoded runtime config, imports at top) / diff 符合 CONTRIBUTING.md 的硬性红线
- [x] I ran an equivalent local Codex code review and fixed or justified every finding. The
      installed Claude Code reports `Unknown command: /code-review`.
      / 已用 Codex 完成本地等价审查,findings 已全部修复或说明
- [x] `uv run pytest tests/` was run; all three failures reproduce unchanged on the clean base,
      and the targeted dependency-sync tests pass
      / 已运行全量测试并确认三个失败均为主线既有问题,针对性测试通过
- [x] Agent-touching change: real smoke run evidence is included above
      / 涉及 agent 运行路径的改动已附真实 smoke run 证据
- [x] No secrets, cookies, or unredacted logs in the diff
      / diff 中无密钥、cookie、未脱敏日志

## Notes for reviewers

- The exact SHA makes the behavior reproducible, but it is temporarily hosted on a contributor fork. Replace it with an official Browser Use release as soon as the upstream fixes are merged and published.
- One navigation late in the 3012 run produced transient detached-target background warnings. They did not block subsequent CDP requests or task shutdown. This change addresses the stale-session fanout and watchdog stall; it does not claim to eliminate every normal target-detach race at navigation boundaries.
- Installing this optional extra now requires Git/network access. The repository already uses an immutable VCS dependency for another optional agent, but this remains a compatibility consideration.
