### PR TITLE
Fix agent leaderboard model comparison

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -543,7 +543,7 @@
           <tr>
             <th data-key="rank">#</th>
             <th data-key="agent">Agent</th>
-            <th data-key="model">Model / runtime</th>
+            <th data-key="model">Model</th>
             <th data-key="browser">Browser</th>
             <th data-key="pass" class="num">Pass</th>
             <th data-key="fail" class="num">Fail</th>
@@ -554,10 +554,10 @@
           </tr>
         </thead>
         <tbody>
-          <tr data-rank="1" data-agent="Hermes" data-model="gpt-5.5 medium" data-browser="Lexmount" data-pass="174" data-fail="36" data-total="210" data-success="82.86" data-steps="" data-e2e="184.4">
+          <tr data-rank="1" data-agent="Hermes" data-model="gpt-5.5" data-browser="Lexmount" data-pass="174" data-fail="36" data-total="210" data-success="82.86" data-steps="" data-e2e="184.4">
             <td class="num">1</td>
             <td><span class="cell-strong">Hermes</span></td>
-            <td><code class="cell-mono">gpt-5.5 medium</code></td>
+            <td><code class="cell-mono">gpt-5.5</code></td>
             <td><span class="browser-pill">Lexmount</span></td>
             <td class="num">174</td>
             <td class="num">36</td>
@@ -566,10 +566,10 @@
             <td class="num">-</td>
             <td class="num">184.4</td>
           </tr>
-          <tr data-rank="2" data-agent="Codex" data-model="gpt-5.5 medium" data-browser="Lexmount" data-pass="171" data-fail="39" data-total="210" data-success="81.43" data-steps="" data-e2e="254.4">
+          <tr data-rank="2" data-agent="Codex" data-model="gpt-5.5" data-browser="Lexmount" data-pass="171" data-fail="39" data-total="210" data-success="81.43" data-steps="" data-e2e="254.4">
             <td class="num">2</td>
             <td><span class="cell-strong">Codex</span></td>
-            <td><code class="cell-mono">gpt-5.5 medium</code></td>
+            <td><code class="cell-mono">gpt-5.5</code></td>
             <td><span class="browser-pill">Lexmount</span></td>
             <td class="num">171</td>
             <td class="num">39</td>
@@ -578,10 +578,22 @@
             <td class="num">-</td>
             <td class="num">254.4</td>
           </tr>
-          <tr data-rank="3" data-agent="Claude Code" data-model="gpt-5.5 medium" data-browser="Lexmount" data-pass="156" data-fail="54" data-total="210" data-success="74.29" data-steps="" data-e2e="228.4">
+          <tr data-rank="3" data-agent="browser-use" data-model="gpt-5.5" data-browser="Lexmount" data-pass="156" data-fail="54" data-total="210" data-success="74.3" data-steps="14.00" data-e2e="212.0">
             <td class="num">3</td>
+            <td><span class="cell-strong">browser-use</span></td>
+            <td><code class="cell-mono">gpt-5.5</code></td>
+            <td><span class="browser-pill">Lexmount</span></td>
+            <td class="num">156</td>
+            <td class="num">54</td>
+            <td class="num">210</td>
+            <td class="num"><strong>74.3</strong></td>
+            <td class="num">14.0</td>
+            <td class="num">212.0</td>
+          </tr>
+          <tr data-rank="4" data-agent="Claude Code" data-model="gpt-5.5" data-browser="Lexmount" data-pass="156" data-fail="54" data-total="210" data-success="74.29" data-steps="" data-e2e="228.4">
+            <td class="num">4</td>
             <td><span class="cell-strong">Claude Code</span></td>
-            <td><code class="cell-mono">gpt-5.5 medium</code></td>
+            <td><code class="cell-mono">gpt-5.5</code></td>
             <td><span class="browser-pill">Lexmount</span></td>
             <td class="num">156</td>
             <td class="num">54</td>
@@ -590,10 +602,10 @@
             <td class="num">-</td>
             <td class="num">228.4</td>
           </tr>
-          <tr data-rank="4" data-agent="Cursor" data-model="GPT-5.5 Medium" data-browser="Lexmount" data-pass="153" data-fail="57" data-total="210" data-success="72.86" data-steps="" data-e2e="211.8">
-            <td class="num">4</td>
+          <tr data-rank="5" data-agent="Cursor" data-model="gpt-5.5" data-browser="Lexmount" data-pass="153" data-fail="57" data-total="210" data-success="72.86" data-steps="" data-e2e="211.8">
+            <td class="num">5</td>
             <td><span class="cell-strong">Cursor</span></td>
-            <td><code class="cell-mono">GPT-5.5 Medium</code></td>
+            <td><code class="cell-mono">gpt-5.5</code></td>
             <td><span class="browser-pill">Lexmount</span></td>
             <td class="num">153</td>
             <td class="num">57</td>
@@ -602,10 +614,10 @@
             <td class="num">-</td>
             <td class="num">211.8</td>
           </tr>
-          <tr data-rank="5" data-agent="OpenClaw" data-model="gpt-5.5 medium" data-browser="Lexmount" data-pass="144" data-fail="66" data-total="210" data-success="68.57" data-steps="" data-e2e="476.0">
-            <td class="num">5</td>
+          <tr data-rank="6" data-agent="OpenClaw" data-model="gpt-5.5" data-browser="Lexmount" data-pass="144" data-fail="66" data-total="210" data-success="68.57" data-steps="" data-e2e="476.0">
+            <td class="num">6</td>
             <td><span class="cell-strong">OpenClaw</span></td>
-            <td><code class="cell-mono">gpt-5.5 medium</code></td>
+            <td><code class="cell-mono">gpt-5.5</code></td>
             <td><span class="browser-pill">Lexmount</span></td>
             <td class="num">144</td>
             <td class="num">66</td>


### PR DESCRIPTION
## Summary
- rename the Agent Leaderboard model column from Model / runtime to Model
- normalize gpt-5.5 model labels by removing the medium runtime suffix
- add the comparable browser-use + gpt-5.5 row from the model leaderboard into the agent leaderboard

## Tests
- exact leaderboard table parser check
- git diff --check